### PR TITLE
Fix RMM dependency

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -38,16 +38,16 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - &cmake_ver cmake>=3.23.1,!=3.25.0
-          - librmm==23.8.*
+          - rmm==23.8.*
       - output_types: conda
         packages:
-          - fmt>=9.1.0,<10
-          - &gtest gtest==1.10.0.*
-          - &gmock gmock==1.10.0.*
-          - spdlog>=1.11.0,<1.12
           - cython>=0.29,<0.30
+          - fmt>=9.1.0,<10
+          - &gmock gmock>=1.13.0
+          - &gtest gtest>=1.13.0
+          - librmm==23.8.*
           - &numpy numpy>=1.21
-          - rmm==23.8.*
+          - spdlog>=1.11.0,<1.12
   checks:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
The `dependencies.yaml` file lists `librmm` for conda/pyproject/requirements, but the C++ package librmm isn't available for pyproject/requirements files. Only the Python package `rmm` is available as a wheel. This PR swaps the two dependencies in the list.

Also I updated `gmock` / `gtest` to align with the versions used by the rest of RAPIDS and sorted the dependency list.