### PR TITLE
Use timeouts in C++ tests when progressing the worker

### DIFF
--- a/cpp/tests/include/utils.h
+++ b/cpp/tests/include/utils.h
@@ -42,3 +42,5 @@ inline void waitRequests(std::shared_ptr<ucxx::Worker> worker,
 
 std::function<void()> getProgressFunction(std::shared_ptr<ucxx::Worker> worker,
                                           ProgressMode progressMode);
+
+bool loopWithTimeout(std::chrono::milliseconds timeout, std::function<bool()> f);

--- a/cpp/tests/listener.cpp
+++ b/cpp/tests/listener.cpp
@@ -13,9 +13,6 @@
 
 namespace {
 
-constexpr size_t MaxProgressAttempts = 50;
-constexpr size_t MaxFlakyAttempts    = 3;
-
 struct ListenerContainer {
   ucs_status_t status{UCS_OK};
   std::shared_ptr<ucxx::Worker> worker{nullptr};
@@ -146,43 +143,38 @@ TEST_F(ListenerTest, IsAlive)
     _worker->progress();
 
   listenerContainer->endpoint = nullptr;
-  for (size_t attempt = 0; attempt < MaxProgressAttempts && ep->isAlive(); ++attempt)
+
+  loopWithTimeout(std::chrono::milliseconds(5000), [this, ep]() {
     _worker->progress();
+    return !ep->isAlive();
+  });
+
   ASSERT_FALSE(ep->isAlive());
 }
 
 TEST_F(ListenerTest, RaiseOnError)
 {
-  auto run = [this](bool lastAttempt) {
-    auto listenerContainer = createListenerContainer();
-    auto listener          = createListener(listenerContainer);
+  auto listenerContainer = createListenerContainer();
+  auto listener          = createListener(listenerContainer);
+  _worker->progress();
+
+  auto ep = _worker->createEndpointFromHostname("127.0.0.1", listener->getPort());
+  while (listenerContainer->endpoint == nullptr)
     _worker->progress();
 
-    auto ep = _worker->createEndpointFromHostname("127.0.0.1", listener->getPort());
-    while (listenerContainer->endpoint == nullptr)
+  listenerContainer->endpoint = nullptr;
+
+  loopWithTimeout(std::chrono::milliseconds(5000), [this, ep]() {
+    try {
       _worker->progress();
-
-    listenerContainer->endpoint = nullptr;
-    bool success                = false;
-    for (size_t attempt = 0; attempt < MaxProgressAttempts; ++attempt) {
-      try {
-        _worker->progress();
-        ep->raiseOnError();
-      } catch (ucxx::Error) {
-        success = true;
-        break;
-      }
+      ep->raiseOnError();
+    } catch (ucxx::Error) {
+      return true;
     }
+    return false;
+  });
 
-    if (!success && !lastAttempt) return false;
-
-    EXPECT_THROW(ep->raiseOnError(), ucxx::Error);
-    return true;
-  };
-
-  for (size_t flakyAttempt = 0; flakyAttempt < MaxFlakyAttempts; ++flakyAttempt) {
-    if (run(flakyAttempt == MaxFlakyAttempts - 1)) break;
-  }
+  EXPECT_THROW(ep->raiseOnError(), ucxx::Error);
 }
 
 TEST_F(ListenerTest, CloseCallback)
@@ -203,8 +195,11 @@ TEST_F(ListenerTest, CloseCallback)
   ASSERT_FALSE(isClosed);
 
   listenerContainer->endpoint = nullptr;
-  for (size_t attempt = 0; attempt < MaxProgressAttempts && !isClosed; ++attempt)
+
+  loopWithTimeout(std::chrono::milliseconds(5000), [this, &isClosed]() {
     _worker->progress();
+    return isClosed;
+  });
 
   ASSERT_TRUE(isClosed);
 }

--- a/cpp/tests/utils.cpp
+++ b/cpp/tests/utils.cpp
@@ -25,3 +25,14 @@ std::function<void()> getProgressFunction(std::shared_ptr<ucxx::Worker> worker,
   else
     return std::function<void()>();
 }
+
+bool loopWithTimeout(std::chrono::milliseconds timeout, std::function<bool()> f)
+{
+  auto startTime = std::chrono::system_clock::now();
+  auto endTime   = startTime + std::chrono::milliseconds(timeout);
+
+  while (std::chrono::system_clock::now() < endTime) {
+    if (f()) return true;
+  }
+  return false;
+}

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -91,10 +91,10 @@ TEST_F(WorkerTest, TagProbe)
   requests.push_back(ep->tagSend(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0}));
   waitRequests(_worker, requests, progressWorker);
 
-  // Attempt to progress worker 10 times (arbitrarily defined).
-  // TODO: Maybe a timeout would fit best.
-  for (size_t i = 0; i < 10 && !_worker->tagProbe(ucxx::Tag{0}); ++i)
+  loopWithTimeout(std::chrono::milliseconds(5000), [this, progressWorker]() {
     progressWorker();
+    return _worker->tagProbe(ucxx::Tag{0});
+  });
 
   ASSERT_TRUE(_worker->tagProbe(ucxx::Tag{0}));
 }
@@ -111,10 +111,10 @@ TEST_F(WorkerTest, AmProbe)
   requests.push_back(ep->amSend(buf.data(), buf.size() * sizeof(int), UCS_MEMORY_TYPE_HOST));
   waitRequests(_worker, requests, progressWorker);
 
-  // Attempt to progress worker 10 times (arbitrarily defined).
-  // TODO: Maybe a timeout would fit best.
-  for (size_t i = 0; i < 10 && !_worker->tagProbe(ucxx::Tag{0}); ++i)
+  loopWithTimeout(std::chrono::milliseconds(5000), [this, progressWorker, ep]() {
     progressWorker();
+    return _worker->amProbe(ep->getHandle());
+  });
 
   ASSERT_TRUE(_worker->amProbe(ep->getHandle()));
 }


### PR DESCRIPTION
Tests such as those checking for endpoint state must progress the worker and then check again for state. Previously we used arbitrary iteration count to decide when to stop and this was responsible for tests occasionally failing. A better approach is to use a timeout and break as soon as the condition is satisfied or fail after the predefined timeout is expired, while this isn't necessarily fail-safe it proved much more reliable. In local stress tests in over an hour no failures were observed with the current timeout (5 seconds), whereas such tests would previously fail within a few minutes. The 5 seconds timeout seems like a safe default, from observing local runs 1-2 seconds timeout would also suffice, but given CI can be more subjective to slowdowns under high loads the 5 seconds seem like a safer initial default.