### PR TITLE
Require Numba 0.57.0+

### DIFF
--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -173,7 +173,7 @@ outputs:
         - pynvml >=11.4.1
       run_constrained:
         - cupy >=9.5.0
-        - numba >=0.56.2
+        - numba >=0.57.0
     test:
       commands:
         - test -f $PREFIX/lib/libucxx_python.so

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -109,6 +109,6 @@ dependencies:
           - cupy
           - dask>=2023.1.1
           - distributed>=2023.1.1
-          - numba
+          - numba>=0.57.0
           - pytest
           - pytest-asyncio


### PR DESCRIPTION
Align with the rest of RAPIDS on these requirements. Also needed for CUDA 12 support.