### PR TITLE
Derive `ucxx::RequestTagMulti` from `ucxx::Request`

### DIFF
--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -445,11 +445,11 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<RequestTagMulti> tagMultiSend(const std::vector<void*>& buffer,
-                                                const std::vector<size_t>& size,
-                                                const std::vector<int>& isCUDA,
-                                                const ucp_tag_t tag,
-                                                const bool enablePythonFuture);
+  std::shared_ptr<Request> tagMultiSend(const std::vector<void*>& buffer,
+                                        const std::vector<size_t>& size,
+                                        const std::vector<int>& isCUDA,
+                                        const ucp_tag_t tag,
+                                        const bool enablePythonFuture);
 
   /**
    * @brief Enqueue a multi-buffer tag receive operation.
@@ -472,7 +472,7 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<RequestTagMulti> tagMultiRecv(const ucp_tag_t tag, const bool enablePythonFuture);
+  std::shared_ptr<Request> tagMultiRecv(const ucp_tag_t tag, const bool enablePythonFuture);
 
   /**
    * @brief Get `ucxx::Worker` component from a worker or listener object.

--- a/cpp/include/ucxx/request.h
+++ b/cpp/include/ucxx/request.h
@@ -107,7 +107,7 @@ class Request : public Component {
    * Cancel the request. Often called by the an error handler or parent's object
    * destructor but may be called by the user to cancel the request as well.
    */
-  void cancel();
+  virtual void cancel();
 
   /**
    * @brief Return the status of the request.

--- a/cpp/include/ucxx/request_tag_multi.h
+++ b/cpp/include/ucxx/request_tag_multi.h
@@ -15,7 +15,6 @@
 #include <ucxx/endpoint.h>
 #include <ucxx/future.h>
 #include <ucxx/request.h>
-#include <ucxx/request_helper.h>
 
 namespace ucxx {
 
@@ -27,23 +26,25 @@ struct BufferRequest {
 
 typedef std::shared_ptr<BufferRequest> BufferRequestPtr;
 
-class RequestTagMulti : public std::enable_shared_from_this<RequestTagMulti> {
+class RequestTagMulti : public Request {
  private:
-  std::shared_ptr<Endpoint> _endpoint{nullptr};  ///< Endpoint that generated request
   bool _send{false};       ///< Whether this is a send (`true`) operation or recv (`false`)
   ucp_tag_t _tag{0};       ///< Tag to match
   size_t _totalFrames{0};  ///< The total number of frames handled by this request
-  std::mutex _completedRequestsMutex;  ///< Mutex to control access to completed requests container
+  std::mutex
+    _completedRequestsMutex{};  ///< Mutex to control access to completed requests container
   std::vector<BufferRequest*> _completedRequests{};  ///< Requests that already completed
-  ucs_status_t _status{UCS_INPROGRESS};              ///< Status of the multi-buffer request
-  std::shared_ptr<Future> _future;  ///< Future to be notified when transfer of all frames complete
 
  public:
   std::vector<BufferRequestPtr> _bufferRequests{};  ///< Container of all requests posted
   bool _isFilled{false};                            ///< Whether the all requests have been posted
 
  private:
-  RequestTagMulti() = delete;
+  RequestTagMulti()                       = delete;
+  RequestTagMulti(const RequestTagMulti&) = delete;
+  RequestTagMulti& operator=(RequestTagMulti const&) = delete;
+  RequestTagMulti(RequestTagMulti&& o)               = delete;
+  RequestTagMulti& operator=(RequestTagMulti&& o) = delete;
 
   /**
    * @brief Protected constructor of a multi-buffer tag receive request.
@@ -237,52 +238,11 @@ class RequestTagMulti : public std::enable_shared_from_this<RequestTagMulti> {
    * @param[in] status the status of the request being completed.
    * @throws std::runtime_error if called by a send request.
    */
-  void callback(ucs_status_t status);
+  void recvCallback(ucs_status_t status);
 
-  /**
-   * @brief Return the status of the request.
-   *
-   * Return a `ucs_status_t` that may be used for more fine-grained error handling than
-   * relying on `checkError()` alone, which does not currently implement all error
-   * statuses supported by UCX.
-   *
-   * @return the current status of the request.
-   */
-  ucs_status_t getStatus();
+  void populateDelayedSubmission() override;
 
