### PR TITLE
Fixes for various tests intermittently failing in CI

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -24,6 +24,12 @@ print_system_stats
 
 BINARY_PATH=${CONDA_PREFIX}/bin
 
+NEXT_PORT=12345
+function get_next_port() {
+  echo ${NEXT_PORT}
+  NEXT_PORT=$((NEXT_PORT + 1))
+}
+
 run_tests() {
   CMD_LINE="UCX_TCP_CM_REUSEADDR=y timeout 10m ${BINARY_PATH}/gtests/libucxx/UCXX_TEST"
 
@@ -35,13 +41,13 @@ run_tests() {
 run_benchmark() {
   PROGRESS_MODE=$1
 
-  # UCX_TCP_CM_REUSEADDR=y to be able to bind immediately to the same port before
-  # `TIME_WAIT` timeout
-  CMD_LINE_SERVER="UCX_TCP_CM_REUSEADDR=y timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE}"
-  CMD_LINE_CLIENT="timeout 10m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} 127.0.0.1"
+  SERVER_PORT=$(get_next_port)    # Use different ports every time to prevent `Device is busy`
+
+  CMD_LINE_SERVER="timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT}"
+  CMD_LINE_CLIENT="timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} 127.0.0.1"
 
   rapids-logger "Running: \n  - ${CMD_LINE_SERVER}\n  - ${CMD_LINE_CLIENT}"
-  UCX_TCP_CM_REUSEADDR=y timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} &
+  UCX_TCP_CM_REUSEADDR=y timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} &
   sleep 1
 
   MAX_ATTEMPTS=10
@@ -49,7 +55,7 @@ run_benchmark() {
   set +e
   for attempt in $(seq 1 ${MAX_ATTEMPTS}); do
     echo "Attempt ${attempt}/${MAX_ATTEMPTS} to run client"
-    timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} 127.0.0.1
+    timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} 127.0.0.1
     LAST_STATUS=$?
     if [ ${LAST_STATUS} -eq 0 ]; then
       break;
@@ -67,12 +73,12 @@ run_benchmark() {
 run_example() {
   PROGRESS_MODE=$1
 
-  # UCX_TCP_CM_REUSEADDR=y to be able to bind immediately to the same port before
-  # `TIME_WAIT` timeout
-  CMD_LINE="UCX_TCP_CM_REUSEADDR=y timeout 1m ${BINARY_PATH}/examples/libucxx/ucxx_example_basic -m ${PROGRESS_MODE}"
+  SERVER_PORT=$(get_next_port)    # Use different ports every time to prevent `Device is busy`
+
+  CMD_LINE="timeout 1m ${BINARY_PATH}/examples/libucxx/ucxx_example_basic -m ${PROGRESS_MODE} -p ${SERVER_PORT}"
 
   rapids-logger "Running: \n  - ${CMD_LINE}"
-  UCX_TCP_CM_REUSEADDR=y timeout 1m ${BINARY_PATH}/examples/libucxx/ucxx_example_basic -m ${PROGRESS_MODE}
+  UCX_TCP_CM_REUSEADDR=y timeout 1m ${BINARY_PATH}/examples/libucxx/ucxx_example_basic -m ${PROGRESS_MODE} -p ${SERVER_PORT}
 }
 
 rapids-logger "Downloading artifacts from previous jobs"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -72,7 +72,7 @@ run_py_benchmark() {
 }
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=${RAPIDS_CONDA_BLD_OUTPUT_DIR}
+CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -60,15 +60,19 @@ run_py_benchmark() {
 
   CMD_LINE="UCXPY_ENABLE_DELAYED_SUBMISSION=${ENABLE_DELAYED_SUBMISSION} UCXPY_ENABLE_PYTHON_FUTURE=${ENABLE_PYTHON_FUTURE} timeout 2m python -m ucxx.benchmarks.send_recv --backend ${BACKEND} -o cupy --reuse-alloc -n 8MiB --n-buffers $N_BUFFERS --progress-mode ${PROGRESS_MODE} ${ASYNCIO_WAIT}"
 
+  # Workaround for https://github.com/rapidsai/ucxx/issues/15
+  CMD_LINE="UCX_KEEPALIVE_INTERVAL=1ms ${CMD_LINE}"
+
   rapids-logger "Running: ${CMD_LINE}"
   if [ $SLOW -ne 0 ]; then
     rapids-logger "SLOW BENCHMARK: it may seem like a deadlock but will eventually complete."
   fi
-  UCXPY_ENABLE_DELAYED_SUBMISSION=${ENABLE_DELAYED_SUBMISSION} UCXPY_ENABLE_PYTHON_FUTURE=${ENABLE_PYTHON_FUTURE} timeout 2m python -m ucxx.benchmarks.send_recv --backend ${BACKEND} -o cupy --reuse-alloc -n 8MiB --n-buffers $N_BUFFERS --progress-mode ${PROGRESS_MODE} ${ASYNCIO_WAIT}
+
+  UCX_KEEPALIVE_INTERVAL=1ms UCXPY_ENABLE_DELAYED_SUBMISSION=${ENABLE_DELAYED_SUBMISSION} UCXPY_ENABLE_PYTHON_FUTURE=${ENABLE_PYTHON_FUTURE} timeout 2m python -m ucxx.benchmarks.send_recv --backend ${BACKEND} -o cupy --reuse-alloc -n 8MiB --n-buffers $N_BUFFERS --progress-mode ${PROGRESS_MODE} ${ASYNCIO_WAIT}
 }
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=${RAPIDS_CONDA_BLD_OUTPUT_DIR}
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \

--- a/cpp/src/request.cpp
+++ b/cpp/src/request.cpp
@@ -169,6 +169,7 @@ void Request::setStatus(ucs_status_t status)
                    status,
                    ucs_status_string(status));
 
