### PR TITLE
Remove RAPIDS headers from `libucxx`

### DIFF
--- a/conda/recipes/ucxx/install_libucxx.sh
+++ b/conda/recipes/ucxx/install_libucxx.sh
@@ -5,3 +5,8 @@
 
 cmake --install cpp/build
 cmake --install cpp/build --component benchmarks
+
+# For some reason RAPIDS headers are getting installed causing clobbering, which shouldn't happen.
+# To workaround this issue for now, just remove all the RAPIDS headers that were installed to avoid clobbering.
+# xref: https://github.com/rapidsai/ucxx/issues/20
+rm -rf "${PREFIX}/include/rapids"

--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -88,6 +88,7 @@ outputs:
         - test -f $PREFIX/include/ucxx/worker.h
         - test -f $PREFIX/include/ucxx/exception.h
         - test -f $PREFIX/include/ucxx/log.h
+        - test ! -d ${PREFIX}/include/rapids
     about:
       home: https://rapids.ai/
       license: BSD-3-Clause


### PR DESCRIPTION
Fixes https://github.com/rapidsai/ucxx/issues/20

This is a workaround to remove RAPIDS headers from `libucxx`. Ideally they shouldn't be installed in the first place. However for now just remove them to avoid issues.