### PR TITLE
Fix `ucxx::Context` TLS config parser and improve tests

### DIFF
--- a/cpp/src/context.cpp
+++ b/cpp/src/context.cpp
@@ -44,7 +44,7 @@ Context::Context(const ConfigMap ucxConfig, const uint64_t featureFlags)
         // "cuda" or "cuda_copy", then there is no cuda support (just
         // disabling "cuda_ipc" is fine)
         auto next  = tls_value.find_first_of(',', current);
-        auto field = tls_value.substr(next, next - current);
+        auto field = tls_value.substr(current, next - current);
         current    = next + 1;
         if (field == "cuda" || field == "cuda_copy") {
           this->_cudaSupport = false;

--- a/cpp/tests/context.cpp
+++ b/cpp/tests/context.cpp
@@ -3,12 +3,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdlib>
+#include <string>
 
 #include <gtest/gtest.h>
 
 #include <ucxx/api.h>
 
 namespace {
+
+static std::vector<std::string> TlsConfig{"^tcp", "^tcp,sm", "tcp", "tcp,sm", "all"};
+
+class ContextTestCustomConfig : public testing::TestWithParam<std::string> {
+};
 
 TEST(ContextTest, HandleIsValid)
 {
@@ -32,14 +38,18 @@ TEST(ContextTest, DefaultConfigsAndFlags)
   ASSERT_EQ(context->getFeatureFlags(), featureFlags);
 }
 
-TEST(ContextTest, CustomConfig)
+TEST_P(ContextTestCustomConfig, TLS)
 {
-  auto context = ucxx::createContext({{"UCX_TLS", "tcp"}}, ucxx::Context::defaultFeatureFlags);
+  auto tls                           = GetParam();
+  static constexpr auto featureFlags = ucxx::Context::defaultFeatureFlags;
+  auto context                       = ucxx::createContext({{"TLS", tls}}, featureFlags);
 
   auto configMapOut = context->getConfig();
   ASSERT_GT(configMapOut.size(), 1u);
   ASSERT_NE(configMapOut.find("TLS"), configMapOut.end());
-  ASSERT_EQ(configMapOut["TLS"], "tcp");
+  ASSERT_EQ(configMapOut["TLS"], tls);
+
+  ASSERT_EQ(context->getFeatureFlags(), featureFlags);
 }
 
 TEST(ContextTest, CustomFlags)
@@ -67,5 +77,7 @@ TEST(ContextTest, CreateWorker)
   auto worker2 = context->createWorker();
   ASSERT_TRUE(worker2 != nullptr);
 }
+
+INSTANTIATE_TEST_SUITE_P(TLS, ContextTestCustomConfig, testing::ValuesIn(TlsConfig));
 
 }  // namespace

--- a/cpp/tests/context.cpp
+++ b/cpp/tests/context.cpp
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <cstdlib>
+
 #include <gtest/gtest.h>
 
 #include <ucxx/api.h>
@@ -19,11 +21,13 @@ TEST(ContextTest, DefaultConfigsAndFlags)
 {
   static constexpr auto featureFlags = ucxx::Context::defaultFeatureFlags;
   auto context                       = ucxx::createContext({}, featureFlags);
-
-  auto configMapOut = context->getConfig();
+  auto configMapOut                  = context->getConfig();
   ASSERT_GT(configMapOut.size(), 1u);
   ASSERT_NE(configMapOut.find("TLS"), configMapOut.end());
-  ASSERT_EQ(configMapOut["TLS"], "all");
+  if (const char* envTls = std::getenv("UCX_TLS"))
+    ASSERT_EQ(configMapOut["TLS"], envTls);
+  else
+    ASSERT_EQ(configMapOut["TLS"], "all");
 
   ASSERT_EQ(context->getFeatureFlags(), featureFlags);
 }


### PR DESCRIPTION
Fix `ucxx::Context` TLS config parser that caused errors when passing `UCX_TLS=^[transports]`. Additionally improve tests.