### PR TITLE
Make `UCXPY_*` environment variables higher priority

### DIFF
--- a/python/ucxx/_lib_async/application_context.py
+++ b/python/ucxx/_lib_async/application_context.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import threading
+import warnings
 import weakref
 from queue import Queue
 
@@ -48,6 +49,12 @@ class ApplicationContext:
         )
         enable_python_future = ApplicationContext._check_enable_python_future(
             enable_python_future, self.progress_mode
+        )
+
+        logger.info(
+            f"Progress mode: {self.progress_mode}, "
+            f"delayed submission: {enable_delayed_submission}, "
+            f"Python future: {enable_python_future}"
         )
 
         self.exchange_peer_info_timeout = exchange_peer_info_timeout
@@ -126,7 +133,7 @@ class ApplicationContext:
             explicit_enable_python_future = enable_python_future
 
         if not progress_mode.startswith("thread") and explicit_enable_python_future:
-            logger.warning(
+            warnings.warn(
                 f"Notifier thread requested, but {progress_mode} does not "
                 "support it, using Python wait_yield()."
             )

--- a/python/ucxx/_lib_async/application_context.py
+++ b/python/ucxx/_lib_async/application_context.py
@@ -78,11 +78,10 @@ class ApplicationContext:
 
     @staticmethod
     def _check_progress_mode(progress_mode):
-        if progress_mode is None:
-            if "UCXPY_PROGRESS_MODE" in os.environ:
-                progress_mode = os.environ["UCXPY_PROGRESS_MODE"]
-            else:
-                progress_mode = "thread"
+        if "UCXPY_PROGRESS_MODE" in os.environ:
+            progress_mode = os.environ["UCXPY_PROGRESS_MODE"]
+        elif progress_mode is None:
+            progress_mode = "thread"
 
         valid_progress_modes = ["polling", "thread", "thread-polling"]
         if not isinstance(progress_mode, str) or not any(
@@ -97,15 +96,12 @@ class ApplicationContext:
 
     @staticmethod
     def _check_enable_delayed_submission(enable_delayed_submission, progress_mode):
-        if enable_delayed_submission is None:
-            if "UCXPY_ENABLE_DELAYED_SUBMISSION" in os.environ:
-                explicit_enable_delayed_submission = (
-                    False
-                    if os.environ["UCXPY_ENABLE_DELAYED_SUBMISSION"] == "0"
-                    else True
-                )
-            else:
-                explicit_enable_delayed_submission = progress_mode.startswith("thread")
+        if "UCXPY_ENABLE_DELAYED_SUBMISSION" in os.environ:
+            explicit_enable_delayed_submission = (
+                False if os.environ["UCXPY_ENABLE_DELAYED_SUBMISSION"] == "0" else True
+            )
+        elif enable_delayed_submission is None:
+            explicit_enable_delayed_submission = progress_mode.startswith("thread")
         else:
             explicit_enable_delayed_submission = enable_delayed_submission
 
@@ -122,13 +118,12 @@ class ApplicationContext:
 
     @staticmethod
     def _check_enable_python_future(enable_python_future, progress_mode):
-        if enable_python_future is None:
-            if "UCXPY_ENABLE_PYTHON_FUTURE" in os.environ:
-                explicit_enable_python_future = (
-                    os.environ["UCXPY_ENABLE_PYTHON_FUTURE"] != "0"
-                )
-            else:
-                explicit_enable_python_future = False
+        if "UCXPY_ENABLE_PYTHON_FUTURE" in os.environ:
+            explicit_enable_python_future = (
+                os.environ["UCXPY_ENABLE_PYTHON_FUTURE"] != "0"
+            )
+        elif enable_python_future is None:
+            explicit_enable_python_future = False
         else:
             explicit_enable_python_future = enable_python_future
 


### PR DESCRIPTION
Make `UCXPY_*` environment variables higher priority than `ucxx.init()` configuration arguments. This matches the behavior for `UCX_*` environment variables and the `config_dict` kwarg from `ucxx.init()`.

Also add information about selected UCX-Py initialization flags to info logging and convert notifier thread in non-thread progress mode warning to a Python user-facing warning.