-  /**
-   * @brief Return the future used to check on state.
-   *
-   * If the object is built with Python future support, return the future that can be
-   * awaited from Python, returns `nullptr` otherwise.
-   *
-   * @returns the Python future object or `nullptr`.
-   */
-  void* getFuture();
-
-  /**
-   * @brief Check whether the request completed with an error.
-   *
-   * Check whether the request has completed with an error, if an error occurred an
-   * exception is raised, but if the request has completed or is in progress this call will
-   * act as a no-op. To verify whether the request is in progress either `isCompleted()` or
-   * `getStatus()` should be checked.
-   *
-   * @throw `ucxx::CanceledError`         if the request was canceled.
-   * @throw `ucxx::MessageTruncatedError` if the message was truncated.
-   * @throw `ucxx::Error`                 if another error occurred.
-   */
-  void checkError();
-
-  /**
-   * @brief Check whether the request has already completed.
-   *
-   * Check whether the request has already completed. The status of the request must be
-   * verified with `getStatus()` before consumption.
-   *
-   * @return whether the request has completed.
-   */
-  bool isCompleted();
+  void cancel() override;
 };
 
 typedef std::shared_ptr<RequestTagMulti> RequestTagMultiPtr;

--- a/cpp/include/ucxx/request_tag_multi.h
+++ b/cpp/include/ucxx/request_tag_multi.h
@@ -24,9 +24,6 @@ struct BufferRequest {
   std::shared_ptr<Request> request{nullptr};  ///< The `ucxx::RequestTag` of a header or frame
   std::shared_ptr<std::string> stringBuffer{nullptr};  ///< Serialized `Header`
   Buffer* buffer{nullptr};  ///< Internally allocated buffer to receive a frame
-  std::shared_ptr<RequestTagMulti> requestTagMulti{
-    nullptr};  ///< Reference to the owner to ensure it remains alive until all children callbacks
-               ///< terminate
 };
 
 typedef std::shared_ptr<BufferRequest> BufferRequestPtr;

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -17,6 +17,7 @@
 #include <ucxx/request_am.h>
 #include <ucxx/request_stream.h>
 #include <ucxx/request_tag.h>
+#include <ucxx/request_tag_multi.h>
 #include <ucxx/typedefs.h>
 #include <ucxx/utils/sockaddr.h>
 #include <ucxx/utils/ucx.h>
@@ -269,21 +270,21 @@ std::shared_ptr<Request> Endpoint::tagRecv(void* buffer,
     endpoint, false, buffer, length, tag, enablePythonFuture, callbackFunction, callbackData));
 }
 
-std::shared_ptr<RequestTagMulti> Endpoint::tagMultiSend(const std::vector<void*>& buffer,
-                                                        const std::vector<size_t>& size,
-                                                        const std::vector<int>& isCUDA,
-                                                        const ucp_tag_t tag,
-                                                        const bool enablePythonFuture)
+std::shared_ptr<Request> Endpoint::tagMultiSend(const std::vector<void*>& buffer,
+                                                const std::vector<size_t>& size,
+                                                const std::vector<int>& isCUDA,
+                                                const ucp_tag_t tag,
+                                                const bool enablePythonFuture)
 {
   auto endpoint = std::dynamic_pointer_cast<Endpoint>(shared_from_this());
-  return createRequestTagMultiSend(endpoint, buffer, size, isCUDA, tag, enablePythonFuture);
+  return registerInflightRequest(
+    createRequestTagMultiSend(endpoint, buffer, size, isCUDA, tag, enablePythonFuture));
 }
 
-std::shared_ptr<RequestTagMulti> Endpoint::tagMultiRecv(const ucp_tag_t tag,
-                                                        const bool enablePythonFuture)
+std::shared_ptr<Request> Endpoint::tagMultiRecv(const ucp_tag_t tag, const bool enablePythonFuture)
 {
   auto endpoint = std::dynamic_pointer_cast<Endpoint>(shared_from_this());
-  return createRequestTagMultiRecv(endpoint, tag, enablePythonFuture);
+  return registerInflightRequest(createRequestTagMultiRecv(endpoint, tag, enablePythonFuture));
 }
 
 std::shared_ptr<Worker> Endpoint::getWorker() { return ::ucxx::getWorker(_parent); }

--- a/cpp/src/request.cpp
+++ b/cpp/src/request.cpp
@@ -102,7 +102,12 @@ void Request::callback(void* request, ucs_status_t status)
    * Prevent reference count to self from going to zero and thus cause self to be destroyed
    * while `callback()` executes.
    */