+  if (_status != UCS_INPROGRESS) ucxx_error("setStatus called but the status was already set");
   _status.store(status);
 
   if (_enablePythonFuture) {

--- a/cpp/src/request.cpp
+++ b/cpp/src/request.cpp
@@ -162,20 +162,14 @@ void Request::setStatus(ucs_status_t status)
   if (_endpoint != nullptr) _endpoint->removeInflightRequest(this);
   _worker->removeInflightRequest(this);
 
-  if (_status == UCS_INPROGRESS) {
-    // If the status is not `UCS_INPROGRESS`, the derived class has already set the
-    // status, a truncated message for example.
-    _status.store(status);
-  }
-
-  ucs_status_t s = _status;
-
   ucxx_trace_req_f(_ownerString.c_str(),
                    _request,
                    _operationName.c_str(),
                    "callback called with status %d (%s)",
-                   s,
-                   ucs_status_string(s));
+                   status,
+                   ucs_status_string(status));
+
+  _status.store(status);
 
   if (_enablePythonFuture) {
     auto future = std::static_pointer_cast<ucxx::Future>(_future);

--- a/cpp/src/request_stream.cpp
+++ b/cpp/src/request_stream.cpp
@@ -92,8 +92,7 @@ void RequestStream::populateDelayedSubmission()
 
 void RequestStream::callback(void* request, ucs_status_t status, size_t length)
 {
-  status  = length == _length ? status : UCS_ERR_MESSAGE_TRUNCATED;
-  _status = status;
+  status = length == _length ? status : UCS_ERR_MESSAGE_TRUNCATED;
 
   if (status == UCS_ERR_MESSAGE_TRUNCATED) {
     const char* fmt = "length mismatch: %llu (got) != %llu (expected)";

--- a/cpp/src/request_tag.cpp
+++ b/cpp/src/request_tag.cpp
@@ -70,8 +70,6 @@ void RequestTag::callback(void* request, ucs_status_t status, const ucp_tag_recv
     std::snprintf(_status_msg.data(), _status_msg.size(), fmt, info->length, _length);
   }
 
-  _status = status;
-
   Request::callback(request, status);
 }
 

--- a/python/ucxx/_lib_async/tests/test_multiple_nodes.py
+++ b/python/ucxx/_lib_async/tests/test_multiple_nodes.py
@@ -5,6 +5,7 @@ import asyncio
 
 import numpy as np
 import pytest
+from utils import wait_listener_client_handlers
 
 import ucxx
 
@@ -33,6 +34,7 @@ async def server_node(ep):
 async def client_node(port):
     ep = await ucxx.create_endpoint(ucxx.get_address(), port)
     await hello(ep)
+    await ep.close()
     # assert isinstance(ep.ucx_info(), str)
 
 
@@ -54,3 +56,6 @@ async def test_many_servers_many_clients(num_servers, num_clients):
         for __ in range(i, min(i + somaxconn, num_clients * num_servers)):
             clients.append(client_node(listeners[__ % num_servers].port))
         await asyncio.gather(*clients)
+    await asyncio.gather(
+        *(wait_listener_client_handlers(listener) for listener in listeners)
+    )

--- a/python/ucxx/_lib_async/tests/test_send_recv_am.py
+++ b/python/ucxx/_lib_async/tests/test_send_recv_am.py
@@ -83,9 +83,9 @@ async def test_send_recv_am(size, recv_wait, data):
             # immediately as receive data is already available.
             await asyncio.sleep(1)
         await c.am_send(msg)
-    for c in clients:
-        await c.close()
-    await wait_listener_client_handlers(listener)
+
+    while len(recv) == 0:
+        await asyncio.sleep(0)
 
     if data["memory_type"] == "cuda" and msg.nbytes < rndv_thresh:
         # Eager messages are always received on the host, if no custom host
@@ -93,3 +93,7 @@ async def test_send_recv_am(size, recv_wait, data):
         np.testing.assert_equal(recv[0].view(np.int64), msg.get())
     else:
         data["validator"](recv[0], msg)
+
+    for c in clients:
+        await c.close()
+    await wait_listener_client_handlers(listener)

--- a/python/ucxx/_lib_async/tests/test_send_recv_am.py
+++ b/python/ucxx/_lib_async/tests/test_send_recv_am.py
@@ -94,6 +94,5 @@ async def test_send_recv_am(size, recv_wait, data):
     else:
         data["validator"](recv[0], msg)
 
-    for c in clients:
-        await c.close()
+    await asyncio.gather(*(c.close() for c in clients))
     await wait_listener_client_handlers(listener)


### PR DESCRIPTION
Changes included are:

- Use different ports for C++ benchmarks/examples in CI
- Set `UCX_KEEPALIVE_INTERVAL` for Python benchmarks in CI
- Wait Python async AM test message to arrive
- Move `ucxx::Request` status setting to base class