### PR TITLE
Clear out callback data once we have run the callback

### DIFF
--- a/python/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/_lib/libucxx.pyx
@@ -435,6 +435,7 @@ cdef void _generic_callback(void *args) with gil:
             *cb_data['cb_args'],
             **cb_data['cb_kwargs']
         )
+        cb_data.clear()
     except Exception as e:
         pass
 
@@ -892,6 +893,7 @@ cdef void _endpoint_close_callback(void *args) with gil:
             *cb_data['cb_args'],
             **cb_data['cb_kwargs']
         )
+        cb_data.clear()
     except Exception as e:
         logger.error(f"{type(e)} when calling endpoint close callback: {e}")
 
@@ -1293,6 +1295,7 @@ cdef void _listener_callback(ucp_conn_request_h conn_request, void *args) with g
             *cb_data['cb_args'],
             **cb_data['cb_kwargs']
         )
+        cb_data.clear()
     except Exception as e:
         logger.error(f"{type(e)} when calling listener callback: {e}")
 


### PR DESCRIPTION
Although the UCXX python layer is careful not to set up refcycles (such that everything is collected deterministically), the callbacks are a loophole that can break this guarantee.

It is easy to set up a callback that references an object that produces a reference cycle. To avoid this, once we are done, internally, with the callback function (after it is called) drop any references to it.

This reduces the ease of post-hoc debugging (since one the callback has run, we can't see what it was), but ensures that we don't accidentally have a refcycle that inhibits deterministic collection of UCXX objects.