### PR TITLE
Use Ninja as CMake generator in `build.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -166,8 +166,10 @@ fi
 
 
 if buildAll || hasArg libucxx; then
+    CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
     pwd
     cmake -S $REPODIR/cpp -B ${LIB_BUILD_DIR} \
+          -G${CMAKE_GENERATOR} \
           -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DBUILD_BENCHMARKS=${BUILD_BENCHMARKS} \
           -DBUILD_TESTS=${BUILD_TESTS} \


### PR DESCRIPTION
Ninja has been a requirement to build [conda packages](https://github.com/rapidsai/ucxx/blob/branch-0.33/conda/recipes/ucxx/meta.yaml#L45) and [development environments](https://github.com/rapidsai/ucxx/blob/branch-0.33/conda/environments/ucxx-cuda118_arch-x86_64.yaml#L28), but it was not being used to generate the CMake build structure. This will now make Ninja the default in `build.sh` and configurable via the `CMAKE_GENERATOR` environment variable. The build time impact should be low given this project is relatively small at the moment, but may be more relevant in the future.