### PR TITLE
Remove xfail mark from cuDF empty dataframe test

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
@@ -180,12 +180,7 @@ async def test_ucxx_deserialize(ucxx_loop):
     [
         lambda cudf: cudf.Series([1, 2, 3]),
         lambda cudf: cudf.Series([], dtype=object),
-        pytest.param(
-            lambda cudf: cudf.DataFrame([], dtype=object),
-            marks=pytest.mark.xfail(
-                reason="https://github.com/rapidsai/ucxx/issues/149"
-            ),
-        ),
+        lambda cudf: cudf.DataFrame([], dtype=object),
         lambda cudf: cudf.DataFrame([1]).head(0),
         lambda cudf: cudf.DataFrame([1.0]).head(0),
         lambda cudf: cudf.DataFrame({"a": []}),


### PR DESCRIPTION
Empty cuDF dataframe serialization was fixed in https://github.com/rapidsai/cudf/pull/14705 .

Closes https://github.com/rapidsai/ucxx/issues/149 .