### PR TITLE
Properly check for `ucp_ep_create()` errors

### DIFF
--- a/cpp/python/src/python_future.cpp
+++ b/cpp/python/src/python_future.cpp
@@ -4,6 +4,7 @@
  */
 #include <memory>
 #include <stdexcept>
+#include <utility>
 
 #include <Python.h>
 

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -63,7 +63,7 @@ Endpoint::Endpoint(std::shared_ptr<Component> workerOrListener,
   if (worker->isProgressThreadRunning()) {
     utils::CallbackNotifier callbackNotifier{false};
     auto worker = ::ucxx::getWorker(_parent);
-    auto status = UCS_OK;
+    auto status = UCS_INPROGRESS;
     worker->registerGenericPre([this, &status, &params, &callbackNotifier]() {
       auto worker = ::ucxx::getWorker(_parent);
       status      = ucp_ep_create(worker->getHandle(), params, &_handle);


### PR DESCRIPTION
The `UCS_INPROGRESS` state is not valid for `ucp_ep_create`, only `UCS_OK` and errors are returned. Therefore remove that check and additionally fix to check for the proper error, instead of the previous boolean error check.