### PR TITLE
Forward-merge branch-0.34 to branch-0.35

### DIFF
--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -148,14 +148,46 @@ void Endpoint::close()
     // the endpoint status is not UCS_OK
     closeMode = UCP_EP_CLOSE_MODE_FORCE;
   }
-  ucs_status_ptr_t status = ucp_ep_close_nb(_handle, closeMode);
-  if (UCS_PTR_IS_PTR(status)) {
-    auto worker = ::ucxx::getWorker(_parent);
-    while (ucp_request_check_status(status) == UCS_INPROGRESS)
-      if (!worker->isProgressThreadRunning()) worker->progress();
-    ucp_request_free(status);
-  } else if (UCS_PTR_STATUS(status) != UCS_OK) {
-    ucxx_error("Error while closing endpoint: %s", ucs_status_string(UCS_PTR_STATUS(status)));
+
+  auto worker = ::ucxx::getWorker(_parent);
+  ucs_status_ptr_t status;
+
+  if (worker->isProgressThreadRunning()) {
+    utils::CallbackNotifier callbackNotifierPre{false};
+    worker->registerGenericPre([this, &callbackNotifierPre, &status, closeMode]() {
+      status = ucp_ep_close_nb(_handle, closeMode);
+      callbackNotifierPre.store(true);
+    });
+    callbackNotifierPre.wait([](auto flag) { return flag; });
+
+    while (UCS_PTR_IS_PTR(status)) {
+      utils::CallbackNotifier callbackNotifierPost{false};
+      worker->registerGenericPost([this, &callbackNotifierPost, &status]() {
+        ucs_status_t s = ucp_request_check_status(status);
+        if (UCS_PTR_STATUS(s) != UCS_INPROGRESS) {
+          ucp_request_free(status);
+          _callbackData->status = UCS_PTR_STATUS(s);
+          if (UCS_PTR_STATUS(status) != UCS_OK) {
+            ucxx_error("Error while closing endpoint: %s",
+                       ucs_status_string(UCS_PTR_STATUS(status)));
+          }
+        }
+
+        callbackNotifierPost.store(true);
+      });
+      callbackNotifierPost.wait([](auto flag) { return flag; });
+    }
+  } else {
+    status = ucp_ep_close_nb(_handle, closeMode);
+    if (UCS_PTR_IS_PTR(status)) {
+      ucs_status_t s;
+      while ((s = ucp_request_check_status(status)) == UCS_INPROGRESS)
+        worker->progress();
+      ucp_request_free(status);
+      _callbackData->status = s;
+    } else if (UCS_PTR_STATUS(status) != UCS_OK) {
+      ucxx_error("Error while closing endpoint: %s", ucs_status_string(UCS_PTR_STATUS(status)));
+    }
   }
   ucxx_trace("Endpoint closed: %p", _handle);
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.34` that creates a PR to keep `branch-0.35` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.