### PR TITLE
Fixes for `RequestTagMulti` immediate completion

### DIFF
--- a/cpp/src/request_tag_multi.cpp
+++ b/cpp/src/request_tag_multi.cpp
@@ -164,6 +164,9 @@ void RequestTagMulti::markCompleted(ucs_status_t status, RequestCallbackUserData
         if (s != UCS_OK) break;
       }
     }
+    // Check the status of the current (and final) message as it may have completed before
+    // `_bufferRequests->request` was populated.
+    if (s == UCS_OK) s = status;
 
     setStatus(s);
   }

--- a/cpp/src/request_tag_multi.cpp
+++ b/cpp/src/request_tag_multi.cpp
@@ -255,19 +255,19 @@ void RequestTagMulti::send(const std::vector<void*>& buffer,
   for (const auto& header : headers) {
     auto serializedHeader = std::make_shared<std::string>(header.serialize());
     auto bufferRequest    = std::make_shared<BufferRequest>();
+    _bufferRequests.push_back(bufferRequest);
     bufferRequest->request =
       _endpoint->tagSend(&serializedHeader->front(), serializedHeader->size(), _tag, false);
     bufferRequest->stringBuffer = serializedHeader;
-    _bufferRequests.push_back(bufferRequest);
   }
 
   for (size_t i = 0; i < _totalFrames; ++i) {
-    auto bufferRequest     = std::make_shared<BufferRequest>();
+    auto bufferRequest = std::make_shared<BufferRequest>();
+    _bufferRequests.push_back(bufferRequest);
     bufferRequest->request = _endpoint->tagSend(
       buffer[i], size[i], _tag, false, [this](ucs_status_t status, RequestCallbackUserData arg) {
         return this->markCompleted(status, arg);
       });
-    _bufferRequests.push_back(bufferRequest);
   }
 
   _isFilled = true;


### PR DESCRIPTION
When the last underlying `RequestTag` transfer completed immediately during a `RequestTagMulti`, two issues may have occurred before the changes here:

1. The `BufferRequest` may not have been pushed into the `_bufferRequests` container, thus reordering is necessary; and
2. The `_bufferRequests->request` was still unpopulated as the request and `markCompleted()` callback were called before returning the `RequestTag` back to the caller.