### PR TITLE
Update rapids cmake calls to use non-deprecated signatures

### DIFF
--- a/cpp/cmake/thirdparty/get_gtest.cmake
+++ b/cpp/cmake/thirdparty/get_gtest.cmake
@@ -30,7 +30,7 @@ function(find_and_configure_gtest)
 
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
     rapids_export_find_package_root(
-      BUILD GTest [=[${CMAKE_CURRENT_LIST_DIR}]=] ucxx-testing-exports
+      BUILD GTest [=[${CMAKE_CURRENT_LIST_DIR}]=] EXPORT_SET ucxx-testing-exports
     )
   endif()
 

--- a/cpp/python/CMakeLists.txt
+++ b/cpp/python/CMakeLists.txt
@@ -77,5 +77,5 @@ install(DIRECTORY ${UCXX_SOURCE_DIR}/python/include/ucxx
 
 include("${rapids-cmake-dir}/export/find_package_root.cmake")
 rapids_export_find_package_root(
-  BUILD Python3 [=[${CMAKE_CURRENT_LIST_DIR}]=] ucxx-python-exports
+  BUILD Python3 [=[${CMAKE_CURRENT_LIST_DIR}]=] EXPORT_SET ucxx-python-exports
 )


### PR DESCRIPTION
`rapids_export` functions now need an explicit `EXPORT_SET`