### PR TITLE
Fix C++ benchmark run in CI and improve CI logging

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -41,20 +41,21 @@ run_tests() {
 run_benchmark() {
   PROGRESS_MODE=$1
 
-  SERVER_PORT=$(get_next_port)    # Use different ports every time to prevent `Device is busy`
-
-  CMD_LINE_SERVER="timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT}"
-  CMD_LINE_CLIENT="timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} 127.0.0.1"
-
-  rapids-logger "Running: \n  - ${CMD_LINE_SERVER}\n  - ${CMD_LINE_CLIENT}"
-  UCX_TCP_CM_REUSEADDR=y timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} &
-  sleep 1
-
   MAX_ATTEMPTS=10
 
   set +e
   for attempt in $(seq 1 ${MAX_ATTEMPTS}); do
-    echo "Attempt ${attempt}/${MAX_ATTEMPTS} to run client"
+    echo "Attempt ${attempt}/${MAX_ATTEMPTS} to run benchmark"
+
+    SERVER_PORT=$(get_next_port)    # Use different ports every time to prevent `Device is busy`
+
+    CMD_LINE_SERVER="timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT}"
+    CMD_LINE_CLIENT="timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} 127.0.0.1"
+
+    rapids-logger "Running: \n  - ${CMD_LINE_SERVER}\n  - ${CMD_LINE_CLIENT}"
+    UCX_TCP_CM_REUSEADDR=y timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} &
+    sleep 1
+
     timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} 127.0.0.1
     LAST_STATUS=$?
     if [ ${LAST_STATUS} -eq 0 ]; then

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -33,7 +33,7 @@ function get_next_port() {
 run_tests() {
   CMD_LINE="UCX_TCP_CM_REUSEADDR=y timeout 10m ${BINARY_PATH}/gtests/libucxx/UCXX_TEST"
 
-  rapids-logger "Running: \n  - ${CMD_LINE}"
+  log_command "${CMD_LINE}"
 
   UCX_TCP_CM_REUSEADDR=y timeout 10m ${BINARY_PATH}/gtests/libucxx/UCXX_TEST
 }
@@ -49,10 +49,11 @@ run_benchmark() {
 
     SERVER_PORT=$(get_next_port)    # Use different ports every time to prevent `Device is busy`
 
-    CMD_LINE_SERVER="timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT}"
+    CMD_LINE_SERVER="timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} &"
     CMD_LINE_CLIENT="timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} 127.0.0.1"
 
-    rapids-logger "Running: \n  - ${CMD_LINE_SERVER}\n  - ${CMD_LINE_CLIENT}"
+    log_command "${CMD_LINE_SERVER}"
+    log_command "${CMD_LINE_CLIENT}"
     UCX_TCP_CM_REUSEADDR=y timeout 1m ${BINARY_PATH}/benchmarks/libucxx/ucxx_perftest -s 8388608 -r -n 20 -m ${PROGRESS_MODE} -p ${SERVER_PORT} &
     sleep 1
 
@@ -78,7 +79,7 @@ run_example() {
 
   CMD_LINE="timeout 1m ${BINARY_PATH}/examples/libucxx/ucxx_example_basic -m ${PROGRESS_MODE} -p ${SERVER_PORT}"
 
-  rapids-logger "Running: \n  - ${CMD_LINE}"
+  log_command "${CMD_LINE}"
   UCX_TCP_CM_REUSEADDR=y timeout 1m ${BINARY_PATH}/examples/libucxx/ucxx_example_basic -m ${PROGRESS_MODE} -p ${SERVER_PORT}
 }
 
@@ -92,8 +93,10 @@ rapids-mamba-retry install \
 print_ucx_config
 
 rapids-logger "Run tests with conda package"
+rapids-logger "C++ Tests"
 run_tests
 
+rapids-logger "C++ Benchmarks"
 # run_cpp_benchmark PROGRESS_MODE
 run_benchmark   polling
 run_benchmark   blocking
@@ -101,6 +104,7 @@ run_benchmark   thread-polling
 run_benchmark   thread-blocking
 run_benchmark   wait
 
+rapids-logger "C++ Examples"
 # run_cpp_example PROGRESS_MODE
 run_example   polling
 run_example   blocking

--- a/ci/test_utils.sh
+++ b/ci/test_utils.sh
@@ -4,6 +4,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+log_command() {
+  CMD_LINE=$1
+  echo -e "\e[1mRunning: \n ${CMD_LINE}\e[0m"
+}
+
 print_system_stats() {
   rapids-logger "Check GPU usage"
   nvidia-smi


### PR DESCRIPTION
C++ benchmarks do not change port when rerunning, which may be the source of reruns still failing, changing the port for each new attempt now.

Additionally improve logging in CI that is currently too long for `rapids-logger` making it look broken.