### PR TITLE
Process `ucxx::Endpoint::close()` in progress thread

### DIFF
--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -182,7 +182,7 @@ void Endpoint::close()
     if (UCS_PTR_IS_PTR(status)) {
       ucs_status_t s;
       while ((s = ucp_request_check_status(status)) == UCS_INPROGRESS)
-        if (!worker->isProgressThreadRunning()) worker->progress();
+        worker->progress();
       ucp_request_free(status);
       _callbackData->status = s;
     } else if (UCS_PTR_STATUS(status) != UCS_OK) {

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -166,7 +166,7 @@ void Endpoint::close()
         ucs_status_t s = ucp_request_check_status(status);
         if (UCS_PTR_STATUS(s) != UCS_INPROGRESS) {
           ucp_request_free(status);
-          _callbackData->status = status = UCS_PTR_STATUS(s);
+          _callbackData->status = UCS_PTR_STATUS(s);
           if (UCS_PTR_STATUS(status) != UCS_OK) {
             ucxx_error("Error while closing endpoint: %s",
                        ucs_status_string(UCS_PTR_STATUS(status)));


### PR DESCRIPTION
Use generic callbacks to process `ucxx::Endpoint::close()` in the progress thread when enabled.