### PR TITLE
Add librmm and gtest to host environment.

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -40,6 +40,7 @@ sed_runner "s/^version = .*/version = \"${NEXT_FULL_TAG}\"/g" python/pyproject.t
 
 
 # bump RAPIDS libs
+sed_runner "/- librmm =/ s/=.*/=${NEXT_RAPIDS_VERSION}/g" conda/recipes/ucxx/meta.yaml
 sed_runner "/- rmm =/ s/=.*/=${NEXT_RAPIDS_VERSION}/g" conda/recipes/ucxx/meta.yaml
 for FILE in conda/environments/*.yaml dependencies.yaml; do
   sed_runner "/- cuda==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}\.*/g" ${FILE};

--- a/conda/recipes/ucxx/conda_build_config.yaml
+++ b/conda/recipes/ucxx/conda_build_config.yaml
@@ -22,3 +22,6 @@ python:
 
 ucx:
   - 1.14.0
+
+gtest_version:
+  - ">=1.13.0"

--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -51,6 +51,8 @@ requirements:
     - cuda-version ={{ cuda_version }}
     - ucx
     - python
+    - librmm =23.08
+    - gtest {{ gtest_version }}
 
 outputs:
   - name: libucxx


### PR DESCRIPTION
Currently conda builds are fetching `rmm` from CPM, rather than using conda packages. This PR aims to use conda for as many dependencies as possible to avoid repackaging and clobbering issues.

Resolves #20.

Related to #22, #54, similar to https://github.com/rapidsai/cudf/issues/13230