### PR TITLE
Exchange peer info fixes

### DIFF
--- a/python/ucxx/_lib_async/exchange_peer_info.py
+++ b/python/ucxx/_lib_async/exchange_peer_info.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+import asyncio
 import logging
 import struct
 
@@ -12,7 +13,7 @@ from .utils import hash64bits
 logger = logging.getLogger("ucx")
 
 
-async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, listener):
+async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, listener, stream_timeout=5.0):
     """Help function that exchange endpoint information"""
 
     # Pack peer information incl. a checksum
@@ -26,14 +27,14 @@ async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, listener):
     # streaming calls (see <https://github.com/rapidsai/ucx-py/pull/509>)
     if listener is True:
         req = endpoint.stream_send(my_info_arr)
-        await req.wait()
+        await asyncio.wait_for(req.wait(), timeout=stream_timeout)
         req = endpoint.stream_recv(peer_info_arr)
-        await req.wait()
+        await asyncio.wait_for(req.wait(), timeout=stream_timeout)
     else:
         req = endpoint.stream_recv(peer_info_arr)
-        await req.wait()
+        await asyncio.wait_for(req.wait(), timeout=stream_timeout)
         req = endpoint.stream_send(my_info_arr)
-        await req.wait()
+        await asyncio.wait_for(req.wait(), timeout=stream_timeout)
 
     # Unpacking and sanity check of the peer information
     ret = {}


### PR DESCRIPTION
Add a timeout to `exchange_peer_info` to prevent indefinite hangs in `exchange_peer_info`, specifically when executing `stream_recv` on the client side. The causes for this is unknown but believed to be due to messages being lost if there's either multiple stream messages being transferred simultaneously among various endpoints or being lost due to the receiving end taking too long to launch `stream_recv`, see https://github.com/rapidsai/ucx-py/pull/509 for a similar issue related to stream API. By adding a timeout doesn't allow recovery, but at least allows a UCX-Py client to retry upon failure to establish the endpoint.

Additionally, raise endpoint's error if an error occurs during `exchange_peer_info`.