### PR TITLE
Use gtest version from conda_build_config.yaml.

### DIFF
--- a/conda/recipes/ucxx/conda_build_config.yaml
+++ b/conda/recipes/ucxx/conda_build_config.yaml
@@ -23,5 +23,8 @@ python:
 ucx:
   - 1.14.0
 
-gtest_version:
+gmock:
+  - ">=1.13.0"
+
+gtest:
   - ">=1.13.0"

--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -178,8 +178,8 @@ outputs:
         - cudatoolkit
         {% endif %}
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
-        - gtest {{ gtest_version }}
-        - gmock {{ gtest_version }}
+        - gtest
+        - gmock
     about:
       home: https://rapids.ai/
       license: BSD-3-Clause

--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - ucx
     - python
     - librmm =23.08
-    - gtest {{ gtest_version }}
+    - gtest
 
 outputs:
   - name: libucxx

--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -178,8 +178,8 @@ outputs:
         - cudatoolkit
         {% endif %}
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
-        - gtest
-        - gmock
+        - gtest {{ gtest_version }}
+        - gmock {{ gtest_version }}
     about:
       home: https://rapids.ai/
       license: BSD-3-Clause


### PR DESCRIPTION
This PR adds appropriate pinnings for `gtest` and `gmock` in `libucxx-tests`.