### PR TITLE
Simplify callback notifier and provide (optional) spin-lock implementation

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -124,6 +124,7 @@ add_library(
   src/request_tag_multi.cpp
   src/worker.cpp
   src/worker_progress_thread.cpp
+  src/utils/callback_notifier.cpp
   src/utils/file_descriptor.cpp
   src/utils/python.cpp
   src/utils/sockaddr.cpp

--- a/cpp/include/ucxx/utils/callback_notifier.h
+++ b/cpp/include/ucxx/utils/callback_notifier.h
@@ -2,34 +2,40 @@
  * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#define UCXX_USE_SPINLOCK 1
+#if (UCXX_USE_SPINLOCK == 1)
+#include <atomic>
+#else
 #include <condition_variable>
-#include <functional>
-#include <memory>
 #include <mutex>
-#include <utility>
-
+#endif
 namespace ucxx {
 
 namespace utils {
 
-template <typename Flag>
 class CallbackNotifier {
  private:
-  Flag _flag{};                                  //< flag storing state
+#if (UCXX_USE_SPINLOCK == 1)
+  std::atomic_bool _flag{};  //< flag storing state
+#else
+  bool _flag{};                                  //< flag storing state
   std::mutex _mutex{};                           //< lock to guard accesses
   std::condition_variable _conditionVariable{};  //< notification condition var
-
+#endif
  public:
   /**
    * @brief Construct a thread-safe notification object with given initial value.
    *
-   * Construct a thread-safe notification object with a given initial value which may be
-   * later set via `store()` in one thread and block other threads running `wait()` while
-   * the new value is not set.
+   * Construct a thread-safe notification object which can signal
+   * release of some shared state with `set()` while other threads
+   * block on `wait()` until the shared state is released.
+   *
+   * If `UCXX_USE_SPINLOCK` is 0, this uses a condition variable,
+     otherwise it uses an atomic spinlock.
    *
    * @param[in] init  The initial flag value
    */
-  explicit CallbackNotifier(Flag flag) : _flag{flag} {}
+  CallbackNotifier() : _flag{false} {}
 
   ~CallbackNotifier() {}
 
@@ -39,39 +45,37 @@ class CallbackNotifier {
   CallbackNotifier& operator=(CallbackNotifier&& o)    = delete;
 
   /**
-   * @brief Store a new flag value and notify waiting threads.
+   * @brief Notify waiting threads that we are done and they can proceed
    *
-   * Store a new flag value and notify others threads blocked by a call to `wait()`.
+   * Set the flag to true and notify others threads blocked by a call to `wait()`.
    * See also `std::condition_variable::notify_all`.
-   *
-   * @param[in] flag  The new flag value.
    */
-  void store(Flag flag)
+  void set()
   {
+#if (UCXX_USE_SPINLOCK == 1)
+    _flag.store(true, std::memory_order_release);
+#else
     {
       std::lock_guard lock(_mutex);
-      _flag = flag;
+      _flag = true;
     }
     _conditionVariable.notify_all();
+#endif
   }
 
   /**
-   * @brief Wait while predicate is not true for the flag value to change.
+   * @brief Wait until set has been called
    *
-   * Wait while predicate is not true which should be satisfied by a change in the flag's
-   * value by a `store()` call on a different thread.
-   *
-   * @param[in] compare Function of type `T -> bool` called with the flag value. This
-   *                    function loops until the predicate is satisfied. See also
-   *                    `std::condition_variable::wait`.
-   * @param[out]        The new flag value.
+   * See also `std::condition_variable::wait`
    */
-  template <typename Compare>
-  Flag wait(Compare compare)
+  void wait()
   {
+#if (UCXX_USE_SPINLOCK == 1)
+    while (!_flag.load(std::memory_order_acquire)) {}
+#else
     std::unique_lock lock(_mutex);
-    _conditionVariable.wait(lock, [this, &compare]() { return compare(_flag); });
-    return std::move(_flag);
+    _conditionVariable.wait(lock, [this]() { return _flag; });
+#endif
   }
 };
 

--- a/cpp/include/ucxx/utils/callback_notifier.h
+++ b/cpp/include/ucxx/utils/callback_notifier.h
@@ -11,27 +11,26 @@ namespace utils {
 
 class CallbackNotifier {
  private:
-  std::atomic_bool _spinlock{};                  //< spinlock if we're not using condition variables
-  bool _flag{};                                  //< flag storing state
+  std::atomic_bool _flag{};                      //< flag storing state
   std::mutex _mutex{};                           //< lock to guard accesses
   std::condition_variable _conditionVariable{};  //< notification condition var
-  bool _use_spinlock{};                          //< should we use the spinlock?
-  bool use_spinlock();
 
  public:
   /**
-   * @brief Construct a thread-safe notification object with given initial value.
+   * @brief Construct a thread-safe notification object
    *
    * Construct a thread-safe notification object which can signal
    * release of some shared state with `set()` while other threads
    * block on `wait()` until the shared state is released.
    *
-   * If libc is glibc and the version is older than 2.25, this uses a
-   * spinlock otherwise it uses a condition variable,
+   * If libc is glibc and the version is older than 2.25, the
+   * implementation uses a spinlock otherwise it uses a condition
+   * variable.
    *
-   * @param[in] init  The initial flag value
+   * When C++-20 is the minimum supported version, it should use
+   * atomic.wait + notify_all.
    */
-  CallbackNotifier() : _flag{false}, _spinlock{false}, _use_spinlock{use_spinlock()} {};
+  CallbackNotifier() : _flag{false} {};
 
   ~CallbackNotifier() = default;
 
@@ -49,9 +48,9 @@ class CallbackNotifier {
   void set();
 
   /**
-   * @brief Wait until set has been called
+   * @brief Wait until `set()` has been called
    *
-   * See also `std::condition_variable::wait`
+   * See also `std::condition_variable::wait`.
    */
   void wait();
 };

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -559,6 +559,15 @@ class Worker : public Component {
   bool isProgressThreadRunning();
 
   /**
+   * @brief Get the progress thread ID.
+   *
+   * Get the progress thread ID, only valid if `startProgressThread()` was called.
+   *
+   * @returns the progress thread ID.
+   */
+  std::thread::id getProgressThreadId();
+
+  /**
    * @brief Cancel inflight requests.
    *
    * Cancel inflight requests, returning the total number of requests that were canceled.

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -57,15 +57,14 @@ void InflightRequests::remove(const Request* const request)
 
 size_t InflightRequests::cancelAll()
 {
+  std::scoped_lock lock{_cancelMutex, _mutex};
+  size_t total = _inflightRequests->size();
+
   // Fast path when no requests have been registered or the map has been
   // previously released.
-  if (_inflightRequests->size() == 0) return 0;
+  if (total == 0) return 0;
 
-  ucxx_debug("Canceling %lu requests", _inflightRequests->size());
-
-  std::scoped_lock lock{_cancelMutex, _mutex};
-
-  size_t total = _inflightRequests->size();
+  ucxx_debug("Canceling %lu requests", total);
 
   for (auto& r : *_inflightRequests) {
     auto request = r.second;

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -51,16 +51,16 @@ Listener::~Listener()
   auto worker = std::static_pointer_cast<Worker>(_parent);
 
   if (worker->isProgressThreadRunning()) {
-    utils::CallbackNotifier callbackNotifierPre{false};
+    utils::CallbackNotifier callbackNotifierPre{};
     worker->registerGenericPre([this, &callbackNotifierPre]() {
       ucp_listener_destroy(_handle);
-      callbackNotifierPre.store(true);
+      callbackNotifierPre.set();
     });
-    callbackNotifierPre.wait([](auto flag) { return flag; });
+    callbackNotifierPre.wait();
 
-    utils::CallbackNotifier callbackNotifierPost{false};
-    worker->registerGenericPost([&callbackNotifierPost]() { callbackNotifierPost.store(true); });
-    callbackNotifierPost.wait([](auto flag) { return flag; });
+    utils::CallbackNotifier callbackNotifierPost{};
+    worker->registerGenericPost([&callbackNotifierPost]() { callbackNotifierPost.set(); });
+    callbackNotifierPost.wait();
   } else {
     ucp_listener_destroy(this->_handle);
     worker->progress();

--- a/cpp/src/utils/callback_notifier.cpp
+++ b/cpp/src/utils/callback_notifier.cpp
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "ucxx/log.h"
+#include <features.h>
+#include <iostream>
+#include <ucxx/utils/callback_notifier.h>
+#ifdef __GLIBC__
+#include <gnu/libc-version.h>
+#include <string>
+#endif
+
+namespace ucxx {
+namespace utils {
+
+#ifdef __GLIBC__
+bool CallbackNotifier::use_spinlock()
+{
+  static bool use_set = false;
+  static bool use     = false;
+  if (use_set) return use;
+  use_set           = true;
+  auto libc_version = std::string_view{gnu_get_libc_version()};
+  auto dot          = libc_version.find(".");
+  if (dot == std::string::npos) {
+    use = false;
+  } else {
+    int glibc_major = std::stoi(libc_version.substr(0, dot).data());
+    int glibc_minor = std::stoi(libc_version.substr(dot + 1).data());
+    use             = glibc_major < 2 || (glibc_major == 2 && glibc_minor < 25);
+    ucxx_trace("glibc version %s detected, spinlock use is %d", libc_version.data(), use);
+  }
+  return use;
+}
+#else
+bool CallbackNotifier::use_spinlock() { return false; }
+#endif
+
+void CallbackNotifier::set()
+{
+  if (use_spinlock()) {
+    _spinlock.store(true, std::memory_order_release);
+  } else {
+    {
+      std::lock_guard lock(_mutex);
+      _flag = true;
+    }
+    _conditionVariable.notify_all();
+  }
+}
+void CallbackNotifier::wait()
+{
+  if (use_spinlock()) {
+    while (!_spinlock.load(std::memory_order_acquire)) {}
+  } else {
+    std::unique_lock lock(_mutex);
+    _conditionVariable.wait(lock, [this]() { return _flag; });
+  }
+}
+
+}  // namespace utils
+}  // namespace ucxx

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -407,16 +407,16 @@ size_t Worker::cancelInflightRequests()
   }
 
   if (isProgressThreadRunning()) {
-    utils::CallbackNotifier callbackNotifierPre{false};
+    utils::CallbackNotifier callbackNotifierPre{};
     registerGenericPre([&callbackNotifierPre, &canceled, &inflightRequestsToCancel]() {
       canceled = inflightRequestsToCancel->cancelAll();
-      callbackNotifierPre.store(true);
+      callbackNotifierPre.set();
     });
-    callbackNotifierPre.wait([](auto flag) { return flag; });
+    callbackNotifierPre.wait();
 
-    utils::CallbackNotifier callbackNotifierPost{false};
-    registerGenericPost([&callbackNotifierPost]() { callbackNotifierPost.store(true); });
-    callbackNotifierPost.wait([](auto flag) { return flag; });
+    utils::CallbackNotifier callbackNotifierPost{};
+    registerGenericPost([&callbackNotifierPost]() { callbackNotifierPost.set(); });
+    callbackNotifierPost.wait();
   } else {
     canceled = inflightRequestsToCancel->cancelAll();
   }
@@ -462,12 +462,12 @@ bool Worker::tagProbe(const ucp_tag_t tag)
      * indicate the progress thread has immediately finished executing and post-progress
      * ran without a further progress operation.
      */
-    utils::CallbackNotifier callbackNotifierPre{false};
-    registerGenericPre([&callbackNotifierPre]() { callbackNotifierPre.store(true); });
-    callbackNotifierPre.wait([](auto flag) { return flag; });
-    utils::CallbackNotifier callbackNotifierPost{false};
-    registerGenericPost([&callbackNotifierPost]() { callbackNotifierPost.store(true); });
-    callbackNotifierPost.wait([](auto flag) { return flag; });
+    utils::CallbackNotifier callbackNotifierPre{};
+    registerGenericPre([&callbackNotifierPre]() { callbackNotifierPre.set(); });
+    callbackNotifierPre.wait();
+    utils::CallbackNotifier callbackNotifierPost{};
+    registerGenericPost([&callbackNotifierPost]() { callbackNotifierPost.set(); });
+    callbackNotifierPost.wait();
   }
 
   ucp_tag_recv_info_t info;

--- a/cpp/src/worker_progress_thread.cpp
+++ b/cpp/src/worker_progress_thread.cpp
@@ -56,19 +56,19 @@ WorkerProgressThread::~WorkerProgressThread()
     return;
   }
 
-  utils::CallbackNotifier callbackNotifierPre{false};
+  utils::CallbackNotifier callbackNotifierPre{};
   _delayedSubmissionCollection->registerGenericPre(
-    [&callbackNotifierPre]() { callbackNotifierPre.store(true); });
+    [&callbackNotifierPre]() { callbackNotifierPre.set(); });
   _signalWorkerFunction();
-  callbackNotifierPre.wait([](auto flag) { return flag; });
+  callbackNotifierPre.wait();
 
-  utils::CallbackNotifier callbackNotifierPost{false};
+  utils::CallbackNotifier callbackNotifierPost{};
   _delayedSubmissionCollection->registerGenericPost([this, &callbackNotifierPost]() {
     _stop = true;
-    callbackNotifierPost.store(true);
+    callbackNotifierPost.set();
   });
   _signalWorkerFunction();
-  callbackNotifierPost.wait([](auto flag) { return flag; });
+  callbackNotifierPost.wait();
 
   _thread.join();
 }


### PR DESCRIPTION
Rather than passing information through the callback notifier object, merely use it as a barrier for memory ordering. Additionally, provide an alternate implementation (automatically enabled when running with glibc <= 2.25) that uses an atomic spinlock rather than condition variables.