### PR TITLE
Add UCP handle to create/destroy trace logging

### DIFF
--- a/cpp/src/context.cpp
+++ b/cpp/src/context.cpp
@@ -22,8 +22,8 @@ Context::Context(const ConfigMap ucxConfig, const uint64_t featureFlags)
   // UCP
   ucp_params_t params = {.field_mask = UCP_PARAM_FIELD_FEATURES, .features = featureFlags};
 
-  utils::ucsErrorThrow(ucp_init(&params, this->_config.getHandle(), &this->_handle));
-  ucxx_trace("Context created: %p", this->_handle);
+  utils::ucsErrorThrow(ucp_init(&params, _config.getHandle(), &_handle));
+  ucxx_trace("Context created: %p, UCP handle: %p", this, _handle);
 
   ucp_context_attr_t attr = {.field_mask = UCP_ATTR_FIELD_MEMORY_TYPES};
   ucp_context_query(_handle, &attr);
@@ -33,7 +33,7 @@ Context::Context(const ConfigMap ucxConfig, const uint64_t featureFlags)
   // "cuda_copy", "cuda_ipc"} is in the active transports.
   // If the transport list is negated ("^" at start), then it is to be
   // interpreted as all \ given
-  auto configMap = this->_config.get();
+  auto configMap = _config.get();
   auto tls       = configMap.find("TLS");
   if (_cudaSupport) {
     if (tls != configMap.end()) {
@@ -72,18 +72,18 @@ std::shared_ptr<Context> createContext(const ConfigMap ucxConfig, const uint64_t
 
 Context::~Context()
 {
-  if (this->_handle != nullptr) ucp_cleanup(this->_handle);
-  ucxx_trace("Context destroyed: %p", this->_handle);
+  if (_handle != nullptr) ucp_cleanup(_handle);
+  ucxx_trace("Context destroyed: %p, UCP handle: %p", this, _handle);
 }
 
-ConfigMap Context::getConfig() { return this->_config.get(); }
+ConfigMap Context::getConfig() { return _config.get(); }
 
-ucp_context_h Context::getHandle() { return this->_handle; }
+ucp_context_h Context::getHandle() { return _handle; }
 
 std::string Context::getInfo()
 {
   FILE* TextFileDescriptor = utils::createTextFileDescriptor();
-  ucp_context_print_info(this->_handle, TextFileDescriptor);
+  ucp_context_print_info(_handle, TextFileDescriptor);
   return utils::decodeTextFileDescriptor(TextFileDescriptor);
 }
 

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -75,6 +75,12 @@ Endpoint::Endpoint(std::shared_ptr<Component> workerOrListener,
   } else {
     utils::ucsErrorThrow(ucp_ep_create(worker->getHandle(), params, &_handle));
   }
+
+  ucxx_trace("Endpoint created: %p, UCP handle: %p, parent: %p, endpointErrorHandling: %d",
+             this,
+             _handle,
+             _parent.get(),
+             endpointErrorHandling);
 }
 
 std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> worker,
@@ -133,7 +139,7 @@ std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(std::shared_ptr<Worker
 Endpoint::~Endpoint()
 {
   close();
-  ucxx_trace("Endpoint destroyed: %p", _originalHandle);
+  ucxx_trace("Endpoint destroyed: %p, UCP handle: %p", this, _originalHandle);
 }
 
 void Endpoint::close()
@@ -191,7 +197,7 @@ void Endpoint::close()
       ucxx_error("Error while closing endpoint: %s", ucs_status_string(UCS_PTR_STATUS(status)));
     }
   }
-  ucxx_trace("Endpoint closed: %p", _handle);
+  ucxx_trace("Endpoint closed: %p, UCP handle: %p", this, _handle);
 
   if (_callbackData->closeCallback) {
     ucxx_debug("Calling user callback for endpoint %p", _handle);

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -31,7 +31,7 @@ Listener::Listener(std::shared_ptr<Worker> worker,
   params.sockaddr.addrlen = info->ai_addrlen;
 
   utils::ucsErrorThrow(ucp_listener_create(worker->getHandle(), &params, &_handle));
-  ucxx_trace("Listener created: %p", _handle);
+  ucxx_trace("Listener created: %p, UCP handle: %p", this, _handle);
 
   ucp_listener_attr_t attr = {.field_mask = UCP_LISTENER_ATTR_FIELD_SOCKADDR};
   utils::ucsErrorThrow(ucp_listener_query(_handle, &attr));
@@ -62,11 +62,11 @@ Listener::~Listener()
     worker->registerGenericPost([&callbackNotifierPost]() { callbackNotifierPost.set(); });
     callbackNotifierPost.wait();
   } else {
-    ucp_listener_destroy(this->_handle);
+    ucp_listener_destroy(_handle);
     worker->progress();
   }
 
-  ucxx_trace("Listener destroyed: %p", this->_handle);
+  ucxx_trace("Listener destroyed: %p, UCP handle: %p", this, _handle);
 }
 
 std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -60,8 +60,9 @@ Worker::Worker(std::shared_ptr<Context> context,
     utils::ucsErrorThrow(ucp_worker_set_am_recv_handler(_handle, &am_handler_param));
   }
 
-  ucxx_trace("Worker created: %p, enableDelayedSubmission: %d, enableFuture: %d",
+  ucxx_trace("Worker created: %p, UCP handle: %p, enableDelayedSubmission: %d, enableFuture: %d",
              this,
+             _handle,
              enableDelayedSubmission,
              _enableFuture);
 
@@ -158,7 +159,7 @@ Worker::~Worker()
   drainWorkerTagRecv();
 
   ucp_worker_destroy(_handle);
-  ucxx_trace("Worker destroyed: %p", _handle);
+  ucxx_trace("Worker destroyed: %p, UCP handle: %p", this, _handle);
 
   if (_epollFileDescriptor >= 0) close(_epollFileDescriptor);
 }


### PR DESCRIPTION
Add the UCP handle to trace logging, thus making a distinction between the UCXX object (`this`) pointer and the underlying UCP handle, allowing to more easily match objects during debugging sessions.