### PR TITLE
Update to clang 16.0.6.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
                 types: [cython]
                 additional_dependencies: ["flake8-force"]
       - repo: https://github.com/pre-commit/mirrors-clang-format
-        rev: v11.1.0
+        rev: v16.0.6
         hooks:
               - id: clang-format
                 files: \.(h|cpp)$

--- a/cpp/benchmarks/perftest.cpp
+++ b/cpp/benchmarks/perftest.cpp
@@ -292,8 +292,8 @@ int main(int argc, char** argv)
 
   bool is_server = app_context.server_addr == NULL;
   auto tagMap    = std::make_shared<TagMap>(TagMap{
-    {SEND, is_server ? 0 : 1},
-    {RECV, is_server ? 1 : 0},
+       {SEND, is_server ? 0 : 1},
+       {RECV, is_server ? 1 : 0},
   });
 
   std::shared_ptr<ListenerContext> listener_ctx;

--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -39,11 +39,11 @@ class Address : public Component {
   Address(std::shared_ptr<Worker> worker, ucp_address_t* address, size_t length);
 
  public:
-  Address()               = delete;
-  Address(const Address&) = delete;
+  Address()                          = delete;
+  Address(const Address&)            = delete;
   Address& operator=(Address const&) = delete;
   Address(Address&& o)               = delete;
-  Address& operator=(Address&& o) = delete;
+  Address& operator=(Address&& o)    = delete;
 
   ~Address();
 

--- a/cpp/include/ucxx/buffer.h
+++ b/cpp/include/ucxx/buffer.h
@@ -38,11 +38,11 @@ class Buffer {
   Buffer(const BufferType bufferType, const size_t size);
 
  public:
-  Buffer()              = delete;
-  Buffer(const Buffer&) = delete;
+  Buffer()                         = delete;
+  Buffer(const Buffer&)            = delete;
   Buffer& operator=(Buffer const&) = delete;
   Buffer(Buffer&& o)               = delete;
-  Buffer& operator=(Buffer&& o) = delete;
+  Buffer& operator=(Buffer&& o)    = delete;
 
   /**
    * @brief Virtual destructor.
@@ -87,11 +87,11 @@ class HostBuffer : public Buffer {
   void* _buffer;  ///< Pointer to the allocated buffer
 
  public:
-  HostBuffer()                  = delete;
-  HostBuffer(const HostBuffer&) = delete;
+  HostBuffer()                             = delete;
+  HostBuffer(const HostBuffer&)            = delete;
   HostBuffer& operator=(HostBuffer const&) = delete;
   HostBuffer(HostBuffer&& o)               = delete;
-  HostBuffer& operator=(HostBuffer&& o) = delete;
+  HostBuffer& operator=(HostBuffer&& o)    = delete;
 
   /**
    * @brief Constructor of concrete type `HostBuffer`.
@@ -171,11 +171,11 @@ class RMMBuffer : public Buffer {
   std::unique_ptr<rmm::device_buffer> _buffer;  ///< RMM-allocated device buffer
 
  public:
-  RMMBuffer()                 = delete;
-  RMMBuffer(const RMMBuffer&) = delete;
+  RMMBuffer()                            = delete;
+  RMMBuffer(const RMMBuffer&)            = delete;
   RMMBuffer& operator=(RMMBuffer const&) = delete;
   RMMBuffer(RMMBuffer&& o)               = delete;
-  RMMBuffer& operator=(RMMBuffer&& o) = delete;
+  RMMBuffer& operator=(RMMBuffer&& o)    = delete;
 
   /**
    * @brief Constructor of concrete type `RMMBuffer`.

--- a/cpp/include/ucxx/config.h
+++ b/cpp/include/ucxx/config.h
@@ -39,11 +39,11 @@ class Config {
   ConfigMap ucxConfigToMap();
 
  public:
-  Config()              = delete;
-  Config(const Config&) = delete;
+  Config()                         = delete;
+  Config(const Config&)            = delete;
   Config& operator=(Config const&) = delete;
   Config(Config&& o)               = delete;
-  Config& operator=(Config&& o) = delete;
+  Config& operator=(Config&& o)    = delete;
 
   /**
    * @brief Constructor that reads the UCX configuration and apply user options.

--- a/cpp/include/ucxx/context.h
+++ b/cpp/include/ucxx/context.h
@@ -42,11 +42,11 @@ class Context : public Component {
   static constexpr uint64_t defaultFeatureFlags =
     UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP | UCP_FEATURE_STREAM | UCP_FEATURE_AM | UCP_FEATURE_RMA;
 
-  Context()               = delete;
-  Context(const Context&) = delete;
+  Context()                          = delete;
+  Context(const Context&)            = delete;
   Context& operator=(Context const&) = delete;
   Context(Context&& o)               = delete;
-  Context& operator=(Context&& o) = delete;
+  Context& operator=(Context&& o)    = delete;
 
   /**
    * @brief Constructor of `shared_ptr<ucxx::Context>`.

--- a/cpp/include/ucxx/delayed_submission.h
+++ b/cpp/include/ucxx/delayed_submission.h
@@ -81,11 +81,11 @@ class DelayedSubmissionCollection {
    */
   explicit DelayedSubmissionCollection(bool enableDelayedRequestSubmission = false);
 
-  DelayedSubmissionCollection()                                   = delete;
-  DelayedSubmissionCollection(const DelayedSubmissionCollection&) = delete;
+  DelayedSubmissionCollection()                                              = delete;
+  DelayedSubmissionCollection(const DelayedSubmissionCollection&)            = delete;
   DelayedSubmissionCollection& operator=(DelayedSubmissionCollection const&) = delete;
   DelayedSubmissionCollection(DelayedSubmissionCollection&& o)               = delete;
-  DelayedSubmissionCollection& operator=(DelayedSubmissionCollection&& o) = delete;
+  DelayedSubmissionCollection& operator=(DelayedSubmissionCollection&& o)    = delete;
 
   /**
    * @brief Process pending delayed request submission and generic-pre callback operations.

--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -87,11 +87,11 @@ class Endpoint : public Component {
   std::shared_ptr<Request> registerInflightRequest(std::shared_ptr<Request> request);
 
  public:
-  Endpoint()                = delete;
-  Endpoint(const Endpoint&) = delete;
+  Endpoint()                           = delete;
+  Endpoint(const Endpoint&)            = delete;
   Endpoint& operator=(Endpoint const&) = delete;
   Endpoint(Endpoint&& o)               = delete;
-  Endpoint& operator=(Endpoint&& o) = delete;
+  Endpoint& operator=(Endpoint&& o)    = delete;
 
   ~Endpoint();
 

--- a/cpp/include/ucxx/future.h
+++ b/cpp/include/ucxx/future.h
@@ -29,11 +29,11 @@ class Future : public std::enable_shared_from_this<Future> {
   explicit Future(std::shared_ptr<Notifier> notifier) : _notifier(notifier) {}
 
  public:
-  Future()              = delete;
-  Future(const Future&) = delete;
+  Future()                         = delete;
+  Future(const Future&)            = delete;
   Future& operator=(Future const&) = delete;
   Future(Future&& o)               = delete;
-  Future& operator=(Future&& o) = delete;
+  Future& operator=(Future&& o)    = delete;
 
   /**
    * @brief Virtual destructor.

--- a/cpp/include/ucxx/inflight_requests.h
+++ b/cpp/include/ucxx/inflight_requests.h
@@ -30,10 +30,10 @@ class InflightRequests {
    */
   InflightRequests() = default;
 
-  InflightRequests(const InflightRequests&) = delete;
+  InflightRequests(const InflightRequests&)            = delete;
   InflightRequests& operator=(InflightRequests const&) = delete;
   InflightRequests(InflightRequests&& o)               = delete;
-  InflightRequests& operator=(InflightRequests&& o) = delete;
+  InflightRequests& operator=(InflightRequests&& o)    = delete;
 
   /**
    * @brief Destructor.

--- a/cpp/include/ucxx/internal/request_am.h
+++ b/cpp/include/ucxx/internal/request_am.h
@@ -33,11 +33,11 @@ class RecvAmMessage {
     nullptr};  ///< Request which will later be notified/delivered to user
   std::shared_ptr<Buffer> _buffer{nullptr};  ///< Buffer containing the received data
 
-  RecvAmMessage()                     = delete;
-  RecvAmMessage(const RecvAmMessage&) = delete;
+  RecvAmMessage()                                = delete;
+  RecvAmMessage(const RecvAmMessage&)            = delete;
   RecvAmMessage& operator=(RecvAmMessage const&) = delete;
   RecvAmMessage(RecvAmMessage&& o)               = delete;
-  RecvAmMessage& operator=(RecvAmMessage&& o) = delete;
+  RecvAmMessage& operator=(RecvAmMessage&& o)    = delete;
 
   /**
    * @brief Constructor of `ucxx::RecvAmMessage`.

--- a/cpp/include/ucxx/listener.h
+++ b/cpp/include/ucxx/listener.h
@@ -40,11 +40,11 @@ class Listener : public Component {
            void* callbackArgs);
 
  public:
-  Listener()                = delete;
-  Listener(const Listener&) = delete;
+  Listener()                           = delete;
+  Listener(const Listener&)            = delete;
   Listener& operator=(Listener const&) = delete;
   Listener(Listener&& o)               = delete;
-  Listener& operator=(Listener&& o) = delete;
+  Listener& operator=(Listener&& o)    = delete;
 
   ~Listener();
 

--- a/cpp/include/ucxx/notifier.h
+++ b/cpp/include/ucxx/notifier.h
@@ -22,10 +22,10 @@ class Notifier {
   Notifier() = default;
 
  public:
-  Notifier(const Notifier&) = delete;
+  Notifier(const Notifier&)            = delete;
   Notifier& operator=(Notifier const&) = delete;
   Notifier(Notifier&& o)               = delete;
-  Notifier& operator=(Notifier&& o) = delete;
+  Notifier& operator=(Notifier&& o)    = delete;
 
   /**
    * @brief Virtual destructor.

--- a/cpp/include/ucxx/request.h
+++ b/cpp/include/ucxx/request.h
@@ -88,11 +88,11 @@ class Request : public Component {
   void setStatus(ucs_status_t status);
 
  public:
-  Request()               = delete;
-  Request(const Request&) = delete;
+  Request()                          = delete;
+  Request(const Request&)            = delete;
   Request& operator=(Request const&) = delete;
   Request(Request&& o)               = delete;
-  Request& operator=(Request&& o) = delete;
+  Request& operator=(Request&& o)    = delete;
 
   /**
    * @brief `ucxx::Request` destructor.

--- a/cpp/include/ucxx/request_tag_multi.h
+++ b/cpp/include/ucxx/request_tag_multi.h
@@ -28,10 +28,10 @@ struct BufferRequest {
   BufferRequest();
   ~BufferRequest();
 
-  BufferRequest(const BufferRequest&) = delete;
+  BufferRequest(const BufferRequest&)            = delete;
   BufferRequest& operator=(BufferRequest const&) = delete;
   BufferRequest(BufferRequest&& o)               = delete;
-  BufferRequest& operator=(BufferRequest&& o) = delete;
+  BufferRequest& operator=(BufferRequest&& o)    = delete;
 };
 
 typedef std::shared_ptr<BufferRequest> BufferRequestPtr;
@@ -50,11 +50,11 @@ class RequestTagMulti : public Request {
   bool _isFilled{false};                            ///< Whether the all requests have been posted
 
  private:
-  RequestTagMulti()                       = delete;
-  RequestTagMulti(const RequestTagMulti&) = delete;
+  RequestTagMulti()                                  = delete;
+  RequestTagMulti(const RequestTagMulti&)            = delete;
   RequestTagMulti& operator=(RequestTagMulti const&) = delete;
   RequestTagMulti(RequestTagMulti&& o)               = delete;
-  RequestTagMulti& operator=(RequestTagMulti&& o) = delete;
+  RequestTagMulti& operator=(RequestTagMulti&& o)    = delete;
 
   /**
    * @brief Protected constructor of a multi-buffer tag receive request.

--- a/cpp/include/ucxx/utils/callback_notifier.h
+++ b/cpp/include/ucxx/utils/callback_notifier.h
@@ -33,10 +33,10 @@ class CallbackNotifier {
 
   ~CallbackNotifier() {}
 
-  CallbackNotifier(const CallbackNotifier&) = delete;
+  CallbackNotifier(const CallbackNotifier&)            = delete;
   CallbackNotifier& operator=(CallbackNotifier const&) = delete;
   CallbackNotifier(CallbackNotifier&& o)               = delete;
-  CallbackNotifier& operator=(CallbackNotifier&& o) = delete;
+  CallbackNotifier& operator=(CallbackNotifier&& o)    = delete;
 
   /**
    * @brief Store a new flag value and notify waiting threads.

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -149,11 +149,11 @@ class Worker : public Component {
                   const bool enableFuture            = false);
 
  public:
-  Worker()              = delete;
-  Worker(const Worker&) = delete;
+  Worker()                         = delete;
+  Worker(const Worker&)            = delete;
   Worker& operator=(Worker const&) = delete;
   Worker(Worker&& o)               = delete;
-  Worker& operator=(Worker&& o) = delete;
+  Worker& operator=(Worker&& o)    = delete;
 
   /**
    * @brief Constructor of `shared_ptr<ucxx::Worker>`.

--- a/cpp/python/include/ucxx/python/notifier.h
+++ b/cpp/python/include/ucxx/python/notifier.h
@@ -58,10 +58,10 @@ class Notifier : public ::ucxx::Notifier {
   RequestNotifierWaitState waitRequestNotifierWithTimeout(uint64_t period);
 
  public:
-  Notifier(const Notifier&) = delete;
+  Notifier(const Notifier&)            = delete;
   Notifier& operator=(Notifier const&) = delete;
   Notifier(Notifier&& o)               = delete;
-  Notifier& operator=(Notifier&& o) = delete;
+  Notifier& operator=(Notifier&& o)    = delete;
 
   /**
    * @brief Constructor of `shared_ptr<ucxx::python::Notifier>`.

--- a/cpp/python/include/ucxx/python/python_future.h
+++ b/cpp/python/include/ucxx/python/python_future.h
@@ -37,11 +37,11 @@ class Future : public ::ucxx::Future {
   explicit Future(std::shared_ptr<::ucxx::Notifier> notifier);
 
  public:
-  Future()              = delete;
-  Future(const Future&) = delete;
+  Future()                         = delete;
+  Future(const Future&)            = delete;
   Future& operator=(Future const&) = delete;
   Future(Future&& o)               = delete;
-  Future& operator=(Future&& o) = delete;
+  Future& operator=(Future&& o)    = delete;
 
   /**
    * @brief Constructor of `shared_ptr<ucxx::python::Future>`.

--- a/cpp/python/include/ucxx/python/worker.h
+++ b/cpp/python/include/ucxx/python/worker.h
@@ -42,11 +42,11 @@ class Worker : public ::ucxx::Worker {
          const bool enableFuture            = false);
 
  public:
-  Worker()              = delete;
-  Worker(const Worker&) = delete;
+  Worker()                         = delete;
+  Worker(const Worker&)            = delete;
   Worker& operator=(Worker const&) = delete;
   Worker(Worker&& o)               = delete;
-  Worker& operator=(Worker&& o) = delete;
+  Worker& operator=(Worker&& o)    = delete;
 
   /**
    * @brief Constructor of `shared_ptr<ucxx::python::Worker>`.

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -199,7 +199,7 @@ void Worker::initBlockingProgressMode()
 
   epoll_event workerEvent = {.events = EPOLLIN,
                              .data   = {
-                               .fd = _workerFileDescriptor,
+                                 .fd = _workerFileDescriptor,
                              }};
 
   err = epoll_ctl(_epollFileDescriptor, EPOLL_CTL_ADD, _workerFileDescriptor, &workerEvent);

--- a/cpp/tests/context.cpp
+++ b/cpp/tests/context.cpp
@@ -13,8 +13,7 @@ namespace {
 
 static std::vector<std::string> TlsConfig{"^tcp", "^tcp,sm", "tcp", "tcp,sm", "all"};
 
-class ContextTestCustomConfig : public testing::TestWithParam<std::string> {
-};
+class ContextTestCustomConfig : public testing::TestWithParam<std::string> {};
 
 TEST(ContextTest, HandleIsValid)
 {


### PR DESCRIPTION
This PR updates ucxx to use clang 16.0.6. This aligns ucxx with the major version 16 being used elsewhere in RAPIDS.