### PR TITLE
Enable sccache hits for local builds

### DIFF
--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -30,6 +30,7 @@ build:
     - SCCACHE_S3_KEY_PREFIX=libucxx-aarch64 # [aarch64]
     - SCCACHE_S3_KEY_PREFIX=libucxx-linux64 # [linux64]
     - SCCACHE_S3_USE_SSL
+    - SCCACHE_S3_NO_CREDENTIALS
 
 requirements:
   build:


### PR DESCRIPTION
This change passes through the value of `SCCACHE_S3_NO_CREDENTIALS` to our `conda` builds, enabling devs to utilize the `sccache` cache that's populated by CI when they are reproducing build issues locally as per [these](https://docs.rapids.ai/resources/reproducing-ci/) instructions.