### PR TITLE
Sync stream after allocation and result copy to host

### DIFF
--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -122,6 +122,9 @@ class RequestTest : public ::testing::TestWithParam<
       _sendPtr[i] = _sendBuffer[i]->data();
       if (allocateRecvBuffer) _recvPtr[i] = _recvBuffer[i]->data();
     }
+#if UCXX_ENABLE_RMM
+    if (_bufferType == ucxx::BufferType::RMM) { rmm::cuda_stream_default.synchronize(); }
+#endif
   }
 
   void copyResults()
@@ -141,6 +144,9 @@ class RequestTest : public ::testing::TestWithParam<
 #endif
       }
     }
+#if UCXX_ENABLE_RMM
+    if (_bufferType == ucxx::BufferType::RMM) { rmm::cuda_stream_default.synchronize(); }
+#endif
   }
 };
 


### PR DESCRIPTION
Stream synchronization was missing from C++ RMM tests, which caused data races with errors such as below:

```
[  FAILED  ] RMMProgressModes/RequestTest.ProgressAm/9, where GetParam() = (4-byte object <01-00 00-00>, false, false, 4-byte object <03-00 00-00>, 1024) (10 ms)
```