### PR TITLE
Avoid refcycle in listener create callback for deliver_endpoint=True

### DIFF
--- a/python/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/_lib/libucxx.pyx
@@ -6,6 +6,7 @@ import asyncio
 import enum
 import functools
 import logging
+import weakref
 
 from cpython.buffer cimport PyBUF_FORMAT, PyBUF_ND, PyBUF_WRITABLE
 from cpython.ref cimport PyObject
@@ -1285,7 +1286,7 @@ cdef void _listener_callback(ucp_conn_request_h conn_request, void *args) with g
     try:
         cb_data['cb_func'](
             (
-                cb_data['listener'].create_endpoint_from_conn_request(
+                cb_data['listener']().create_endpoint_from_conn_request(
                     int(<uintptr_t>conn_request), True
                 ) if 'listener' in cb_data else
                 int(<uintptr_t>conn_request)
@@ -1302,6 +1303,7 @@ cdef class UCXListener():
         shared_ptr[Listener] _listener
         bint _enable_python_future
         dict _cb_data
+        object __weakref__
 
     def __init__(
             self,
@@ -1353,7 +1355,7 @@ cdef class UCXListener():
             worker.is_python_future_enabled(),
         )
         if deliver_endpoint is True:
-            cb_data["listener"] = listener
+            cb_data["listener"] = weakref.ref(listener)
         return listener
 
     @property

--- a/python/ucxx/_lib/tests/test_ucx_getters.py
+++ b/python/ucxx/_lib/tests/test_ucx_getters.py
@@ -25,11 +25,11 @@ def _init_and_get_objects(progress_mode):
     # callback even after it has terminated.
     listener_ep = [None]
 
-    def _listener_handler(conn_request):
-        listener_ep[0] = listener.create_endpoint_from_conn_request(conn_request, True)
+    def _listener_handler(ep):
+        listener_ep[0] = ep
 
     listener = ucx_api.UCXListener.create(
-        worker=worker, port=0, cb_func=_listener_handler
+        worker=worker, port=0, cb_func=_listener_handler, deliver_endpoint=True
     )
 
     client_ep = ucx_api.UCXEndpoint.create(


### PR DESCRIPTION
Rather than storing a strong reference to the listener object we created, use a weakref.