### PR TITLE
Set default Python async epoll timeout and fix more tests

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -23,7 +23,7 @@ rapids-print-env
 print_system_stats
 
 run_tests() {
-  rapids-logger "Running: timeout 2m pytest-vs python/ucxx/_lib/tests/"
+  rapids-logger "Running: timeout 2m pytest -vs python/ucxx/_lib/tests/"
   timeout 2m pytest -vs python/ucxx/_lib/tests/
 }
 
@@ -78,13 +78,10 @@ rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   libucxx ucxx
 
-rapids-logger "Run tests with conda package"
-run_tests
-
 print_ucx_config
 
-rapids-logger "\e[1mRunning: pytest-vs python/ucxx/_lib/tests/\e[0m"
-pytest -vs python/ucxx/_lib/tests/
+rapids-logger "Run tests with conda package"
+run_tests
 
 # run_tests_async PROGRESS_MODE   ENABLE_DELAYED_SUBMISSION ENABLE_PYTHON_FUTURE SKIP
 run_tests_async   thread          0                         0                    0

--- a/python/ucxx/_lib_async/continuous_ucx_progress.py
+++ b/python/ucxx/_lib_async/continuous_ucx_progress.py
@@ -49,7 +49,7 @@ class ThreadMode(ProgressTask):
     def __init__(self, worker, event_loop, polling_mode=False):
         super().__init__(worker, event_loop)
         worker.set_progress_thread_start_callback(_create_context)
-        worker.start_progress_thread(polling_mode=polling_mode)
+        worker.start_progress_thread(polling_mode=polling_mode, epoll_timeout=1)
 
     def __del__(self):
         self.worker.stop_progress_thread()

--- a/python/ucxx/_lib_async/tests/test_endpoint.py
+++ b/python/ucxx/_lib_async/tests/test_endpoint.py
@@ -20,6 +20,7 @@ async def test_close_callback(server_close_callback):
     async def server_node(ep):
         if server_close_callback is True:
             ep.set_close_callback(_close_callback)
+        await ep.close()
 
     async def client_node(port):
         ep = await ucxx.create_endpoint(
@@ -28,6 +29,7 @@ async def test_close_callback(server_close_callback):
         )
         if server_close_callback is False:
             ep.set_close_callback(_close_callback)
+        await ep.close()
 
     listener = ucxx.create_listener(
         server_node,
@@ -39,7 +41,6 @@ async def test_close_callback(server_close_callback):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transfer_api", ["am", "tag", "tag_multi"])
-@pytest.mark.xfail(reason="https://github.com/rapidsai/ucxx/issues/19")
 async def test_cancel(transfer_api):
     if transfer_api == "am":
         pytest.skip("AM not implemented yet")

--- a/python/ucxx/_lib_async/tests/test_probe.py
+++ b/python/ucxx/_lib_async/tests/test_probe.py
@@ -10,7 +10,6 @@ import ucxx as ucxx
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transfer_api", ["am", "tag"])
-@pytest.mark.xfail(reason="https://github.com/rapidsai/ucxx/issues/19")
 async def test_message_probe(transfer_api):
     msg = bytearray(b"0" * 10)
 
@@ -29,6 +28,7 @@ async def test_message_probe(transfer_api):
             await ep.recv(received)
         assert received == msg
 
+        await ep.close()
         listener.close()
 
     async def client_node(port):
@@ -40,6 +40,7 @@ async def test_message_probe(transfer_api):
             await ep.am_send(msg)
         else:
             await ep.send(msg)
+        await ep.close()
 
     listener = ucxx.create_listener(
         server_node,

--- a/python/ucxx/_lib_async/tests/test_reset.py
+++ b/python/ucxx/_lib_async/tests/test_reset.py
@@ -46,16 +46,16 @@ async def test_lt_still_in_scope_error():
 
     lt = ucxx.create_listener(server)
     ep = await ucxx.create_endpoint(ucxx.get_address(), lt.port)
+    await wait_listener_client_handlers(lt)
+
     del ep
     with pytest.raises(
         ucxx.exceptions.UCXError,
         match="Trying to reset UCX but not all Endpoints and/or Listeners are closed()",
     ):
-        ucxx.reset()
+        reset()
 
-    await wait_listener_client_handlers(lt)
     lt.close()
-    ucxx.reset()
 
 
 @pytest.mark.asyncio
@@ -69,11 +69,12 @@ async def test_ep_still_in_scope_error():
     lt = ucxx.create_listener(server)
     ep = await ucxx.create_endpoint(ucxx.get_address(), lt.port)
     await wait_listener_client_handlers(lt)
+
     del lt
     with pytest.raises(
         ucxx.exceptions.UCXError,
         match="Trying to reset UCX but not all Endpoints and/or Listeners are closed()",
     ):
-        ucxx.reset()
+        reset()
+
     ep.abort()
-    ucxx.reset()

--- a/python/ucxx/_lib_async/tests/test_shutdown.py
+++ b/python/ucxx/_lib_async/tests/test_shutdown.py
@@ -30,7 +30,6 @@ async def _shutdown_recv(ep, message_type):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("message_type", ["tag", "am"])
-@pytest.mark.xfail(reason="https://github.com/rapidsai/ucxx/issues/19")
 async def test_server_shutdown(message_type):
     """The server calls shutdown"""
     if message_type == "am":
@@ -152,7 +151,6 @@ async def test_listener_del(message_type):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("message_type", ["tag", "am"])
-@pytest.mark.xfail(reason="https://github.com/rapidsai/ucxx/issues/19")
 async def test_close_after_n_recv(message_type):
     """The Endpoint.close_after_n_recv()"""
     if message_type == "am":

--- a/python/ucxx/_lib_async/tests/utils.py
+++ b/python/ucxx/_lib_async/tests/utils.py
@@ -161,4 +161,5 @@ async def wait_listener_client_handlers(listener):
     pass
     while listener.active_clients > 0:
         await asyncio.sleep(0)
-        ucxx.progress()
+        if not ucxx.core._get_ctx().progress_mode.startswith("thread"):
+            ucxx.progress()


### PR DESCRIPTION
Set a 1 ms epoll timeout for Python async progress thread. Without an epoll timeout the progress thread may never wake up. Setting a default timeout will prevent that which may cause deadlocks in some circumstances.

Additionally fix some Python async tests.

Fixes #19 