-  auto selfReference = shared_from_this();
+  try {
+    auto selfReference = shared_from_this();
+  } catch (std::bad_weak_ptr& exception) {
+    ucxx_debug("Request %p destroyed before callback() was executed", this);
+    return;
+  }
 
   if (request != nullptr) ucp_request_free(request);
 

--- a/cpp/src/request.cpp
+++ b/cpp/src/request.cpp
@@ -102,8 +102,9 @@ void Request::callback(void* request, ucs_status_t status)
    * Prevent reference count to self from going to zero and thus cause self to be destroyed
    * while `callback()` executes.
    */
+  decltype(shared_from_this()) selfReference = nullptr;
   try {
-    auto selfReference = shared_from_this();
+    selfReference = shared_from_this();
   } catch (std::bad_weak_ptr& exception) {
     ucxx_debug("Request %p destroyed before callback() was executed", this);
     return;

--- a/cpp/src/request_stream.cpp
+++ b/cpp/src/request_stream.cpp
@@ -69,6 +69,16 @@ void RequestStream::request()
 
 void RequestStream::populateDelayedSubmission()
 {
+  if (_delayedSubmission->_send && _endpoint->getHandle() == nullptr) {
+    ucxx_warn("Endpoint was closed before message could be sent");
+    Request::callback(this, UCS_ERR_CANCELED);
+    return;
+  } else if (!_delayedSubmission->_send && _worker->getHandle() == nullptr) {
+    ucxx_warn("Worker was closed before message could be received");
+    Request::callback(this, UCS_ERR_CANCELED);
+    return;
+  }
+
   request();
 
   if (_enablePythonFuture)

--- a/cpp/src/request_tag.cpp
+++ b/cpp/src/request_tag.cpp
@@ -120,6 +120,16 @@ void RequestTag::request()
 
 void RequestTag::populateDelayedSubmission()
 {
+  if (_delayedSubmission->_send && _endpoint->getHandle() == nullptr) {
+    ucxx_warn("Endpoint was closed before message could be sent");
+    Request::callback(this, UCS_ERR_CANCELED);
+    return;
+  } else if (!_delayedSubmission->_send && _worker->getHandle() == nullptr) {
+    ucxx_warn("Worker was closed before message could be received");
+    Request::callback(this, UCS_ERR_CANCELED);
+    return;
+  }
+
   request();
 
   if (_enablePythonFuture)

--- a/cpp/src/request_tag_multi.cpp
+++ b/cpp/src/request_tag_multi.cpp
@@ -147,7 +147,13 @@ void RequestTagMulti::markCompleted(ucs_status_t status, RequestCallbackUserData
    * Prevent reference count to self from going to zero and thus cause self to be destroyed
    * while `markCompleted()` executes.
    */
-  auto selfReference = shared_from_this();
+  try {
+    auto selfReference = shared_from_this();
+  } catch (std::bad_weak_ptr& exception) {
+    ucxx_debug("RequestTagMulti %p destroyed before all markCompleted() callbacks were executed",
+               this);
+    return;
+  }
 
   ucxx_trace_req("RequestTagMulti::markCompleted request: %p, tag: %lx", this, _tag);
   std::lock_guard<std::mutex> lock(_completedRequestsMutex);

--- a/cpp/src/request_tag_multi.cpp
+++ b/cpp/src/request_tag_multi.cpp
@@ -147,8 +147,9 @@ void RequestTagMulti::markCompleted(ucs_status_t status, RequestCallbackUserData
    * Prevent reference count to self from going to zero and thus cause self to be destroyed
    * while `markCompleted()` executes.
    */
+  decltype(shared_from_this()) selfReference = nullptr;
   try {
-    auto selfReference = shared_from_this();
+    selfReference = shared_from_this();
   } catch (std::bad_weak_ptr& exception) {
     ucxx_debug("RequestTagMulti %p destroyed before all markCompleted() callbacks were executed",
                this);

--- a/cpp/src/request_tag_multi.cpp
+++ b/cpp/src/request_tag_multi.cpp
@@ -143,6 +143,12 @@ void RequestTagMulti::recvFrames()
 
 void RequestTagMulti::markCompleted(ucs_status_t status, RequestCallbackUserData request)
 {
+  /**
+   * Prevent reference count to self from going to zero and thus cause self to be destroyed
+   * while `markCompleted()` executes.
+   */
+  auto selfReference = shared_from_this();
+
   ucxx_trace_req("RequestTagMulti::markCompleted request: %p, tag: %lx", this, _tag);
   std::lock_guard<std::mutex> lock(_completedRequestsMutex);
 

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -227,7 +227,7 @@ TEST_P(RequestTest, ProgressTagMulti)
   std::vector<int> multiIsCUDA(numMulti, _bufferType == ucxx::BufferType::RMM);
 
   // Submit and wait for transfers to complete
-  std::vector<std::shared_ptr<ucxx::RequestTagMulti>> requests;
+  std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(_ep->tagMultiSend(_sendPtr, multiSize, multiIsCUDA, 0, false));
   requests.push_back(_ep->tagMultiRecv(0, false));
   waitRequests(_worker, requests, _progressWorker);
@@ -238,7 +238,8 @@ TEST_P(RequestTest, ProgressTagMulti)
   size_t transferIdx = 0;
 
   // Populate recv pointers
-  for (const auto& br : recvRequest->_bufferRequests) {
+  for (const auto& br :
+       std::dynamic_pointer_cast<ucxx::RequestTagMulti>(requests[1])->_bufferRequests) {
     // br->buffer == nullptr are headers
     if (br->buffer) {
       ASSERT_EQ(br->buffer->getType(), _bufferType);

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -192,12 +192,13 @@ TEST_P(WorkerProgressTest, ProgressTagMulti)
   std::vector<size_t> multiSize(numMulti, send.size() * sizeof(int));
   std::vector<int> multiIsCUDA(numMulti, false);
 
-  std::vector<std::shared_ptr<ucxx::RequestTagMulti>> requests;
+  std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(ep->tagMultiSend(multiBuffer, multiSize, multiIsCUDA, 0, false));
   requests.push_back(ep->tagMultiRecv(0, false));
   waitRequests(_worker, requests, _progressWorker);
 
-  for (const auto& br : requests[1]->_bufferRequests) {
+  for (const auto& br :
+       std::dynamic_pointer_cast<ucxx::RequestTagMulti>(requests[1])->_bufferRequests) {
     // br->buffer == nullptr are headers
     if (br->buffer) {
       ASSERT_EQ(br->buffer->getType(), ucxx::BufferType::Host);

--- a/python/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/_lib/libucxx.pyx
@@ -1123,7 +1123,7 @@ cdef class UCXEndpoint():
         cdef vector[void*] v_buffer
         cdef vector[size_t] v_size
         cdef vector[int] v_is_cuda
-        cdef RequestTagMultiPtr ucxx_buffer_requests
+        cdef shared_ptr[Request] ucxx_buffer_requests
 
         for arr in arrays:
             if not isinstance(arr, Array):
@@ -1157,7 +1157,7 @@ cdef class UCXEndpoint():
         )
 
     def tag_recv_multi(self, size_t tag):
-        cdef RequestTagMultiPtr ucxx_buffer_requests
+        cdef shared_ptr[Request] ucxx_buffer_requests
 
         with nogil:
             ucxx_buffer_requests = self._endpoint.get().tagMultiRecv(

--- a/python/ucxx/_lib/ucxx_api.pxd
+++ b/python/ucxx/_lib/ucxx_api.pxd
@@ -282,14 +282,14 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
         shared_ptr[Request] tagRecv(
             void* buffer, size_t length, ucp_tag_t tag, bint enable_python_future
         ) except +raise_py_error
-        shared_ptr[RequestTagMulti] tagMultiSend(
+        shared_ptr[Request] tagMultiSend(
             const vector[void*]& buffer,
             const vector[size_t]& length,
             const vector[int]& isCUDA,
             ucp_tag_t tag,
             bint enable_python_future
         ) except +raise_py_error
-        shared_ptr[RequestTagMulti] tagMultiRecv(
+        shared_ptr[Request] tagMultiRecv(
             ucp_tag_t tag, bint enable_python_future
         ) except +raise_py_error
         bint isAlive()


### PR DESCRIPTION
Large parts of `ucxx::RequestTagMulti`'s structure was derived from `ucxx::Request`, thus making it a derived class is the natural way of reducing code duplication.

Additionally fix lifetime of `ucxx::RequestTagMulti` by ensuring a reference to `std::shared_ptr<ucxx::RequestTagMulti>` is held until all children callback finish execution. If the owner of the
`std::shared_ptr<ucxx::RequestTagMulti>` releases it too quickly, the object's refcount may go to 0 before the last child send/receive request completes its callback, thus causing invalid memory usage.