### PR TITLE
Use a weakref finalizer to stop notifier thread

### DIFF
--- a/python/ucxx/_lib_async/application_context.py
+++ b/python/ucxx/_lib_async/application_context.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import functools
 import logging
 import os
 import threading
@@ -144,12 +145,23 @@ class ApplicationContext:
                 name="UCX-Py Async Notifier Thread",
             )
             self.notifier_thread.start()
+            weakref.finalize(
+                self,
+                functools.partial(
+                    self.stop_notifier_thread,
+                    self.notifier_thread_q,
+                    self.notifier_thread,
+                ),
+            )
         else:
             logger.debug(
                 "UCXX not compiled with UCXX_ENABLE_PYTHON, disabling notifier thread"
             )
 
-    def stop_notifier_thread(self):
+    # Must be a staticmethod so that it can be used in a weakref
+    # finalizer on the application context
+    @staticmethod
+    def stop_notifier_thread(queue, thread):
         """
         Stop Python future notifier thread
 
@@ -157,24 +169,22 @@ class ApplicationContext:
         notification enabled via `UCXPY_ENABLE_PYTHON_FUTURE=1` or
         `ucxx.init(..., enable_python_future=True)`.
 
-        .. warning:: When the notifier thread is enabled it may be necessary to
-                     explicitly call this method before shutting down the process or
-                     or application, otherwise it may block indefinitely waiting for
-                     the thread to terminate. Executing `ucxx.reset()` will also run
-                     this method, so it's not necessary to have both.
+        The application context arranges to call this function
+        automatically in a weakref finalizer when it goes out of
+        scope. If using the global application context, `ucxx.reset()`
+        will drop the reference and cause the notifier thread to be
+        stopped. For a user-maintained context, one must just ensure
+        that the reference is dropped.
         """
-        if self.notifier_thread_q and self.notifier_thread:
-            self.notifier_thread_q.put("shutdown")
-            while True:
-                # Having a timeout is required. During the notifier thread shutdown
-                # it may require the GIL, which will cause a deadlock with the `join()`
-                # call otherwise.
-                self.notifier_thread.join(timeout=0.01)
-                if not self.notifier_thread.is_alive():
-                    break
-            logger.debug("Notifier thread stopped")
-        else:
-            logger.debug("Notifier thread not running")
+        queue.put("shutdown")
+        while True:
+            # Having a timeout is required. During the notifier thread shutdown
+            # it may require the GIL, which will cause a deadlock with the `join()`
+            # call otherwise.
+            thread.join(timeout=0.01)
+            if not thread.is_alive():
+                break
+        logger.debug("Notifier thread stopped")
 
     def create_listener(
         self,

--- a/python/ucxx/core.py
+++ b/python/ucxx/core.py
@@ -94,7 +94,6 @@ def reset():
 
     The library is initiated at next API call.
     """
-    stop_notifier_thread()
     global _ctx
     if _ctx is not None:
         weakref_ctx = weakref.ref(_ctx)
@@ -104,19 +103,11 @@ def reset():
             msg = (
                 "Trying to reset UCX but not all Endpoints and/or Listeners "
                 "are closed(). The following objects are still referencing "
-                "ApplicationContext: "
+                f"the global ApplicationContext {weakref_ctx()}: "
             )
             for o in gc.get_referrers(weakref_ctx()):
                 msg += "\n  %s" % str(o)
             raise UCXError(msg)
-
-
-def stop_notifier_thread():
-    global _ctx
-    if _ctx:
-        _ctx.stop_notifier_thread()
-    else:
-        logger.debug("UCX is not initialized.")
 
 
 def get_ucx_version():
@@ -248,4 +239,3 @@ create_listener.__doc__ = ApplicationContext.create_listener.__doc__
 create_endpoint.__doc__ = ApplicationContext.create_endpoint.__doc__
 continuous_ucx_progress.__doc__ = ApplicationContext.continuous_ucx_progress.__doc__
 get_ucp_worker.__doc__ = ApplicationContext.get_ucp_worker.__doc__
-stop_notifier_thread.__doc__ = ApplicationContext.stop_notifier_thread.__doc__


### PR DESCRIPTION
When creating our own application context with the python notifier thread enabled we previously had to arrange to stop it before dropping the reference to the context we created. The consequence of not doing so is that our application hangs in exit waiting for a thread to join that never will.

Applying the principle of least surprise, an object should clean up all of its resources when dropping out of scope. To ensure this change Application.stop_notifier_thread to a staticmethod and attach it as a weakref finalizer when starting the notifier thread. This way, we don't have to handle the case where there is no notifier thread, nor do we have to remember to call the stop function manually.

This additionally allows us to clean up the top-level reset function since there is no longer a need to stop the notifier "manually" during reset.