### PR TITLE
Simplify handling of sockaddr information lookup

### DIFF
--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -70,7 +70,7 @@ class Endpoint : public Component {
    * @param[in] endpointErrorHandling whether to enable endpoint error handling.
    */
   Endpoint(std::shared_ptr<Component> workerOrListener,
-           std::unique_ptr<ucp_ep_params_t, EpParamsDeleter> params,
+           ucp_ep_params_t* params,
            bool endpointErrorHandling);
 
   /**

--- a/cpp/include/ucxx/utils/sockaddr.h
+++ b/cpp/include/ucxx/utils/sockaddr.h
@@ -18,7 +18,7 @@ namespace utils {
  *
  * @param[in] ip_address  valid socket address (e.g., IP address or hostname) or NULL as a
  *                        wildcard for "all" to set the socket address storage to.
- * @param[in] port        port to set the socket address storaget to.
+ * @param[in] port        port to set the socket address storage to.
  *
  * @returns unique pointer wrapping a `struct addrinfo` (frees the addrinfo when out of scope)
  */

--- a/cpp/include/ucxx/utils/sockaddr.h
+++ b/cpp/include/ucxx/utils/sockaddr.h
@@ -12,18 +12,17 @@ namespace ucxx {
 namespace utils {
 
 /**
- * @brief Set socket address and port of a socket address storage.
+ * @brief Get an addrinfo struct corresponding to an address and port.
  *
- * Set a socket address and port as defined by the user in a socket address storage that
- * may later be used to specify an address to bind a UCP listener to.
+ * This information can later be used to bind a UCP listener or endpoint.
  *
  * @param[in] ip_address  valid socket address (e.g., IP address or hostname) or NULL as a
  *                        wildcard for "all" to set the socket address storage to.
  * @param[in] port        port to set the socket address storaget to.
  *
- * @returns unique pointer wrapping a `struct addrinfo`
+ * @returns unique pointer wrapping a `struct addrinfo` (frees the addrinfo when out of scope)
  */
-std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> sockaddr_set(const char* ip_address,
+std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> get_addrinfo(const char* ip_address,
                                                                           uint16_t port);
 
 /**

--- a/cpp/include/ucxx/utils/sockaddr.h
+++ b/cpp/include/ucxx/utils/sockaddr.h
@@ -4,7 +4,8 @@
  */
 #pragma once
 
-#include <ucp/api/ucp.h>
+#include <memory>
+#include <netdb.h>
 
 namespace ucxx {
 
@@ -16,24 +17,14 @@ namespace utils {
  * Set a socket address and port as defined by the user in a socket address storage that
  * may later be used to specify an address to bind a UCP listener to.
  *
- * @param[in] sockaddr    pointer to the UCS socket address storage.
  * @param[in] ip_address  valid socket address (e.g., IP address or hostname) or NULL as a
  *                        wildcard for "all" to set the socket address storage to.
  * @param[in] port        port to set the socket address storaget to.
+ *
+ * @returns unique pointer wrapping a `struct addrinfo`
  */
-int sockaddr_set(ucs_sock_addr_t* sockaddr, const char* ip_address, uint16_t port);
-
-/**
- * @brief Release the underlying socket address.
- *
- * Release the underlying socket address container.
- *
- * NOTE: This function does not release the `ucs_sock_addr_t`, only the underlying
- * `sockaddr` member.
- *
- * @param[in] sockaddr  pointer to the UCS socket address storage.
- */
-void sockaddr_free(ucs_sock_addr_t* sockaddr);
+std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> sockaddr_set(const char* ip_address,
+                                                                          uint16_t port);
 
 /**
  * @brief Get socket address and port of a socket address storage.

--- a/cpp/src/context.cpp
+++ b/cpp/src/context.cpp
@@ -17,13 +17,10 @@ namespace ucxx {
 Context::Context(const ConfigMap ucxConfig, const uint64_t featureFlags)
   : _config{ucxConfig}, _featureFlags{featureFlags}
 {
-  ucp_params_t params{};
-
   parseLogLevel();
 
   // UCP
-  params.field_mask = UCP_PARAM_FIELD_FEATURES;
-  params.features   = featureFlags;
+  ucp_params_t params = {.field_mask = UCP_PARAM_FIELD_FEATURES, .features = featureFlags};
 
   utils::ucsErrorThrow(ucp_init(&params, this->_config.getHandle(), &this->_handle));
   ucxx_trace("Context created: %p", this->_handle);

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -23,15 +23,8 @@
 
 namespace ucxx {
 
-void EpParamsDeleter::operator()(ucp_ep_params_t* ptr)
-{
-  if (ptr != nullptr && ptr->field_mask & UCP_EP_PARAM_FIELD_SOCK_ADDR)
-    ucxx::utils::sockaddr_free(&ptr->sockaddr);
-  if (ptr) delete ptr;
-}
-
 Endpoint::Endpoint(std::shared_ptr<Component> workerOrListener,
-                   std::unique_ptr<ucp_ep_params_t, EpParamsDeleter> params,
+                   ucp_ep_params_t* params,
                    bool endpointErrorHandling)
   : _endpointErrorHandling{endpointErrorHandling}
 {
@@ -50,7 +43,7 @@ Endpoint::Endpoint(std::shared_ptr<Component> workerOrListener,
   params->err_handler.cb  = Endpoint::errorCallback;
   params->err_handler.arg = _callbackData.get();
 
-  utils::ucsErrorThrow(ucp_ep_create(worker->getHandle(), params.get(), &_handle));
+  utils::ucsErrorThrow(ucp_ep_create(worker->getHandle(), params, &_handle));
   ucxx_trace("Endpoint created: %p", _handle);
 }
 
@@ -62,14 +55,16 @@ std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> wor
   if (worker == nullptr || worker->getHandle() == nullptr)
     throw ucxx::Error("Worker not initialized");
 
-  auto params = std::unique_ptr<ucp_ep_params_t, EpParamsDeleter>(new ucp_ep_params_t);
+  ucp_ep_params_t params{};
+  params.field_mask = UCP_EP_PARAM_FIELD_FLAGS | UCP_EP_PARAM_FIELD_SOCK_ADDR |
+                      UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE | UCP_EP_PARAM_FIELD_ERR_HANDLER;
+  params.flags = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
+  auto info    = ucxx::utils::sockaddr_set(ipAddress.c_str(), port);
 
-  params->field_mask = UCP_EP_PARAM_FIELD_FLAGS | UCP_EP_PARAM_FIELD_SOCK_ADDR |
-                       UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE | UCP_EP_PARAM_FIELD_ERR_HANDLER;
-  params->flags = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
-  if (ucxx::utils::sockaddr_set(&params->sockaddr, ipAddress.c_str(), port)) throw std::bad_alloc();
+  params.sockaddr.addrlen = info->ai_addrlen;
+  params.sockaddr.addr    = info->ai_addr;
 
-  return std::shared_ptr<Endpoint>(new Endpoint(worker, std::move(params), endpointErrorHandling));
+  return std::shared_ptr<Endpoint>(new Endpoint(worker, &params, endpointErrorHandling));
 }
 
 std::shared_ptr<Endpoint> createEndpointFromConnRequest(std::shared_ptr<Listener> listener,
@@ -79,14 +74,13 @@ std::shared_ptr<Endpoint> createEndpointFromConnRequest(std::shared_ptr<Listener
   if (listener == nullptr || listener->getHandle() == nullptr)
     throw ucxx::Error("Worker not initialized");
 
-  auto params        = std::unique_ptr<ucp_ep_params_t, EpParamsDeleter>(new ucp_ep_params_t);
-  params->field_mask = UCP_EP_PARAM_FIELD_FLAGS | UCP_EP_PARAM_FIELD_CONN_REQUEST |
-                       UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE | UCP_EP_PARAM_FIELD_ERR_HANDLER;
-  params->flags        = UCP_EP_PARAMS_FLAGS_NO_LOOPBACK;
-  params->conn_request = connRequest;
+  ucp_ep_params_t params{};
+  params.field_mask = UCP_EP_PARAM_FIELD_FLAGS | UCP_EP_PARAM_FIELD_CONN_REQUEST |
+                      UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE | UCP_EP_PARAM_FIELD_ERR_HANDLER;
+  params.flags        = UCP_EP_PARAMS_FLAGS_NO_LOOPBACK;
+  params.conn_request = connRequest;
 
-  return std::shared_ptr<Endpoint>(
-    new Endpoint(listener, std::move(params), endpointErrorHandling));
+  return std::shared_ptr<Endpoint>(new Endpoint(listener, &params, endpointErrorHandling));
 }
 
 std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(std::shared_ptr<Worker> worker,
@@ -98,12 +92,12 @@ std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(std::shared_ptr<Worker
   if (address == nullptr || address->getHandle() == nullptr || address->getLength() == 0)
     throw ucxx::Error("Address not initialized");
 
-  auto params        = std::unique_ptr<ucp_ep_params_t, EpParamsDeleter>(new ucp_ep_params_t);
-  params->field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS | UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
-                       UCP_EP_PARAM_FIELD_ERR_HANDLER;
-  params->address = address->getHandle();
+  ucp_ep_params_t params{};
+  params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS | UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
+                      UCP_EP_PARAM_FIELD_ERR_HANDLER;
+  params.address = address->getHandle();
 
-  return std::shared_ptr<Endpoint>(new Endpoint(worker, std::move(params), endpointErrorHandling));
+  return std::shared_ptr<Endpoint>(new Endpoint(worker, &params, endpointErrorHandling));
 }
 
 Endpoint::~Endpoint()

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -64,13 +64,10 @@ std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> wor
 
   auto params = std::unique_ptr<ucp_ep_params_t, EpParamsDeleter>(new ucp_ep_params_t);
 
-  struct hostent* hostname = gethostbyname(ipAddress.c_str());
-  if (hostname == nullptr) throw ucxx::Error(std::string("Invalid IP address or hostname"));
-
   params->field_mask = UCP_EP_PARAM_FIELD_FLAGS | UCP_EP_PARAM_FIELD_SOCK_ADDR |
                        UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE | UCP_EP_PARAM_FIELD_ERR_HANDLER;
   params->flags = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
-  if (ucxx::utils::sockaddr_set(&params->sockaddr, hostname->h_name, port)) throw std::bad_alloc();
+  if (ucxx::utils::sockaddr_set(&params->sockaddr, ipAddress.c_str(), port)) throw std::bad_alloc();
 
   return std::shared_ptr<Endpoint>(new Endpoint(worker, std::move(params), endpointErrorHandling));
 }

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -55,11 +55,11 @@ std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> wor
   if (worker == nullptr || worker->getHandle() == nullptr)
     throw ucxx::Error("Worker not initialized");
 
-  ucp_ep_params_t params{};
-  params.field_mask = UCP_EP_PARAM_FIELD_FLAGS | UCP_EP_PARAM_FIELD_SOCK_ADDR |
-                      UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE | UCP_EP_PARAM_FIELD_ERR_HANDLER;
-  params.flags = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
-  auto info    = ucxx::utils::get_addrinfo(ipAddress.c_str(), port);
+  ucp_ep_params_t params = {.field_mask = UCP_EP_PARAM_FIELD_FLAGS | UCP_EP_PARAM_FIELD_SOCK_ADDR |
+                                          UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
+                                          UCP_EP_PARAM_FIELD_ERR_HANDLER,
+                            .flags = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER};
+  auto info              = ucxx::utils::get_addrinfo(ipAddress.c_str(), port);
 
   params.sockaddr.addrlen = info->ai_addrlen;
   params.sockaddr.addr    = info->ai_addr;
@@ -74,11 +74,11 @@ std::shared_ptr<Endpoint> createEndpointFromConnRequest(std::shared_ptr<Listener
   if (listener == nullptr || listener->getHandle() == nullptr)
     throw ucxx::Error("Worker not initialized");
 
-  ucp_ep_params_t params{};
-  params.field_mask = UCP_EP_PARAM_FIELD_FLAGS | UCP_EP_PARAM_FIELD_CONN_REQUEST |
-                      UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE | UCP_EP_PARAM_FIELD_ERR_HANDLER;
-  params.flags        = UCP_EP_PARAMS_FLAGS_NO_LOOPBACK;
-  params.conn_request = connRequest;
+  ucp_ep_params_t params = {
+    .field_mask = UCP_EP_PARAM_FIELD_FLAGS | UCP_EP_PARAM_FIELD_CONN_REQUEST |
+                  UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE | UCP_EP_PARAM_FIELD_ERR_HANDLER,
+    .flags        = UCP_EP_PARAMS_FLAGS_NO_LOOPBACK,
+    .conn_request = connRequest};
 
   return std::shared_ptr<Endpoint>(new Endpoint(listener, &params, endpointErrorHandling));
 }
@@ -92,10 +92,10 @@ std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(std::shared_ptr<Worker
   if (address == nullptr || address->getHandle() == nullptr || address->getLength() == 0)
     throw ucxx::Error("Address not initialized");
 
-  ucp_ep_params_t params{};
-  params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS | UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
-                      UCP_EP_PARAM_FIELD_ERR_HANDLER;
-  params.address = address->getHandle();
+  ucp_ep_params_t params = {.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS |
+                                          UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
+                                          UCP_EP_PARAM_FIELD_ERR_HANDLER,
+                            .address = address->getHandle()};
 
   return std::shared_ptr<Endpoint>(new Endpoint(worker, &params, endpointErrorHandling));
 }

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> wor
   params.field_mask = UCP_EP_PARAM_FIELD_FLAGS | UCP_EP_PARAM_FIELD_SOCK_ADDR |
                       UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE | UCP_EP_PARAM_FIELD_ERR_HANDLER;
   params.flags = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
-  auto info    = ucxx::utils::sockaddr_set(ipAddress.c_str(), port);
+  auto info    = ucxx::utils::get_addrinfo(ipAddress.c_str(), port);
 
   params.sockaddr.addrlen = info->ai_addrlen;
   params.sockaddr.addr    = info->ai_addr;

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -27,6 +27,7 @@ void EpParamsDeleter::operator()(ucp_ep_params_t* ptr)
 {
   if (ptr != nullptr && ptr->field_mask & UCP_EP_PARAM_FIELD_SOCK_ADDR)
     ucxx::utils::sockaddr_free(&ptr->sockaddr);
+  if (ptr) delete ptr;
 }
 
 Endpoint::Endpoint(std::shared_ptr<Component> workerOrListener,

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -34,11 +34,9 @@ Listener::Listener(std::shared_ptr<Worker> worker,
   params.conn_handler.cb  = callback;
   params.conn_handler.arg = callbackArgs;
 
-  if (ucxx::utils::sockaddr_set(&params.sockaddr, NULL, port))
-    // throw std::bad_alloc("Failed allocation of sockaddr")
-    throw std::bad_alloc();
-  std::unique_ptr<ucs_sock_addr_t, void (*)(ucs_sock_addr_t*)> sockaddr(&params.sockaddr,
-                                                                        ucxx::utils::sockaddr_free);
+  auto info               = ucxx::utils::sockaddr_set(NULL, port);
+  params.sockaddr.addr    = info->ai_addr;
+  params.sockaddr.addrlen = info->ai_addrlen;
 
   ucp_listener_h handle = nullptr;
   utils::ucsErrorThrow(ucp_listener_create(worker->getHandle(), &params, &handle));

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -27,13 +27,9 @@ Listener::Listener(std::shared_ptr<Worker> worker,
   if (worker == nullptr || worker->getHandle() == nullptr)
     throw ucxx::Error("Worker not initialized");
 
-  ucp_listener_params_t params{};
-  ucp_listener_attr_t attr{};
-
-  params.field_mask = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR | UCP_LISTENER_PARAM_FIELD_CONN_HANDLER;
-  params.conn_handler.cb  = callback;
-  params.conn_handler.arg = callbackArgs;
-
+  ucp_listener_params_t params = {
+    .field_mask   = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR | UCP_LISTENER_PARAM_FIELD_CONN_HANDLER,
+    .conn_handler = {.cb = callback, .arg = callbackArgs}};
   auto info               = ucxx::utils::get_addrinfo(NULL, port);
   params.sockaddr.addr    = info->ai_addr;
   params.sockaddr.addrlen = info->ai_addrlen;
@@ -43,7 +39,7 @@ Listener::Listener(std::shared_ptr<Worker> worker,
   _handle = std::unique_ptr<ucp_listener, void (*)(ucp_listener_h)>(handle, ucpListenerDestructor);
   ucxx_trace("Listener created: %p", _handle.get());
 
-  attr.field_mask = UCP_LISTENER_ATTR_FIELD_SOCKADDR;
+  ucp_listener_attr_t attr = {.field_mask = UCP_LISTENER_ATTR_FIELD_SOCKADDR};
   utils::ucsErrorThrow(ucp_listener_query(_handle.get(), &attr));
 
   char ipString[INET6_ADDRSTRLEN];

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -34,7 +34,7 @@ Listener::Listener(std::shared_ptr<Worker> worker,
   params.conn_handler.cb  = callback;
   params.conn_handler.arg = callbackArgs;
 
-  auto info               = ucxx::utils::sockaddr_set(NULL, port);
+  auto info               = ucxx::utils::get_addrinfo(NULL, port);
   params.sockaddr.addr    = info->ai_addr;
   params.sockaddr.addrlen = info->ai_addrlen;
 

--- a/cpp/src/utils/sockaddr.cpp
+++ b/cpp/src/utils/sockaddr.cpp
@@ -16,7 +16,7 @@ namespace ucxx {
 
 namespace utils {
 
-std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> sockaddr_set(const char* ip_address,
+std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> get_addrinfo(const char* ip_address,
                                                                           uint16_t port)
 {
   std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> info(nullptr, ::freeaddrinfo);

--- a/cpp/src/utils/sockaddr.cpp
+++ b/cpp/src/utils/sockaddr.cpp
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <arpa/inet.h>
-#include <netinet/in.h>
+#include <memory>
+#include <netdb.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 
+#include <ucxx/exception.h>
 #include <ucxx/utils/sockaddr.h>
 
 namespace ucxx {
@@ -16,14 +18,26 @@ namespace utils {
 
 int sockaddr_set(ucs_sock_addr_t* sockaddr, const char* ip_address, uint16_t port)
 {
-  struct sockaddr_in* addr = reinterpret_cast<sockaddr_in*>(malloc(sizeof(struct sockaddr_in)));
-  if (addr == NULL) { return 1; }
-  memset(addr, 0, sizeof(struct sockaddr_in));
-  addr->sin_family      = AF_INET;
-  addr->sin_addr.s_addr = ip_address == NULL ? INADDR_ANY : inet_addr(ip_address);
-  addr->sin_port        = htons(port);
-  sockaddr->addr        = (const struct sockaddr*)addr;
-  sockaddr->addrlen     = sizeof(struct sockaddr_in);
+  std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> info(nullptr, ::freeaddrinfo);
+  {
+    char ports[6];
+    struct addrinfo* result = nullptr;
+    struct addrinfo hints;
+    // Don't restrict lookups
+    ::memset(&hints, 0, sizeof(hints));
+    // Except, port is numeric, address may be NULL meaning the
+    // returned address is the wildcard.
+    hints.ai_flags = AI_NUMERICSERV | AI_PASSIVE;
+    if (::snprintf(ports, sizeof(ports), "%u", port) > sizeof(ports))
+      throw ucxx::Error(std::string("Invalid port"));
+    if (::getaddrinfo(ip_address, ports, &hints, &result))
+      throw ucxx::Error(std::string("Invalid IP address or hostname"));
+    info.reset(result);
+  }
+  void* x = ::malloc(info->ai_addrlen);
+  ::memcpy(x, info->ai_addr, info->ai_addrlen);
+  sockaddr->addr    = reinterpret_cast<struct sockaddr*>(x);
+  sockaddr->addrlen = info->ai_addrlen;
   return 0;
 }
 

--- a/cpp/src/utils/sockaddr.cpp
+++ b/cpp/src/utils/sockaddr.cpp
@@ -16,7 +16,8 @@ namespace ucxx {
 
 namespace utils {
 
-int sockaddr_set(ucs_sock_addr_t* sockaddr, const char* ip_address, uint16_t port)
+std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> sockaddr_set(const char* ip_address,
+                                                                          uint16_t port)
 {
   std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> info(nullptr, ::freeaddrinfo);
   {
@@ -34,16 +35,7 @@ int sockaddr_set(ucs_sock_addr_t* sockaddr, const char* ip_address, uint16_t por
       throw ucxx::Error(std::string("Invalid IP address or hostname"));
     info.reset(result);
   }
-  void* x = ::malloc(info->ai_addrlen);
-  ::memcpy(x, info->ai_addr, info->ai_addrlen);
-  sockaddr->addr    = reinterpret_cast<struct sockaddr*>(x);
-  sockaddr->addrlen = info->ai_addrlen;
-  return 0;
-}
-
-void sockaddr_free(ucs_sock_addr_t* sockaddr)
-{
-  ::free(const_cast<void*>(reinterpret_cast<const void*>(sockaddr->addr)));
+  return info;
 }
 
 void sockaddr_get_ip_port_str(const struct sockaddr_storage* sockaddr,

--- a/cpp/src/utils/sockaddr.cpp
+++ b/cpp/src/utils/sockaddr.cpp
@@ -51,18 +51,18 @@ void sockaddr_get_ip_port_str(const struct sockaddr_storage* sockaddr,
                               char* port_str,
                               size_t max_str_size)
 {
-  struct sockaddr_in addr_in;
-  struct sockaddr_in6 addr_in6;
+  const struct sockaddr_in* addr_in   = nullptr;
+  const struct sockaddr_in6* addr_in6 = nullptr;
 
   switch (sockaddr->ss_family) {
     case AF_INET:
-      memcpy(&addr_in, sockaddr, sizeof(struct sockaddr_in));
-      inet_ntop(AF_INET, &addr_in.sin_addr, ip_str, max_str_size);
-      snprintf(port_str, max_str_size, "%d", ntohs(addr_in.sin_port));
+      addr_in = reinterpret_cast<decltype(addr_in)>(sockaddr);
+      inet_ntop(AF_INET, &addr_in->sin_addr, ip_str, max_str_size);
+      snprintf(port_str, max_str_size, "%u", ntohs(addr_in->sin_port));
     case AF_INET6:
-      memcpy(&addr_in6, sockaddr, sizeof(struct sockaddr_in6));
-      inet_ntop(AF_INET6, &addr_in6.sin6_addr, ip_str, max_str_size);
-      snprintf(port_str, max_str_size, "%d", ntohs(addr_in6.sin6_port));
+      addr_in6 = reinterpret_cast<decltype(addr_in6)>(sockaddr);
+      inet_ntop(AF_INET6, &addr_in6->sin6_addr, ip_str, max_str_size);
+      snprintf(port_str, max_str_size, "%u", ntohs(addr_in6->sin6_port));
     default:
       ip_str   = const_cast<char*>(reinterpret_cast<const char*>("Invalid address family"));
       port_str = const_cast<char*>(reinterpret_cast<const char*>("Invalid address family"));

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -24,13 +24,11 @@ namespace ucxx {
 
 Worker::Worker(std::shared_ptr<Context> context, const bool enableDelayedSubmission)
 {
-  ucp_worker_params_t params{};
-
   if (context == nullptr || context->getHandle() == nullptr)
     throw std::runtime_error("Context not initialized");
 
-  params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
-  params.thread_mode = UCS_THREAD_MODE_MULTI;
+  ucp_worker_params_t params = {.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE,
+                                .thread_mode = UCS_THREAD_MODE_MULTI};
   utils::ucsErrorThrow(ucp_worker_create(context->getHandle(), &params, &_handle));
 
   if (enableDelayedSubmission)


### PR DESCRIPTION
Migrate away from using `gethostbyname` (deprecated) to `getaddrinfo`. As a consequence, we can refactor some memory management and handle allocation lifetime with a `unique_ptr`.

Although this doesn't introduce a class for managing sockaddr objects, it does make the lifetime management transparent enough that this closes #8.