### PR TITLE
Fix segmentation fault on canceled requests that are not awaited

### DIFF
--- a/cpp/include/ucxx/inflight_requests.h
+++ b/cpp/include/ucxx/inflight_requests.h
@@ -134,7 +134,7 @@ class InflightRequests {
    *
    * @returns The count of requests that are in process of cancelation.
    */
-  size_t getCancelingCount();
+  size_t getCancelingSize();
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -40,12 +40,12 @@ class Worker : public Component {
   int _epollFileDescriptor{-1};         ///< The epoll file descriptor
   int _workerFileDescriptor{-1};        ///< The worker file descriptor
   std::mutex _inflightRequestsMutex{};  ///< Mutex to access the inflight requests pool
-  std::shared_ptr<InflightRequests> _inflightRequests{
-    std::make_shared<InflightRequests>()};  ///< The inflight requests
+  std::unique_ptr<InflightRequests> _inflightRequests{
+    std::make_unique<InflightRequests>()};  ///< The inflight requests
   std::mutex
     _inflightRequestsToCancelMutex{};  ///< Mutex to access the inflight requests to cancel pool
-  std::shared_ptr<InflightRequests> _inflightRequestsToCancel{
-    std::make_shared<InflightRequests>()};  ///< The inflight requests scheduled to be canceled
+  std::unique_ptr<InflightRequests> _inflightRequestsToCancel{
+    std::make_unique<InflightRequests>()};  ///< The inflight requests scheduled to be canceled
   std::shared_ptr<WorkerProgressThread> _progressThread{nullptr};  ///< The progress thread object
   std::thread::id _progressThreadId{};                             ///< The progress thread ID
   std::function<void(void*)> _progressThreadStartCallback{
@@ -601,7 +601,7 @@ class Worker : public Component {
    *
    * @param[in] inflight requests object that implements the `cancelAll()` method.
    */
-  void scheduleRequestCancel(std::shared_ptr<InflightRequests> inflightRequests);
+  void scheduleRequestCancel(InflightRequestsMapPtrPair inflightRequests);
 
   /**
    * @brief Remove reference to request from internal container.

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -601,7 +601,7 @@ class Worker : public Component {
    *
    * @param[in] inflight requests object that implements the `cancelAll()` method.
    */
-  void scheduleRequestCancel(InflightRequestsMapPtrPair inflightRequests);
+  void scheduleRequestCancel(TrackedRequestsPtr trackedRequests);
 
   /**
    * @brief Remove reference to request from internal container.

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -275,7 +275,7 @@ size_t Endpoint::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
 
   if (std::this_thread::get_id() == worker->getProgressThreadId()) {
     canceled = _inflightRequests->cancelAll();
-    for (uint64_t i = 0; i < maxAttempts && _inflightRequests->getCancelingCount() > 0; ++i)
+    for (uint64_t i = 0; i < maxAttempts && _inflightRequests->getCancelingSize() > 0; ++i)
       worker->progress();
   } else if (worker->isProgressThreadRunning()) {
     bool cancelSuccess = false;
@@ -289,7 +289,7 @@ size_t Endpoint::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
 
       utils::CallbackNotifier callbackNotifierPost{};
       worker->registerGenericPost([this, &callbackNotifierPost, &cancelSuccess]() {
-        cancelSuccess = _inflightRequests->getCancelingCount() == 0;
+        cancelSuccess = _inflightRequests->getCancelingSize() == 0;
         callbackNotifierPost.set();
       });
       if (!callbackNotifierPost.wait(period)) continue;

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -258,7 +258,7 @@ std::shared_ptr<Request> Endpoint::registerInflightRequest(std::shared_ptr<Reque
    * for cancelation, including the present one.
    */
   if (_callbackData->status != UCS_OK)
-    _callbackData->worker->scheduleRequestCancel(_inflightRequests);
+    _callbackData->worker->scheduleRequestCancel(_inflightRequests->release());
 
   return request;
 }
@@ -404,7 +404,7 @@ void Endpoint::errorCallback(void* arg, ucp_ep_h ep, ucs_status_t status)
 {
   ErrorCallbackData* data = reinterpret_cast<ErrorCallbackData*>(arg);
   data->status            = status;
-  data->worker->scheduleRequestCancel(data->inflightRequests);
+  data->worker->scheduleRequestCancel(data->inflightRequests->release());
   if (data->closeCallback) {
     ucxx_debug("Calling user callback for endpoint %p", ep);
     data->closeCallback(data->closeCallbackArg);

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -93,16 +93,16 @@ size_t InflightRequests::dropCanceled()
   return removed;
 }
 
-size_t InflightRequests::getCancelingCount()
+size_t InflightRequests::getCancelingSize()
 {
   dropCanceled();
-  size_t cancelingCount = 0;
+  size_t cancelingSize = 0;
   {
     std::scoped_lock lock{_cancelMutex};
-    cancelingCount = _trackedRequests->_canceling->size();
+    cancelingSize = _trackedRequests->_canceling->size();
   }
 
-  return cancelingCount;
+  return cancelingSize;
 }
 
 size_t InflightRequests::cancelAll()

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -12,24 +12,24 @@ namespace ucxx {
 
 InflightRequests::~InflightRequests() { cancelAll(); }
 
-size_t InflightRequests::size() { return _inflightRequests->size(); }
+size_t InflightRequests::size() { return _trackedRequests->_inflight->size(); }
 
 void InflightRequests::insert(std::shared_ptr<Request> request)
 {
   std::lock_guard<std::mutex> lock(_mutex);
 
-  _inflightRequests->insert({request.get(), request});
+  _trackedRequests->_inflight->insert({request.get(), request});
 }
 
-void InflightRequests::merge(InflightRequestsMapPtrPair inflightRequestsMapPtrPair)
+void InflightRequests::merge(TrackedRequestsPtr trackedRequests)
 {
   {
     std::lock_guard<std::mutex> lock(_mutex);
-    _inflightRequests->merge(*(inflightRequestsMapPtrPair.first));
+    _trackedRequests->_inflight->merge(*(trackedRequests->_inflight));
   }
   {
     std::lock_guard<std::mutex> lock(_cancelMutex);
-    _cancelingRequests->merge(*(inflightRequestsMapPtrPair.second));
+    _trackedRequests->_canceling->merge(*(trackedRequests->_canceling));
   }
 }
 
@@ -51,19 +51,19 @@ void InflightRequests::remove(const Request* const request)
     if (result == 0) {
       return;
     } else if (result == -1) {
-      auto search = _inflightRequests->find(request);
+      auto search = _trackedRequests->_inflight->find(request);
       decltype(search->second) tmpRequest;
-      if (search != _inflightRequests->end()) {
+      if (search != _trackedRequests->_inflight->end()) {
         /**
          * If this is the last request to hold `std::shared_ptr<ucxx::Endpoint>` erasing it
          * may cause the `ucxx::Endpoint`s destructor and subsequently the `close()` method
          * to be called which will in turn call `cancelAll()` and attempt to take the
          * mutexes. For this reason we should make a temporary copy of the request being
-         * erased from `_inflightRequests` to allow unlocking the mutexes and only then
+         * erased from `_trackedRequests->_inflight` to allow unlocking the mutexes and only then
          * destroy the object upon this method's return.
          */
         tmpRequest = search->second;
-        _inflightRequests->erase(search);
+        _trackedRequests->_inflight->erase(search);
       }
       _cancelMutex.unlock();
       _mutex.unlock();
@@ -78,10 +78,11 @@ size_t InflightRequests::dropCanceled()
 
   {
     std::scoped_lock lock{_cancelMutex};
-    for (auto it = _cancelingRequests->begin(); it != _cancelingRequests->end();) {
+    for (auto it = _trackedRequests->_canceling->begin();
+         it != _trackedRequests->_canceling->end();) {
       auto request = it->second;
       if (request != nullptr && request->getStatus() != UCS_INPROGRESS) {
-        it = _cancelingRequests->erase(it);
+        it = _trackedRequests->_canceling->erase(it);
         ++removed;
       } else {
         ++it;
@@ -98,7 +99,7 @@ size_t InflightRequests::getCancelingCount()
   size_t cancelingCount = 0;
   {
     std::scoped_lock lock{_cancelMutex};
-    cancelingCount = _cancelingRequests->size();
+    cancelingCount = _trackedRequests->_canceling->size();
   }
 
   return cancelingCount;
@@ -106,17 +107,17 @@ size_t InflightRequests::getCancelingCount()
 
 size_t InflightRequests::cancelAll()
 {
-  decltype(_inflightRequests) toCancel;
+  decltype(_trackedRequests->_inflight) toCancel;
   size_t total;
   {
     std::scoped_lock lock{_cancelMutex, _mutex};
-    total = _inflightRequests->size();
+    total = _trackedRequests->_inflight->size();
 
     // Fast path when no requests have been registered or the map has been
     // previously released.
     if (total == 0) return 0;
 
-    toCancel = std::exchange(_inflightRequests, std::make_unique<InflightRequestsMap>());
+    toCancel = std::exchange(_trackedRequests->_inflight, std::make_unique<InflightRequestsMap>());
   }
 
   ucxx_debug("Canceling %lu requests", total);
@@ -128,19 +129,18 @@ size_t InflightRequests::cancelAll()
 
   {
     std::scoped_lock lock{_cancelMutex, _mutex};
-    _cancelingRequests->merge(*toCancel);
+    _trackedRequests->_canceling->merge(*toCancel);
   }
   dropCanceled();
 
   return total;
 }
 
-InflightRequestsMapPtrPair InflightRequests::release()
+TrackedRequestsPtr InflightRequests::release()
 {
   std::scoped_lock lock{_cancelMutex, _mutex};
 
-  return {std::exchange(_inflightRequests, std::make_unique<InflightRequestsMap>()),
-          std::exchange(_cancelingRequests, std::make_unique<InflightRequestsMap>())};
+  return std::exchange(_trackedRequests, std::make_unique<TrackedRequests>());
 }
 
 }  // namespace ucxx

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -448,14 +448,13 @@ size_t Worker::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
   return canceled;
 }
 
-void Worker::scheduleRequestCancel(InflightRequestsMapPtrPair inflightRequestsMapPtrPair)
+void Worker::scheduleRequestCancel(TrackedRequestsPtr trackedRequests)
 {
   {
     std::lock_guard<std::mutex> lock(_inflightRequestsMutex);
-    ucxx_debug(
-      "Scheduling cancelation of %lu requests",
-      inflightRequestsMapPtrPair.first->size() + inflightRequestsMapPtrPair.second->size());
-    _inflightRequestsToCancel->merge(std::move(inflightRequestsMapPtrPair));
+    ucxx_debug("Scheduling cancelation of %lu requests",
+               trackedRequests->_inflight->size() + trackedRequests->_canceling->size());
+    _inflightRequestsToCancel->merge(std::move(trackedRequests));
   }
 }
 

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -411,7 +411,7 @@ size_t Worker::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
 
   if (std::this_thread::get_id() == getProgressThreadId()) {
     canceled = inflightRequestsToCancel->cancelAll();
-    for (uint64_t i = 0; i < maxAttempts && inflightRequestsToCancel->getCancelingCount() > 0; ++i)
+    for (uint64_t i = 0; i < maxAttempts && inflightRequestsToCancel->getCancelingSize() > 0; ++i)
       progressPending();
   } else if (isProgressThreadRunning()) {
     bool cancelSuccess = false;
@@ -426,7 +426,7 @@ size_t Worker::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
       utils::CallbackNotifier callbackNotifierPost{};
       registerGenericPost(
         [this, &callbackNotifierPost, &inflightRequestsToCancel, &cancelSuccess]() {
-          cancelSuccess = inflightRequestsToCancel->getCancelingCount() == 0;
+          cancelSuccess = inflightRequestsToCancel->getCancelingSize() == 0;
           callbackNotifierPost.set();
         });
       if (!callbackNotifierPost.wait(period)) continue;
@@ -440,7 +440,7 @@ size_t Worker::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
     canceled = inflightRequestsToCancel->cancelAll();
   }
 
-  if (inflightRequestsToCancel->getCancelingCount() > 0) {
+  if (inflightRequestsToCancel->getCancelingSize() > 0) {
     std::lock_guard<std::mutex> lock(_inflightRequestsMutex);
     _inflightRequestsToCancel->merge(inflightRequestsToCancel->release());
   }

--- a/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
@@ -398,10 +398,6 @@ async def test_ucxx_protocol(ucxx_loop, cleanup, port):
 
 
 @gen_test()
-@pytest.mark.skipif(
-    int(os.environ.get("UCXPY_ENABLE_PYTHON_FUTURE", "1")) != 0,
-    reason="Segfaults when Python futures are enabled",
-)
 async def test_ucxx_unreachable(
     ucxx_loop,
 ):

--- a/python/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/_lib/libucxx.pyx
@@ -691,6 +691,7 @@ cdef class UCXRequest():
 
     def __dealloc__(self):
         with nogil:
+            self._request.get().cancel()
             self._request.reset()
 
     def is_completed(self):

--- a/python/ucxx/_lib/ucxx_api.pxd
+++ b/python/ucxx/_lib/ucxx_api.pxd
@@ -327,6 +327,7 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
         void checkError() except +raise_py_error
         void* getFuture() except +raise_py_error
         shared_ptr[Buffer] getRecvBuffer() except +raise_py_error
+        void cancel()
 
 
 cdef extern from "<ucxx/request_tag_multi.h>" namespace "ucxx" nogil:


### PR DESCRIPTION
Calling `InflightRequests::cancelAll()` does not guarantee the requests to be canceled immediately, just like any other request we must check their status before releasing the `ucxx::Request` object. To prevent the user from releasing a request that has not yet completed and may still call the completion callback we must make sure we still keep a reference
to it until its status is set. With this change we now ensure both `ucxx::Endpoint` and `ucxx::Worker` will only release references after those requests that have issued cancelation complete.

It is also important that all requests have a valid status before destroying the object, thus we should cancel a request if all references to the Cython `UCXRequest` object have been dropped but the request has not completed yet.

Additionally use `std::unique_ptr<InflightRequests>` in `ucxx::Worker` and reenable `test_ucxx_unreachable`.