### PR TITLE
Forward-merge branch-0.33 to branch-0.34

### DIFF
--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -122,6 +122,9 @@ class RequestTest : public ::testing::TestWithParam<
       _sendPtr[i] = _sendBuffer[i]->data();
       if (allocateRecvBuffer) _recvPtr[i] = _recvBuffer[i]->data();
     }
+#if UCXX_ENABLE_RMM
+    if (_bufferType == ucxx::BufferType::RMM) { rmm::cuda_stream_default.synchronize(); }
+#endif
   }
 
   void copyResults()
@@ -141,6 +144,9 @@ class RequestTest : public ::testing::TestWithParam<
 #endif
       }
     }
+#if UCXX_ENABLE_RMM
+    if (_bufferType == ucxx::BufferType::RMM) { rmm::cuda_stream_default.synchronize(); }
+#endif
   }
 };
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.33` that creates a PR to keep `branch-0.34` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.