### PR TITLE
Do a roundtrip message transfer for `test_send_recv_am`

### DIFF
--- a/python/ucxx/_lib_async/tests/test_send_recv_am.py
+++ b/python/ucxx/_lib_async/tests/test_send_recv_am.py
@@ -77,21 +77,21 @@ async def test_send_recv_am(size, recv_wait, data):
         await ucxx.create_endpoint(ucxx.get_address(), listener.port)
         for i in range(num_clients)
     ]
-    for c in clients:
-        if recv_wait:
-            # By sleeping here we ensure that the listener's
-            # ep.am_recv call will have to wait, rather than return
-            # immediately as receive data is already available.
-            await asyncio.sleep(1)
-        await c.am_send(msg)
-        recv_msg = await c.am_recv()
+    if recv_wait:
+        # By sleeping here we ensure that the listener's
+        # ep.am_recv call will have to wait, rather than return
+        # immediately as receive data is already available.
+        await asyncio.sleep(1)
+    await asyncio.gather(*(c.am_send(msg) for c in clients))
+    recv_msgs = await asyncio.gather(*(c.am_recv() for c in clients))
 
-    if data["memory_type"] == "cuda" and msg.nbytes < rndv_thresh:
-        # Eager messages are always received on the host, if no custom host
-        # allocator is registered, UCXX defaults to `np.array`.
-        np.testing.assert_equal(recv_msg.view(np.int64), msg.get())
-    else:
-        data["validator"](recv_msg, msg)
+    for recv_msg in recv_msgs:
+        if data["memory_type"] == "cuda" and msg.nbytes < rndv_thresh:
+            # Eager messages are always received on the host, if no custom host
+            # allocator is registered, UCXX defaults to `np.array`.
+            np.testing.assert_equal(recv_msg.view(np.int64), msg.get())
+        else:
+            data["validator"](recv_msg, msg)
 
     await asyncio.gather(*(c.close() for c in clients))
     await wait_listener_client_handlers(listener)


### PR DESCRIPTION
A roundtrip ensures the client receives the reply and thus prevents us from the checking for a transfer that didn't complete yet.