### PR TITLE
Improve log messages

### DIFF
--- a/cpp/include/ucxx/request.h
+++ b/cpp/include/ucxx/request.h
@@ -17,8 +17,13 @@
 #include <ucxx/request_data.h>
 #include <ucxx/typedefs.h>
 
-#define ucxx_trace_req_f(_owner, _req, _name, _message, ...) \
-  ucxx_trace_req("%s, req %p, op %s: " _message, (_owner), (_req), (_name), ##__VA_ARGS__)
+#define ucxx_trace_req_f(_owner, _req, _handle, _name, _message, ...)          \
+  ucxx_trace_req("ucxx::Request: %p on %s, UCP handle: %p, op: %s, " _message, \
+                 (_req),                                                       \
+                 (_owner),                                                     \
+                 (_handle),                                                    \
+                 (_name),                                                      \
+                 ##__VA_ARGS__)
 
 namespace ucxx {
 

--- a/cpp/python/src/future.cpp
+++ b/cpp/python/src/future.cpp
@@ -60,13 +60,18 @@ static PyObject* get_asyncio_future_object()
   }
 
   asyncio_module = PyImport_Import(asyncio_str);
-  if (PyErr_Occurred()) ucxx_trace_req("Python error here");
+  if (PyErr_Occurred()) {
+    ucxx_trace_req("Error importing asyncio");
+    PyErr_Print();
+  }
   if (PyErr_Occurred()) PyErr_Print();
   if (asyncio_module == NULL) goto finish;
 
   asyncio_future_object = PyObject_GetAttr(asyncio_module, future_str);
-  if (PyErr_Occurred()) ucxx_trace_req("Python error here");
-  if (PyErr_Occurred()) PyErr_Print();
+  if (PyErr_Occurred()) {
+    ucxx_trace_req("Error getting asyncio.Future method");
+    PyErr_Print();
+  }
   Py_DECREF(asyncio_module);
   if (asyncio_future_object == NULL) { goto finish; }
 
@@ -98,8 +103,10 @@ PyObject* create_python_future()
   }
 
   result = PyObject_CallFunctionObjArgs(future_object, NULL);
-  if (PyErr_Occurred()) ucxx_trace_req("Python error here");
-  if (PyErr_Occurred()) PyErr_Print();
+  if (PyErr_Occurred()) {
+    ucxx_trace_req("Error creating asyncio.Future");
+    PyErr_Print();
+  }
 
 finish:
   PyGILState_Release(state);
@@ -113,8 +120,10 @@ static PyCFunction get_future_method(const char* method_name)
   PyGILState_STATE state = PyGILState_Ensure();
 
   PyObject* future_object = get_asyncio_future_object();
-  if (PyErr_Occurred()) ucxx_trace_req("Python error here");
-  if (PyErr_Occurred()) PyErr_Print();
+  if (PyErr_Occurred()) {
+    ucxx_trace_req("Python error getting asyncio.Future method object");
+    PyErr_Print();
+  }
   PyMethodDef* m = reinterpret_cast<PyTypeObject*>(future_object)->tp_methods;
 
   for (; m != NULL; ++m) {
@@ -139,8 +148,10 @@ PyObject* future_set_result(PyObject* future, PyObject* value)
 
   PyCFunction f = get_future_method("set_result");
   result        = f(future, value);
-  if (PyErr_Occurred()) ucxx_trace_req("Python error here");
-  if (PyErr_Occurred()) PyErr_Print();
+  if (PyErr_Occurred()) {
+    ucxx_trace_req("Error calling `set_result()` from `asyncio.Future` object");
+    PyErr_Print();
+  }
 
   PyGILState_Release(state);
 
@@ -192,7 +203,7 @@ PyObject* create_python_future_with_event_loop(PyObject* event_loop)
 
   result = PyObject_CallMethodObjArgs(event_loop, create_future_str, NULL);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error calling event loop `create_future`.");
+    ucxx_trace_req("Error calling `create_future` from event loop object");
     PyErr_Print();
   }
 
@@ -215,7 +226,7 @@ PyObject* future_set_result_with_event_loop(PyObject* event_loop, PyObject* futu
 
   set_result_callable = PyObject_GetAttr(future, set_result_str);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error getting future `set_result` method.");
+    ucxx_trace_req("Error getting `set_result` method from `asyncio.Future` object");
     PyErr_Print();
     goto finish;
   }
@@ -230,7 +241,8 @@ PyObject* future_set_result_with_event_loop(PyObject* event_loop, PyObject* futu
   result = PyObject_CallMethodObjArgs(
     event_loop, call_soon_threadsafe_str, set_result_callable, value, NULL);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error calling `call_soon_threadsafe` to set future result.");
+    ucxx_trace_req(
+      "Error calling `call_soon_threadsafe` from event loop object to set future result");
     PyErr_Print();
   }
 
@@ -260,7 +272,7 @@ PyObject* future_set_exception_with_event_loop(PyObject* event_loop,
 
   set_exception_callable = PyObject_GetAttr(future, set_exception_str);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error getting future `set_exception` method.");
+    ucxx_trace_req("Error getting `set_exception` method from `asyncio.Future` object");
     PyErr_Print();
     goto finish;
   }
@@ -282,7 +294,8 @@ PyObject* future_set_exception_with_event_loop(PyObject* event_loop,
   result = PyObject_CallMethodObjArgs(
     event_loop, call_soon_threadsafe_str, set_exception_callable, formed_exception, NULL);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error calling `call_soon_threadsafe` to set future exception.");
+    ucxx_trace_req(
+      "Error calling `call_soon_threadsafe` from event loop object to set future exception");
     PyErr_Print();
   }
   goto finish;

--- a/cpp/python/src/future.cpp
+++ b/cpp/python/src/future.cpp
@@ -61,7 +61,7 @@ static PyObject* get_asyncio_future_object()
 
   asyncio_module = PyImport_Import(asyncio_str);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error importing asyncio");
+    ucxx_trace_req("ucxx::python::%s, error importing asyncio", __func__);
     PyErr_Print();
   }
   if (PyErr_Occurred()) PyErr_Print();
@@ -69,7 +69,7 @@ static PyObject* get_asyncio_future_object()
 
   asyncio_future_object = PyObject_GetAttr(asyncio_module, future_str);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error getting asyncio.Future method");
+    ucxx_trace_req("ucxx::python::%s, error getting asyncio.Future method", __func__);
     PyErr_Print();
   }
   Py_DECREF(asyncio_module);
@@ -104,7 +104,7 @@ PyObject* create_python_future()
 
   result = PyObject_CallFunctionObjArgs(future_object, NULL);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error creating asyncio.Future");
+    ucxx_trace_req("ucxx::python::%s, error creating asyncio.Future", __func__);
     PyErr_Print();
   }
 
@@ -121,7 +121,7 @@ static PyCFunction get_future_method(const char* method_name)
 
   PyObject* future_object = get_asyncio_future_object();
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Python error getting asyncio.Future method object");
+    ucxx_trace_req("ucxx::python::%s, error getting asyncio.Future method object", __func__);
     PyErr_Print();
   }
   PyMethodDef* m = reinterpret_cast<PyTypeObject*>(future_object)->tp_methods;
@@ -149,7 +149,8 @@ PyObject* future_set_result(PyObject* future, PyObject* value)
   PyCFunction f = get_future_method("set_result");
   result        = f(future, value);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error calling `set_result()` from `asyncio.Future` object");
+    ucxx_trace_req("ucxx::python::%s, error calling `set_result()` from `asyncio.Future` object",
+                   __func__);
     PyErr_Print();
   }
 
@@ -203,7 +204,8 @@ PyObject* create_python_future_with_event_loop(PyObject* event_loop)
 
   result = PyObject_CallMethodObjArgs(event_loop, create_future_str, NULL);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error calling `create_future` from event loop object");
+    ucxx_trace_req("ucxx::python::%s, error calling `create_future` from event loop object",
+                   __func__);
     PyErr_Print();
   }
 
@@ -226,7 +228,8 @@ PyObject* future_set_result_with_event_loop(PyObject* event_loop, PyObject* futu
 
   set_result_callable = PyObject_GetAttr(future, set_result_str);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error getting `set_result` method from `asyncio.Future` object");
+    ucxx_trace_req(
+      "ucxx::python::%s, error getting `set_result` method from `asyncio.Future` object", __func__);
     PyErr_Print();
     goto finish;
   }
@@ -242,7 +245,9 @@ PyObject* future_set_result_with_event_loop(PyObject* event_loop, PyObject* futu
     event_loop, call_soon_threadsafe_str, set_result_callable, value, NULL);
   if (PyErr_Occurred()) {
     ucxx_trace_req(
-      "Error calling `call_soon_threadsafe` from event loop object to set future result");
+      "ucxx::python::%s, error calling `call_soon_threadsafe` from event loop object to set future "
+      "result",
+      __func__);
     PyErr_Print();
   }
 
@@ -272,7 +277,9 @@ PyObject* future_set_exception_with_event_loop(PyObject* event_loop,
 
   set_exception_callable = PyObject_GetAttr(future, set_exception_str);
   if (PyErr_Occurred()) {
-    ucxx_trace_req("Error getting `set_exception` method from `asyncio.Future` object");
+    ucxx_trace_req(
+      "ucxx::python::%s, Error getting `set_exception` method from `asyncio.Future` object",
+      __func__);
     PyErr_Print();
     goto finish;
   }
@@ -295,7 +302,9 @@ PyObject* future_set_exception_with_event_loop(PyObject* event_loop,
     event_loop, call_soon_threadsafe_str, set_exception_callable, formed_exception, NULL);
   if (PyErr_Occurred()) {
     ucxx_trace_req(
-      "Error calling `call_soon_threadsafe` from event loop object to set future exception");
+      "ucxx::python::%s, Error calling `call_soon_threadsafe` from event loop object to set future "
+      "exception",
+      __func__);
     PyErr_Print();
   }
   goto finish;

--- a/cpp/python/src/notifier.cpp
+++ b/cpp/python/src/notifier.cpp
@@ -33,7 +33,7 @@ void Notifier::scheduleFutureNotify(std::shared_ptr<::ucxx::Future> future, ucs_
     _notifierThreadFutureStatusReady = true;
   }
   _notifierThreadConditionVariable.notify_one();
-  ucxx_trace_req("ucxx::python::Notifier::scheduleFutureNotify, notified: future: %p, handle: %p",
+  ucxx_trace_req("ucxx::python::Notifier::scheduleFutureNotify, notified future: %p, handle: %p",
                  future.get(),
                  future->getHandle());
 }

--- a/cpp/python/src/notifier.cpp
+++ b/cpp/python/src/notifier.cpp
@@ -23,7 +23,8 @@ Notifier::~Notifier() {}
 
 void Notifier::scheduleFutureNotify(std::shared_ptr<::ucxx::Future> future, ucs_status_t status)
 {
-  ucxx_trace_req("ucxx::python::Notifier::scheduleFutureNotify, future: %p, handle: %p",
+  ucxx_trace_req("ucxx::python::Notifier::%s, future: %p, handle: %p",
+                 __func__,
                  future.get(),
                  future->getHandle());
   auto p = std::make_pair(future, status);
@@ -33,7 +34,8 @@ void Notifier::scheduleFutureNotify(std::shared_ptr<::ucxx::Future> future, ucs_
     _notifierThreadFutureStatusReady = true;
   }
   _notifierThreadConditionVariable.notify_one();
-  ucxx_trace_req("ucxx::python::Notifier::scheduleFutureNotify, notified future: %p, handle: %p",
+  ucxx_trace_req("ucxx::python::Notifier::%s, notified future: %p, handle: %p",
+                 __func__,
                  future.get(),
                  future->getHandle());
 }
@@ -46,12 +48,13 @@ void Notifier::runRequestNotifier()
     notifierThreadFutureStatus = std::move(_notifierThreadFutureStatus);
   }
 
-  ucxx_trace_req("ucxx::python::Notifier::runRequestNotifier, notifying %lu",
-                 notifierThreadFutureStatus.size());
+  ucxx_trace_req(
+    "ucxx::python::Notifier::%s, notifying %lu", __func__, notifierThreadFutureStatus.size());
   for (auto& p : notifierThreadFutureStatus) {
     // r->future_set_result;
     p.first->set(p.second);
-    ucxx_trace_req("ucxx::python::Notifier::runRequestNotifier, notified future: %p, handle: %p",
+    ucxx_trace_req("ucxx::python::Notifier::%s, notified future: %p, handle: %p",
+                   __func__,
                    p.first.get(),
                    p.first->getHandle());
   }
@@ -59,7 +62,7 @@ void Notifier::runRequestNotifier()
 
 RequestNotifierWaitState Notifier::waitRequestNotifierWithoutTimeout()
 {
-  ucxx_trace_req("ucxx::python::Notifier::waitRequestNotifierWithoutTimeout");
+  ucxx_trace_req("ucxx::python::Notifier::%s", __func__);
 
   std::unique_lock<std::mutex> lock(_notifierThreadMutex);
   _notifierThreadConditionVariable.wait(lock, [this] {
@@ -70,8 +73,7 @@ RequestNotifierWaitState Notifier::waitRequestNotifierWithoutTimeout()
   auto state = _notifierThreadFutureStatusReady ? RequestNotifierWaitState::Ready
                                                 : RequestNotifierWaitState::Shutdown;
 
-  ucxx_trace_req("ucxx::python::Notifier::waitRequestNotifier, unlock: %d",
-                 static_cast<int>(state));
+  ucxx_trace_req("ucxx::python::Notifier::%s, unlock: %d", __func__, static_cast<int>(state));
   _notifierThreadFutureStatusReady = false;
 
   return state;
@@ -79,7 +81,7 @@ RequestNotifierWaitState Notifier::waitRequestNotifierWithoutTimeout()
 
 RequestNotifierWaitState Notifier::waitRequestNotifierWithTimeout(uint64_t period)
 {
-  ucxx_trace_req("ucxx::python::Notifier::waitRequestNotifierWithTimeout");
+  ucxx_trace_req("ucxx::python::Notifier::%s", __func__);
 
   std::unique_lock<std::mutex> lock(_notifierThreadMutex);
   bool condition = _notifierThreadConditionVariable.wait_for(
@@ -92,8 +94,7 @@ RequestNotifierWaitState Notifier::waitRequestNotifierWithTimeout(uint64_t perio
                                                               : RequestNotifierWaitState::Shutdown)
                           : RequestNotifierWaitState::Timeout);
 
-  ucxx_trace_req("ucxx::python::Notifier::waitRequestNotifier, unlock: %d",
-                 static_cast<int>(state));
+  ucxx_trace_req("ucxx::python::Notifier::%s, unlock: %d", __func__, static_cast<int>(state));
   if (state == RequestNotifierWaitState::Ready) _notifierThreadFutureStatusReady = false;
 
   return state;
@@ -101,7 +102,7 @@ RequestNotifierWaitState Notifier::waitRequestNotifierWithTimeout(uint64_t perio
 
 RequestNotifierWaitState Notifier::waitRequestNotifier(uint64_t period)
 {
-  ucxx_trace_req("ucxx::python::Notifier::waitRequestNotifier");
+  ucxx_trace_req("ucxx::python::Notifier::%s", __func__);
 
   if (_notifierThreadFutureStatusFinished == RequestNotifierThreadState::Stopping) {
     _notifierThreadFutureStatusFinished = RequestNotifierThreadState::Running;

--- a/cpp/python/src/notifier.cpp
+++ b/cpp/python/src/notifier.cpp
@@ -23,8 +23,9 @@ Notifier::~Notifier() {}
 
 void Notifier::scheduleFutureNotify(std::shared_ptr<::ucxx::Future> future, ucs_status_t status)
 {
-  ucxx_trace_req(
-    "Notifier::scheduleFutureNotify(): future: %p, handle: %p", future.get(), future->getHandle());
+  ucxx_trace_req("ucxx::python::Notifier::scheduleFutureNotify, future: %p, handle: %p",
+                 future.get(),
+                 future->getHandle());
   auto p = std::make_pair(future, status);
   {
     std::lock_guard<std::mutex> lock(_notifierThreadMutex);
@@ -32,7 +33,7 @@ void Notifier::scheduleFutureNotify(std::shared_ptr<::ucxx::Future> future, ucs_
     _notifierThreadFutureStatusReady = true;
   }
   _notifierThreadConditionVariable.notify_one();
-  ucxx_trace_req("Notifier::scheduleFutureNotify() notified: future: %p, handle: %p",
+  ucxx_trace_req("ucxx::python::Notifier::scheduleFutureNotify, notified: future: %p, handle: %p",
                  future.get(),
                  future->getHandle());
 }
@@ -45,11 +46,12 @@ void Notifier::runRequestNotifier()
     notifierThreadFutureStatus = std::move(_notifierThreadFutureStatus);
   }
 
-  ucxx_trace_req("Notifier::runRequestNotifier() notifying %lu", notifierThreadFutureStatus.size());
+  ucxx_trace_req("ucxx::python::Notifier::runRequestNotifier, notifying %lu",
+                 notifierThreadFutureStatus.size());
   for (auto& p : notifierThreadFutureStatus) {
     // r->future_set_result;
     p.first->set(p.second);
-    ucxx_trace_req("Notifier::runRequestNotifier() notified future: %p, handle: %p",
+    ucxx_trace_req("ucxx::python::Notifier::runRequestNotifier, notified future: %p, handle: %p",
                    p.first.get(),
                    p.first->getHandle());
   }
@@ -57,7 +59,7 @@ void Notifier::runRequestNotifier()
 
 RequestNotifierWaitState Notifier::waitRequestNotifierWithoutTimeout()
 {
-  ucxx_trace_req("Notifier::waitRequestNotifierWithoutTimeout()");
+  ucxx_trace_req("ucxx::python::Notifier::waitRequestNotifierWithoutTimeout");
 
   std::unique_lock<std::mutex> lock(_notifierThreadMutex);
   _notifierThreadConditionVariable.wait(lock, [this] {
@@ -68,7 +70,8 @@ RequestNotifierWaitState Notifier::waitRequestNotifierWithoutTimeout()
   auto state = _notifierThreadFutureStatusReady ? RequestNotifierWaitState::Ready
                                                 : RequestNotifierWaitState::Shutdown;
 
-  ucxx_trace_req("Notifier::waitRequestNotifier() unlock: %d", static_cast<int>(state));
+  ucxx_trace_req("ucxx::python::Notifier::waitRequestNotifier, unlock: %d",
+                 static_cast<int>(state));
   _notifierThreadFutureStatusReady = false;
 
   return state;
@@ -76,7 +79,7 @@ RequestNotifierWaitState Notifier::waitRequestNotifierWithoutTimeout()
 
 RequestNotifierWaitState Notifier::waitRequestNotifierWithTimeout(uint64_t period)
 {
-  ucxx_trace_req("Notifier::waitRequestNotifierWithTimeout()");
+  ucxx_trace_req("ucxx::python::Notifier::waitRequestNotifierWithTimeout");
 
   std::unique_lock<std::mutex> lock(_notifierThreadMutex);
   bool condition = _notifierThreadConditionVariable.wait_for(
@@ -89,7 +92,8 @@ RequestNotifierWaitState Notifier::waitRequestNotifierWithTimeout(uint64_t perio
                                                               : RequestNotifierWaitState::Shutdown)
                           : RequestNotifierWaitState::Timeout);
 
-  ucxx_trace_req("Notifier::waitRequestNotifier() unlock: %d", static_cast<int>(state));
+  ucxx_trace_req("ucxx::python::Notifier::waitRequestNotifier, unlock: %d",
+                 static_cast<int>(state));
   if (state == RequestNotifierWaitState::Ready) _notifierThreadFutureStatusReady = false;
 
   return state;
@@ -97,7 +101,7 @@ RequestNotifierWaitState Notifier::waitRequestNotifierWithTimeout(uint64_t perio
 
 RequestNotifierWaitState Notifier::waitRequestNotifier(uint64_t period)
 {
-  ucxx_trace_req("Notifier::waitRequestNotifier()");
+  ucxx_trace_req("ucxx::python::Notifier::waitRequestNotifier");
 
   if (_notifierThreadFutureStatusFinished == RequestNotifierThreadState::Stopping) {
     _notifierThreadFutureStatusFinished = RequestNotifierThreadState::Running;

--- a/cpp/python/src/python_future.cpp
+++ b/cpp/python/src/python_future.cpp
@@ -52,8 +52,10 @@ void Future::set(ucs_status_t status)
 {
   if (_handle == nullptr) throw std::runtime_error("Invalid object or already released");
 
-  ucxx_trace_req(
-    "Future::set() this: %p, _handle: %p, status: %s", this, _handle, ucs_status_string(status));
+  ucxx_trace_req("ucxx::python::Future::set, Future: %p, _handle: %p, status: %s",
+                 this,
+                 _handle,
+                 ucs_status_string(status));
   if (status == UCS_OK) {
     if (_asyncioEventLoop == nullptr)
       future_set_result(_handle, Py_True);
@@ -77,11 +79,12 @@ void Future::notify(ucs_status_t status)
 
   auto s = shared_from_this();
 
-  ucxx_trace_req("Future::notify() this: %p, shared.get(): %p, handle: %p, notifier: %p",
-                 this,
-                 s.get(),
-                 _handle,
-                 _notifier.get());
+  ucxx_trace_req(
+    "ucxx::python::Future::notify, Future: %p, shared.get(): %p, handle: %p, notifier: %p",
+    this,
+    s.get(),
+    _handle,
+    _notifier.get());
   _notifier->scheduleFutureNotify(shared_from_this(), status);
 }
 

--- a/cpp/python/src/python_future.cpp
+++ b/cpp/python/src/python_future.cpp
@@ -52,7 +52,8 @@ void Future::set(ucs_status_t status)
 {
   if (_handle == nullptr) throw std::runtime_error("Invalid object or already released");
 
-  ucxx_trace_req("ucxx::python::Future::set, Future: %p, _handle: %p, status: %s",
+  ucxx_trace_req("ucxx::python::Future::%s, Future: %p, _handle: %p, status: %s",
+                 __func__,
                  this,
                  _handle,
                  ucs_status_string(status));
@@ -79,12 +80,12 @@ void Future::notify(ucs_status_t status)
 
   auto s = shared_from_this();
 
-  ucxx_trace_req(
-    "ucxx::python::Future::notify, Future: %p, shared.get(): %p, handle: %p, notifier: %p",
-    this,
-    s.get(),
-    _handle,
-    _notifier.get());
+  ucxx_trace_req("ucxx::python::Future::%s, Future: %p, shared.get(): %p, handle: %p, notifier: %p",
+                 __func__,
+                 this,
+                 s.get(),
+                 _handle,
+                 _notifier.get());
   _notifier->scheduleFutureNotify(shared_from_this(), status);
 }
 

--- a/cpp/python/src/python_future_task_collector.cpp
+++ b/cpp/python/src/python_future_task_collector.cpp
@@ -34,7 +34,7 @@ void PythonFutureTaskCollector::collect()
     std::lock_guard<std::mutex> lock(_mutex);
     for (auto& handle : _toCollect)
       Py_XDECREF(handle);
-    ucxx_trace("PythonFutureTaskCollector::collect, collected %lu PythonFutureTasks",
+    ucxx_trace("ucxx::python::PythonFutureTaskCollector::collect, collected %lu PythonFutureTasks",
                _toCollect.size());
     _toCollect.clear();
   }

--- a/cpp/python/src/python_future_task_collector.cpp
+++ b/cpp/python/src/python_future_task_collector.cpp
@@ -34,7 +34,8 @@ void PythonFutureTaskCollector::collect()
     std::lock_guard<std::mutex> lock(_mutex);
     for (auto& handle : _toCollect)
       Py_XDECREF(handle);
-    ucxx_trace("Collected %lu PythonFutureTasks", _toCollect.size());
+    ucxx_trace("PythonFutureTaskCollector::collect, collected %lu PythonFutureTasks",
+               _toCollect.size());
     _toCollect.clear();
   }
 

--- a/cpp/python/src/python_future_task_collector.cpp
+++ b/cpp/python/src/python_future_task_collector.cpp
@@ -34,7 +34,8 @@ void PythonFutureTaskCollector::collect()
     std::lock_guard<std::mutex> lock(_mutex);
     for (auto& handle : _toCollect)
       Py_XDECREF(handle);
-    ucxx_trace("ucxx::python::PythonFutureTaskCollector::collect, collected %lu PythonFutureTasks",
+    ucxx_trace("ucxx::python::PythonFutureTaskCollector::%s, collected %lu PythonFutureTasks",
+               __func__,
                _toCollect.size());
     _toCollect.clear();
   }

--- a/cpp/python/src/worker.cpp
+++ b/cpp/python/src/worker.cpp
@@ -52,7 +52,8 @@ std::shared_ptr<::ucxx::Worker> createWorker(std::shared_ptr<Context> context,
 void Worker::populateFuturesPool()
 {
   if (_enableFuture) {
-    ucxx_trace_req("ucxx::python::Worker::populateFuturesPool, Worker: %p, populateFuturesPool: %p",
+    ucxx_trace_req("ucxx::python::Worker::%s, Worker: %p, populateFuturesPool: %p",
+                   __func__,
                    this,
                    shared_from_this().get());
     // If the pool goes under half expected size, fill it up again.

--- a/cpp/python/src/worker.cpp
+++ b/cpp/python/src/worker.cpp
@@ -52,7 +52,9 @@ std::shared_ptr<::ucxx::Worker> createWorker(std::shared_ptr<Context> context,
 void Worker::populateFuturesPool()
 {
   if (_enableFuture) {
-    ucxx_trace_req("populateFuturesPool: %p %p", this, shared_from_this().get());
+    ucxx_trace_req("ucxx::python::Worker::populateFuturesPool, Worker: %p, populateFuturesPool: %p",
+                   this,
+                   shared_from_this().get());
     // If the pool goes under half expected size, fill it up again.
     if (_futuresPool.size() < 50) {
       std::lock_guard<std::mutex> lock(_futuresPoolMutex);

--- a/cpp/src/buffer.cpp
+++ b/cpp/src/buffer.cpp
@@ -27,7 +27,7 @@ size_t Buffer::getSize() const noexcept { return _size; }
 
 HostBuffer::HostBuffer(const size_t size) : Buffer(BufferType::Host, size), _buffer{malloc(size)}
 {
-  ucxx_trace_data("HostBuffer(%lu), _buffer: %p", size, _buffer);
+  ucxx_trace_data("ucxx::HostBuffer created: %p, buffer: %p, size: %lu", this, _buffer, size);
 }
 
 HostBuffer::~HostBuffer()
@@ -37,7 +37,7 @@ HostBuffer::~HostBuffer()
 
 void* HostBuffer::release()
 {
-  ucxx_trace_data("HostBuffer::release(), _buffer: %p", _buffer);
+  ucxx_trace_data("ucxx::HostBuffer::release, HostBuffer: %p, buffer: %p", this, _buffer);
   if (!_buffer) throw std::runtime_error("Invalid object or already released");
 
   _bufferType = ucxx::BufferType::Invalid;
@@ -48,7 +48,7 @@ void* HostBuffer::release()
 
 void* HostBuffer::data()
 {
-  ucxx_trace_data("HostBuffer::data(), _buffer: %p", _buffer);
+  ucxx_trace_data("ucxx::HostBuffer::data, HostBuffer: %p, buffer: %p", this, _buffer);
   if (!_buffer) throw std::runtime_error("Invalid object or already released");
 
   return _buffer;
@@ -59,12 +59,12 @@ RMMBuffer::RMMBuffer(const size_t size)
   : Buffer(BufferType::RMM, size),
     _buffer{std::make_unique<rmm::device_buffer>(size, rmm::cuda_stream_default)}
 {
-  ucxx_trace_data("RMMBuffer(%lu), _buffer: %p", size, _buffer.get());
+  ucxx_trace_data("ucxx::RMMBuffer created: %p, buffer: %p, size: %lu", this, _buffer.get(), size);
 }
 
 std::unique_ptr<rmm::device_buffer> RMMBuffer::release()
 {
-  ucxx_trace_data("RMMBuffer::release(), _buffer: %p", _buffer.get());
+  ucxx_trace_data("ucxx::RMMBuffer::release, RMMBuffer: %p, _buffer: %p", this, _buffer.get());
   if (!_buffer) throw std::runtime_error("Invalid object or already released");
 
   _bufferType = ucxx::BufferType::Invalid;
@@ -75,7 +75,7 @@ std::unique_ptr<rmm::device_buffer> RMMBuffer::release()
 
 void* RMMBuffer::data()
 {
-  ucxx_trace_data("RMMBuffer::data(), _buffer: %p", _buffer.get());
+  ucxx_trace_data("ucxx::RMMBuffer::data, RMMBuffer: %p, buffer: %p", this, _buffer.get());
   if (!_buffer) throw std::runtime_error("Invalid object or already released");
 
   return _buffer->data();

--- a/cpp/src/buffer.cpp
+++ b/cpp/src/buffer.cpp
@@ -37,7 +37,7 @@ HostBuffer::~HostBuffer()
 
 void* HostBuffer::release()
 {
-  ucxx_trace_data("ucxx::HostBuffer::release, HostBuffer: %p, buffer: %p", this, _buffer);
+  ucxx_trace_data("ucxx::HostBuffer::%s, HostBuffer: %p, buffer: %p", __func__, this, _buffer);
   if (!_buffer) throw std::runtime_error("Invalid object or already released");
 
   _bufferType = ucxx::BufferType::Invalid;
@@ -48,7 +48,7 @@ void* HostBuffer::release()
 
 void* HostBuffer::data()
 {
-  ucxx_trace_data("ucxx::HostBuffer::data, HostBuffer: %p, buffer: %p", this, _buffer);
+  ucxx_trace_data("ucxx::HostBuffer::%s, HostBuffer: %p, buffer: %p", __func__, this, _buffer);
   if (!_buffer) throw std::runtime_error("Invalid object or already released");
 
   return _buffer;
@@ -64,7 +64,7 @@ RMMBuffer::RMMBuffer(const size_t size)
 
 std::unique_ptr<rmm::device_buffer> RMMBuffer::release()
 {
-  ucxx_trace_data("ucxx::RMMBuffer::release, RMMBuffer: %p, _buffer: %p", this, _buffer.get());
+  ucxx_trace_data("ucxx::RMMBuffer::%s, RMMBuffer: %p, _buffer: %p", __func__, this, _buffer.get());
   if (!_buffer) throw std::runtime_error("Invalid object or already released");
 
   _bufferType = ucxx::BufferType::Invalid;
@@ -75,7 +75,7 @@ std::unique_ptr<rmm::device_buffer> RMMBuffer::release()
 
 void* RMMBuffer::data()
 {
-  ucxx_trace_data("ucxx::RMMBuffer::data, RMMBuffer: %p, buffer: %p", this, _buffer.get());
+  ucxx_trace_data("ucxx::RMMBuffer::%s, RMMBuffer: %p, buffer: %p", __func__, this, _buffer.get());
   if (!_buffer) throw std::runtime_error("Invalid object or already released");
 
   return _buffer->data();

--- a/cpp/src/context.cpp
+++ b/cpp/src/context.cpp
@@ -23,7 +23,7 @@ Context::Context(const ConfigMap ucxConfig, const uint64_t featureFlags)
   ucp_params_t params = {.field_mask = UCP_PARAM_FIELD_FEATURES, .features = featureFlags};
 
   utils::ucsErrorThrow(ucp_init(&params, _config.getHandle(), &_handle));
-  ucxx_trace("Context created: %p, UCP handle: %p", this, _handle);
+  ucxx_trace("ucxx::Context created: %p, UCP handle: %p", this, _handle);
 
   ucp_context_attr_t attr = {.field_mask = UCP_ATTR_FIELD_MEMORY_TYPES};
   ucp_context_query(_handle, &attr);
@@ -60,7 +60,7 @@ Context::Context(const ConfigMap ucxConfig, const uint64_t featureFlags)
     }
   }
 
-  ucxx_info("UCP initiated using config: ");
+  ucxx_info("UCP initialized using config: ");
   for (const auto& kv : configMap)
     ucxx_info("  %s: %s", kv.first.c_str(), kv.second.c_str());
 }
@@ -73,7 +73,7 @@ std::shared_ptr<Context> createContext(const ConfigMap ucxConfig, const uint64_t
 Context::~Context()
 {
   if (_handle != nullptr) ucp_cleanup(_handle);
-  ucxx_trace("Context destroyed: %p, UCP handle: %p", this, _handle);
+  ucxx_trace("ucxx::Context destroyed: %p, UCP handle: %p", this, _handle);
 }
 
 ConfigMap Context::getConfig() { return _config.get(); }

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -194,7 +194,7 @@ void Endpoint::close(uint64_t period, uint64_t maxAttempts)
 
     if (!closeSuccess) {
       _callbackData->status = UCS_ERR_ENDPOINT_TIMEOUT;
-      ucxx_error("All attempts to close timed out on endpoint: %p, UCP handle: %p", this, _handle);
+      ucxx_debug("All attempts to close timed out on endpoint: %p, UCP handle: %p", this, _handle);
     }
   } else {
     status = ucp_ep_close_nb(_handle, closeMode);
@@ -295,7 +295,7 @@ size_t Endpoint::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
       if (!callbackNotifierPost.wait(period)) continue;
     }
     if (!cancelSuccess)
-      ucxx_error("All attempts to cancel inflight requests failed on endpoint: %p, UCP handle: %p",
+      ucxx_debug("All attempts to cancel inflight requests failed on endpoint: %p, UCP handle: %p",
                  this,
                  _handle);
   } else {

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -148,7 +148,8 @@ void Endpoint::close(uint64_t period, uint64_t maxAttempts)
   if (_handle == nullptr) return;
 
   size_t canceled = cancelInflightRequests(3000000000 /* 3s */, 3);
-  ucxx_debug("ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, canceled %lu requests",
+  ucxx_debug("ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, canceled %lu requests",
+             __func__,
              this,
              _handle,
              canceled);
@@ -183,8 +184,9 @@ void Endpoint::close(uint64_t period, uint64_t maxAttempts)
             _callbackData->status = UCS_PTR_STATUS(s);
             if (UCS_PTR_STATUS(status) != UCS_OK) {
               ucxx_error(
-                "ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, error while closing "
+                "ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, error while closing "
                 "endpoint: %s",
+                __func__,
                 this,
                 _handle,
                 ucs_status_string(UCS_PTR_STATUS(status)));
@@ -202,7 +204,8 @@ void Endpoint::close(uint64_t period, uint64_t maxAttempts)
     if (!closeSuccess) {
       _callbackData->status = UCS_ERR_ENDPOINT_TIMEOUT;
       ucxx_debug(
-        "ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, all attempts to close timed out",
+        "ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, all attempts to close timed out",
+        __func__,
         this,
         _handle);
     }
@@ -216,16 +219,18 @@ void Endpoint::close(uint64_t period, uint64_t maxAttempts)
       _callbackData->status = s;
     } else if (UCS_PTR_STATUS(status) != UCS_OK) {
       ucxx_error(
-        "ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, Error while closing endpoint: %s",
+        "ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, Error while closing endpoint: %s",
+        __func__,
         this,
         _handle,
         ucs_status_string(UCS_PTR_STATUS(status)));
     }
   }
-  ucxx_trace("ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, closed", this, _handle);
+  ucxx_trace("ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, closed", __func__, this, _handle);
 
   if (_callbackData->closeCallback) {
-    ucxx_debug("ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, calling user close callback",
+    ucxx_debug("ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, calling user close callback",
+               __func__,
                this,
                _handle);
     _callbackData->closeCallback(_callbackData->closeCallbackArg);
@@ -312,8 +317,9 @@ size_t Endpoint::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
     }
     if (!cancelSuccess)
       ucxx_debug(
-        "ucxx::Endpoint::cancelInflightRequests, Endpoint: %p, UCP handle: %p, all attempts to "
+        "ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, all attempts to "
         "cancel inflight requests failed",
+        __func__,
         this,
         _handle);
   } else {
@@ -424,7 +430,7 @@ void Endpoint::errorCallback(void* arg, ucp_ep_h ep, ucs_status_t status)
   data->status            = status;
   data->worker->scheduleRequestCancel(data->inflightRequests->release());
   if (data->closeCallback) {
-    ucxx_debug("ucxx::Endpoint::errorCallback, UCP handle: %p, calling user close callback", ep);
+    ucxx_debug("ucxx::Endpoint::%s, UCP handle: %p, calling user close callback", __func__, ep);
     data->closeCallback(data->closeCallbackArg);
     data->closeCallback    = nullptr;
     data->closeCallbackArg = nullptr;
@@ -433,17 +439,17 @@ void Endpoint::errorCallback(void* arg, ucp_ep_h ep, ucs_status_t status)
   // Connection reset and timeout often represent just a normal remote
   // endpoint disconnect, log only in debug mode.
   if (status == UCS_ERR_CONNECTION_RESET || status == UCS_ERR_ENDPOINT_TIMEOUT)
-    ucxx_debug(
-      "ucxx::Endpoint::errorCallback, UCP handle: %p, error callback called with status %d: %s",
-      ep,
-      status,
-      ucs_status_string(status));
+    ucxx_debug("ucxx::Endpoint::%s, UCP handle: %p, error callback called with status %d: %s",
+               __func__,
+               ep,
+               status,
+               ucs_status_string(status));
   else
-    ucxx_error(
-      "ucxx::Endpoint::errorCallback, UCP handle: %p, error callback called with status %d: %s",
-      ep,
-      status,
-      ucs_status_string(status));
+    ucxx_error("ucxx::Endpoint::%s, UCP handle: %p, error callback called with status %d: %s",
+               __func__,
+               ep,
+               status,
+               ucs_status_string(status));
 }
 
 }  // namespace ucxx

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -77,7 +77,7 @@ Endpoint::Endpoint(std::shared_ptr<Component> workerOrListener,
     utils::ucsErrorThrow(ucp_ep_create(worker->getHandle(), params, &_handle));
   }
 
-  ucxx_trace("Endpoint created: %p, UCP handle: %p, parent: %p, endpointErrorHandling: %d",
+  ucxx_trace("ucxx::Endpoint created: %p, UCP handle: %p, parent: %p, endpointErrorHandling: %d",
              this,
              _handle,
              _parent.get(),
@@ -140,7 +140,7 @@ std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(std::shared_ptr<Worker
 Endpoint::~Endpoint()
 {
   close(10000000000 /* 10s */);
-  ucxx_trace("Endpoint destroyed: %p, UCP handle: %p", this, _originalHandle);
+  ucxx_trace("ucxx::Endpoint destroyed: %p, UCP handle: %p", this, _originalHandle);
 }
 
 void Endpoint::close(uint64_t period, uint64_t maxAttempts)
@@ -148,7 +148,10 @@ void Endpoint::close(uint64_t period, uint64_t maxAttempts)
   if (_handle == nullptr) return;
 
   size_t canceled = cancelInflightRequests(3000000000 /* 3s */, 3);
-  ucxx_debug("Endpoint %p canceled %lu requests", _handle, canceled);
+  ucxx_debug("ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, canceled %lu requests",
+             this,
+             _handle,
+             canceled);
 
   // Close the endpoint
   unsigned closeMode = UCP_EP_CLOSE_MODE_FORCE;
@@ -179,8 +182,12 @@ void Endpoint::close(uint64_t period, uint64_t maxAttempts)
             ucp_request_free(status);
             _callbackData->status = UCS_PTR_STATUS(s);
             if (UCS_PTR_STATUS(status) != UCS_OK) {
-              ucxx_error("Error while closing endpoint: %s",
-                         ucs_status_string(UCS_PTR_STATUS(status)));
+              ucxx_error(
+                "ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, error while closing "
+                "endpoint: %s",
+                this,
+                _handle,
+                ucs_status_string(UCS_PTR_STATUS(status)));
             }
           }
 
@@ -194,7 +201,10 @@ void Endpoint::close(uint64_t period, uint64_t maxAttempts)
 
     if (!closeSuccess) {
       _callbackData->status = UCS_ERR_ENDPOINT_TIMEOUT;
-      ucxx_debug("All attempts to close timed out on endpoint: %p, UCP handle: %p", this, _handle);
+      ucxx_debug(
+        "ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, all attempts to close timed out",
+        this,
+        _handle);
     }
   } else {
     status = ucp_ep_close_nb(_handle, closeMode);
@@ -205,13 +215,19 @@ void Endpoint::close(uint64_t period, uint64_t maxAttempts)
       ucp_request_free(status);
       _callbackData->status = s;
     } else if (UCS_PTR_STATUS(status) != UCS_OK) {
-      ucxx_error("Error while closing endpoint: %s", ucs_status_string(UCS_PTR_STATUS(status)));
+      ucxx_error(
+        "ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, Error while closing endpoint: %s",
+        this,
+        _handle,
+        ucs_status_string(UCS_PTR_STATUS(status)));
     }
   }
-  ucxx_trace("Endpoint closed: %p, UCP handle: %p", this, _handle);
+  ucxx_trace("ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, closed", this, _handle);
 
   if (_callbackData->closeCallback) {
-    ucxx_debug("Calling user callback for endpoint %p", _handle);
+    ucxx_debug("ucxx::Endpoint::close, Endpoint: %p, UCP handle: %p, calling user close callback",
+               this,
+               _handle);
     _callbackData->closeCallback(_callbackData->closeCallbackArg);
     _callbackData->closeCallback    = nullptr;
     _callbackData->closeCallbackArg = nullptr;
@@ -295,9 +311,11 @@ size_t Endpoint::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
       if (!callbackNotifierPost.wait(period)) continue;
     }
     if (!cancelSuccess)
-      ucxx_debug("All attempts to cancel inflight requests failed on endpoint: %p, UCP handle: %p",
-                 this,
-                 _handle);
+      ucxx_debug(
+        "ucxx::Endpoint::cancelInflightRequests, Endpoint: %p, UCP handle: %p, all attempts to "
+        "cancel inflight requests failed",
+        this,
+        _handle);
   } else {
     canceled = _inflightRequests->cancelAll();
   }
@@ -406,7 +424,7 @@ void Endpoint::errorCallback(void* arg, ucp_ep_h ep, ucs_status_t status)
   data->status            = status;
   data->worker->scheduleRequestCancel(data->inflightRequests->release());
   if (data->closeCallback) {
-    ucxx_debug("Calling user callback for endpoint %p", ep);
+    ucxx_debug("ucxx::Endpoint::errorCallback, UCP handle: %p, calling user close callback", ep);
     data->closeCallback(data->closeCallbackArg);
     data->closeCallback    = nullptr;
     data->closeCallbackArg = nullptr;
@@ -415,15 +433,17 @@ void Endpoint::errorCallback(void* arg, ucp_ep_h ep, ucs_status_t status)
   // Connection reset and timeout often represent just a normal remote
   // endpoint disconnect, log only in debug mode.
   if (status == UCS_ERR_CONNECTION_RESET || status == UCS_ERR_ENDPOINT_TIMEOUT)
-    ucxx_debug("Error callback for endpoint %p called with status %d: %s",
-               ep,
-               status,
-               ucs_status_string(status));
+    ucxx_debug(
+      "ucxx::Endpoint::errorCallback, UCP handle: %p, error callback called with status %d: %s",
+      ep,
+      status,
+      ucs_status_string(status));
   else
-    ucxx_error("Error callback for endpoint %p called with status %d: %s",
-               ep,
-               status,
-               ucs_status_string(status));
+    ucxx_error(
+      "ucxx::Endpoint::errorCallback, UCP handle: %p, error callback called with status %d: %s",
+      ep,
+      status,
+      ucs_status_string(status));
 }
 
 }  // namespace ucxx

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -120,7 +120,7 @@ size_t InflightRequests::cancelAll()
     toCancel = std::exchange(_trackedRequests->_inflight, std::make_unique<InflightRequestsMap>());
   }
 
-  ucxx_debug("Canceling %lu requests", total);
+  ucxx_debug("ucxx::InflightRequests::cancelAll, canceling %lu requests", total);
 
   for (auto& r : *toCancel) {
     auto request = r.second;

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -120,7 +120,7 @@ size_t InflightRequests::cancelAll()
     toCancel = std::exchange(_trackedRequests->_inflight, std::make_unique<InflightRequestsMap>());
   }
 
-  ucxx_debug("ucxx::InflightRequests::cancelAll, canceling %lu requests", total);
+  ucxx_debug("ucxx::InflightRequests::%s, canceling %lu requests", __func__, total);
 
   for (auto& r : *toCancel) {
     auto request = r.second;

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -31,7 +31,7 @@ Listener::Listener(std::shared_ptr<Worker> worker,
   params.sockaddr.addrlen = info->ai_addrlen;
 
   utils::ucsErrorThrow(ucp_listener_create(worker->getHandle(), &params, &_handle));
-  ucxx_trace("Listener created: %p, UCP handle: %p", this, _handle);
+  ucxx_trace("ucxx::Listener created: %p, UCP handle: %p", this, _handle);
 
   ucp_listener_attr_t attr = {.field_mask = UCP_LISTENER_ATTR_FIELD_SOCKADDR};
   utils::ucsErrorThrow(ucp_listener_query(_handle, &attr));
@@ -66,7 +66,7 @@ Listener::~Listener()
     worker->progress();
   }
 
-  ucxx_trace("Listener destroyed: %p, UCP handle: %p", this, _handle);
+  ucxx_trace("ucxx::Listener destroyed: %p, UCP handle: %p", this, _handle);
 }
 
 std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,

--- a/cpp/src/request.cpp
+++ b/cpp/src/request.cpp
@@ -36,25 +36,35 @@ Request::Request(std::shared_ptr<Component> endpointOrWorker,
   _enablePythonFuture &= _worker->isFutureEnabled();
   if (_enablePythonFuture) {
     _future = _worker->getFuture();
-    ucxx_trace_req("req: %p, _future: %p", _request, _future.get());
+    ucxx_trace_req_f(
+      _ownerString.c_str(), this, _request, _operationName.c_str(), "future: %p", _future.get());
   }
 
   std::stringstream ss;
 
   if (_endpoint) {
     setParent(_endpoint);
-    ss << "ep " << _endpoint->getHandle();
+    ss << "ucxx::Endpoint: " << _endpoint->getHandle();
+    ucxx_trace("ucxx::Request created (%s): %p on ucxx::Endpoint: %p",
+               _operationName.c_str(),
+               this,
+               _endpoint.get());
   } else {
     setParent(_worker);
-    ss << "worker " << _worker->getHandle();
+    ss << "ucxx::Worker: " << _worker->getHandle();
+    ucxx_trace("ucxx::Request created (%s): %p on ucxx::Worker: %p",
+               _operationName.c_str(),
+               this,
+               _worker.get());
   }
 
   _ownerString = ss.str();
-
-  ucxx_trace("Request created: %p, %s", this, _operationName.c_str());
 }
 
-Request::~Request() { ucxx_trace("Request destroyed: %p, %s", this, _operationName.c_str()); }
+Request::~Request()
+{
+  ucxx_trace("ucxx::Request destroyed (%s): %p", _operationName.c_str(), this);
+}
 
 void Request::cancel()
 {
@@ -119,22 +129,26 @@ void Request::callback(void* request, ucs_status_t status)
   try {
     selfReference = shared_from_this();
   } catch (std::bad_weak_ptr& exception) {
-    ucxx_debug("Request %p destroyed before callback() was executed", this);
+    ucxx_debug("ucxx::Request: %p destroyed before callback() was executed", this);
     return;
   }
   if (_status != UCS_INPROGRESS)
-    ucxx_trace("Request %p has status already set to %d (%s), callback setting %d (%s)",
-               this,
-               _status,
-               ucs_status_string(_status),
-               status,
-               ucs_status_string(status));
+    ucxx_trace_req_f(_ownerString.c_str(),
+                     this,
+                     _request,
+                     _operationName.c_str(),
+                     "has status already set to %d (%s), callback setting %d (%s)",
+                     _status,
+                     ucs_status_string(_status),
+                     status,
+                     ucs_status_string(status));
 
   if (UCS_PTR_IS_PTR(_request)) ucp_request_free(request);
 
-  ucxx_trace("Request completed: %p, handle: %p", this, request);
+  ucxx_trace_req_f(_ownerString.c_str(), this, _request, _operationName.c_str(), "completed");
   setStatus(status);
-  ucxx_trace("Request %p, isCompleted: %d", this, isCompleted());
+  ucxx_trace_req_f(
+    _ownerString.c_str(), this, _request, _operationName.c_str(), "isCompleted: %d", isCompleted());
 }
 
 void Request::process()
@@ -153,7 +167,6 @@ void Request::process()
                      _request,
                      _operationName.c_str(),
                      "completion will be handled by callback");
-    ucxx_trace("Request submitted: %p, handle: %p", this, _request);
     return;
   } else {
     // Operation completed immediately
@@ -191,13 +204,14 @@ void Request::setStatus(ucs_status_t status)
                      this,
                      _request,
                      _operationName.c_str(),
-                     "callback called with status %d (%s)",
+                     "setStatus called with status %d (%s)",
                      status,
                      ucs_status_string(status));
 
     if (_status != UCS_INPROGRESS)
       ucxx_error(
-        "setStatus called on request: %p with status: %d (%s) but status: %d (%s) was already set",
+        "ucxx::Request: %p, setStatus called with status: %d (%s) but status: %d (%s) was already "
+        "set",
         this,
         status,
         ucs_status_string(status),
@@ -210,13 +224,11 @@ void Request::setStatus(ucs_status_t status)
       future->notify(status);
     }
 
-    ucxx_trace_req_f(_ownerString.c_str(),
-                     this,
-                     _request,
-                     _operationName.c_str(),
-                     "callback %p",
-                     _callback.target<void (*)(void)>());
-    if (_callback) _callback(status, _callbackData);
+    if (_callback) {
+      ucxx_trace_req_f(
+        _ownerString.c_str(), this, _request, _operationName.c_str(), "invoking user callback");
+      _callback(status, _callbackData);
+    }
   }
 }
 

--- a/cpp/src/request.cpp
+++ b/cpp/src/request.cpp
@@ -63,17 +63,19 @@ void Request::cancel()
     if (UCS_PTR_IS_ERR(_request)) {
       ucs_status_t status = UCS_PTR_STATUS(_request);
       ucxx_trace_req_f(_ownerString.c_str(),
+                       this,
                        _request,
                        _operationName.c_str(),
                        "unprocessed request during cancelation contains error: %d (%s)",
                        status,
                        ucs_status_string(status));
     } else {
-      ucxx_trace_req_f(_ownerString.c_str(), _request, _operationName.c_str(), "canceling");
+      ucxx_trace_req_f(_ownerString.c_str(), this, _request, _operationName.c_str(), "canceling");
       if (_request != nullptr) ucp_request_cancel(_worker->getHandle(), _request);
     }
   } else {
     ucxx_trace_req_f(_ownerString.c_str(),
+                     this,
                      _request,
                      _operationName.c_str(),
                      "already completed with status: %d (%s)",
@@ -147,6 +149,7 @@ void Request::process()
   } else if (UCS_PTR_IS_PTR(_request)) {
     // Completion will be handled by callback
     ucxx_trace_req_f(_ownerString.c_str(),
+                     this,
                      _request,
                      _operationName.c_str(),
                      "completion will be handled by callback");
@@ -158,6 +161,7 @@ void Request::process()
   }
 
   ucxx_trace_req_f(_ownerString.c_str(),
+                   this,
                    _request,
                    _operationName.c_str(),
                    "status %d (%s)",
@@ -169,7 +173,7 @@ void Request::process()
       "error on %s with status %d (%s)", _operationName.c_str(), status, ucs_status_string(status));
   } else {
     ucxx_trace_req_f(
-      _ownerString.c_str(), _request, _operationName.c_str(), "completed immediately");
+      _ownerString.c_str(), this, _request, _operationName.c_str(), "completed immediately");
   }
 
   setStatus(status);
@@ -184,6 +188,7 @@ void Request::setStatus(ucs_status_t status)
     _worker->removeInflightRequest(this);
 
     ucxx_trace_req_f(_ownerString.c_str(),
+                     this,
                      _request,
                      _operationName.c_str(),
                      "callback called with status %d (%s)",
@@ -206,6 +211,7 @@ void Request::setStatus(ucs_status_t status)
     }
 
     ucxx_trace_req_f(_ownerString.c_str(),
+                     this,
                      _request,
                      _operationName.c_str(),
                      "callback %p",

--- a/cpp/src/request_am.cpp
+++ b/cpp/src/request_am.cpp
@@ -130,13 +130,13 @@ ucs_status_t RequestAm::recvCallback(void* arg,
     if (reqs != recvWait.end() && !reqs->second.empty()) {
       req = reqs->second.front();
       reqs->second.pop();
-      ucxx_trace_req("amRecv recvWait: %p", req.get());
+      ucxx_trace_req_f(ownerString.c_str(), req.get(), nullptr, "amRecv", "recvWait");
     } else {
       req             = std::shared_ptr<RequestAm>(new RequestAm(
         worker, data::AmReceive(), "amReceive", worker->isFutureEnabled(), nullptr, nullptr));
       auto [queue, _] = recvPool.try_emplace(ep, std::queue<std::shared_ptr<RequestAm>>());
       queue->second.push(req);
-      ucxx_trace_req("amRecv recvPool: %p", req.get());
+      ucxx_trace_req_f(ownerString.c_str(), req.get(), nullptr, "amRecv", "recvPool");
     }
   }
 
@@ -168,10 +168,10 @@ ucs_status_t RequestAm::recvCallback(void* arg,
 
     if (req->_enablePythonFuture)
       ucxx_trace_req_f(ownerString.c_str(),
-                       this,
+                       req.get(),
                        status,
                        "amRecv rndv",
-                       "ep %p, buffer %p, size %lu, future %p, future handle %p, recvCallback",
+                       "recvCallback, ep: %p, buffer: %p, size: %lu, future: %p, future handle: %p",
                        ep,
                        buf->data(),
                        length,
@@ -179,10 +179,10 @@ ucs_status_t RequestAm::recvCallback(void* arg,
                        req->_future->getHandle());
     else
       ucxx_trace_req_f(ownerString.c_str(),
-                       this,
+                       req.get(),
                        status,
                        "amRecv rndv",
-                       "ep %p, buffer %p, size %lu, recvCallback",
+                       "recvCallback, ep: %p, buffer: %p, size: %lu",
                        ep,
                        buf->data(),
                        length);
@@ -211,10 +211,10 @@ ucs_status_t RequestAm::recvCallback(void* arg,
 
     if (req->_enablePythonFuture)
       ucxx_trace_req_f(ownerString.c_str(),
-                       this,
+                       req.get(),
                        nullptr,
                        "amRecv eager",
-                       "ep: %p, buffer %p, size %lu, future %p, future handle %p, recvCallback",
+                       "recvCallback, ep: %p, buffer: %p, size: %lu, future: %p, future handle: %p",
                        ep,
                        buf->data(),
                        length,
@@ -222,10 +222,10 @@ ucs_status_t RequestAm::recvCallback(void* arg,
                        req->_future->getHandle());
     else
       ucxx_trace_req_f(ownerString.c_str(),
-                       this,
+                       req.get(),
                        nullptr,
                        "amRecv eager",
-                       "ep: %p, buffer %p, size %lu, recvCallback",
+                       "recvCallback, ep: %p, buffer: %p, size: %lu",
                        ep,
                        buf->data(),
                        length);
@@ -300,8 +300,8 @@ void RequestAm::populateDelayedSubmission()
                        this,
                        _request,
                        _operationName.c_str(),
-                       "buffer %p, size %lu, memoryType: %u, future %p, future handle %p, "
-                       "populateDelayedSubmission",
+                       "populateDelayedSubmission, buffer %p, size %lu, memoryType: %u, future %p, "
+                       "future handle %p, ",
                        buffer,
                        length,
                        memoryType,
@@ -312,7 +312,7 @@ void RequestAm::populateDelayedSubmission()
                        this,
                        _request,
                        _operationName.c_str(),
-                       "buffer %p, size %lu, memoryType: %u, populateDelayedSubmission",
+                       "populateDelayedSubmission, buffer %p, size %lu, memoryType: %u",
                        buffer,
                        length,
                        memoryType);

--- a/cpp/src/request_am.cpp
+++ b/cpp/src/request_am.cpp
@@ -80,7 +80,7 @@ RequestAm::RequestAm(std::shared_ptr<Component> endpointOrWorker,
 static void _amSendCallback(void* request, ucs_status_t status, void* user_data)
 {
   Request* req = reinterpret_cast<Request*>(user_data);
-  ucxx_trace_req_f(req->getOwnerString().c_str(), request, "amSend", "_amSendCallback");
+  ucxx_trace_req_f(req->getOwnerString().c_str(), nullptr, request, "amSend", "_amSendCallback");
   req->callback(request, status);
 }
 
@@ -90,8 +90,11 @@ static void _recvCompletedCallback(void* request,
                                    void* user_data)
 {
   internal::RecvAmMessage* recvAmMessage = static_cast<internal::RecvAmMessage*>(user_data);
-  ucxx_trace_req_f(
-    recvAmMessage->_request->getOwnerString().c_str(), request, "amRecv", "amRecvCallback");
+  ucxx_trace_req_f(recvAmMessage->_request->getOwnerString().c_str(),
+                   nullptr,
+                   request,
+                   "amRecv",
+                   "amRecvCallback");
   recvAmMessage->callback(request, status);
 }
 
@@ -165,6 +168,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
 
     if (req->_enablePythonFuture)
       ucxx_trace_req_f(ownerString.c_str(),
+                       this,
                        status,
                        "amRecv rndv",
                        "ep %p, buffer %p, size %lu, future %p, future handle %p, recvCallback",
@@ -175,6 +179,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
                        req->_future->getHandle());
     else
       ucxx_trace_req_f(ownerString.c_str(),
+                       this,
                        status,
                        "amRecv rndv",
                        "ep %p, buffer %p, size %lu, recvCallback",
@@ -206,6 +211,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
 
     if (req->_enablePythonFuture)
       ucxx_trace_req_f(ownerString.c_str(),
+                       this,
                        nullptr,
                        "amRecv eager",
                        "ep: %p, buffer %p, size %lu, future %p, future handle %p, recvCallback",
@@ -216,6 +222,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
                        req->_future->getHandle());
     else
       ucxx_trace_req_f(ownerString.c_str(),
+                       this,
                        nullptr,
                        "amRecv eager",
                        "ep: %p, buffer %p, size %lu, recvCallback",
@@ -290,6 +297,7 @@ void RequestAm::populateDelayedSubmission()
   auto log = [this](const void* buffer, const size_t length, const ucs_memory_type_t memoryType) {
     if (_enablePythonFuture)
       ucxx_trace_req_f(_ownerString.c_str(),
+                       this,
                        _request,
                        _operationName.c_str(),
                        "buffer %p, size %lu, memoryType: %u, future %p, future handle %p, "
@@ -301,6 +309,7 @@ void RequestAm::populateDelayedSubmission()
                        _future->getHandle());
     else
       ucxx_trace_req_f(_ownerString.c_str(),
+                       this,
                        _request,
                        _operationName.c_str(),
                        "buffer %p, size %lu, memoryType: %u, populateDelayedSubmission",

--- a/cpp/src/request_stream.cpp
+++ b/cpp/src/request_stream.cpp
@@ -123,6 +123,7 @@ void RequestStream::populateDelayedSubmission()
     if (_enablePythonFuture)
       ucxx_trace_req_f(
         _ownerString.c_str(),
+        this,
         _request,
         _operationName.c_str(),
         "buffer %p, size %lu, future %p, future handle %p, populateDelayedSubmission",
@@ -132,6 +133,7 @@ void RequestStream::populateDelayedSubmission()
         _future->getHandle());
     else
       ucxx_trace_req_f(_ownerString.c_str(),
+                       this,
                        _request,
                        _operationName.c_str(),
                        "buffer %p, size %lu, populateDelayedSubmission",
@@ -176,14 +178,16 @@ void RequestStream::callback(void* request, ucs_status_t status, size_t length)
 void RequestStream::streamSendCallback(void* request, ucs_status_t status, void* arg)
 {
   Request* req = reinterpret_cast<Request*>(arg);
-  ucxx_trace_req_f(req->getOwnerString().c_str(), request, "streamSend", "streamSendCallback");
+  ucxx_trace_req_f(
+    req->getOwnerString().c_str(), nullptr, request, "streamSend", "streamSendCallback");
   return req->callback(request, status);
 }
 
 void RequestStream::streamRecvCallback(void* request, ucs_status_t status, size_t length, void* arg)
 {
   RequestStream* req = reinterpret_cast<RequestStream*>(arg);
-  ucxx_trace_req_f(req->getOwnerString().c_str(), request, "streamRecv", "streamRecvCallback");
+  ucxx_trace_req_f(
+    req->getOwnerString().c_str(), nullptr, request, "streamRecv", "streamRecvCallback");
   return req->callback(request, status, length);
 }
 

--- a/cpp/src/request_stream.cpp
+++ b/cpp/src/request_stream.cpp
@@ -126,7 +126,7 @@ void RequestStream::populateDelayedSubmission()
         this,
         _request,
         _operationName.c_str(),
-        "buffer %p, size %lu, future %p, future handle %p, populateDelayedSubmission",
+        "populateDelayedSubmission, buffer %p, size %lu, future %p, future handle %p",
         buffer,
         length,
         _future.get(),
@@ -136,7 +136,7 @@ void RequestStream::populateDelayedSubmission()
                        this,
                        _request,
                        _operationName.c_str(),
-                       "buffer %p, size %lu, populateDelayedSubmission",
+                       "populateDelayedSubmission, buffer %p, size %lu",
                        buffer,
                        length);
   };

--- a/cpp/src/request_tag.cpp
+++ b/cpp/src/request_tag.cpp
@@ -168,26 +168,25 @@ void RequestTag::populateDelayedSubmission()
 
   auto log = [this](const void* buffer, const size_t length, const Tag tag, const TagMask tagMask) {
     if (_enablePythonFuture)
-      ucxx_trace_req_f(
-        _ownerString.c_str(),
-        this,
-        _request,
-        _operationName.c_str(),
-        "buffer: %p, size: %lu, tag 0x%lx, tagMask: 0x%lx, future %p, future handle %p, "
-        "populateDelayedSubmission",
-        buffer,
-        length,
-        tag,
-        tagMask,
-        _future.get(),
-        _future->getHandle());
+      ucxx_trace_req_f(_ownerString.c_str(),
+                       this,
+                       _request,
+                       _operationName.c_str(),
+                       "populateDelayedSubmission, buffer: %p, size: %lu, tag 0x%lx, tagMask: "
+                       "0x%lx, future %p, future handle %p",
+                       buffer,
+                       length,
+                       tag,
+                       tagMask,
+                       _future.get(),
+                       _future->getHandle());
     else
       ucxx_trace_req_f(
         _ownerString.c_str(),
         this,
         _request,
         _operationName.c_str(),
-        "buffer: %p, size: %lu, tag 0x%lx, tagMask: 0x%lx, populateDelayedSubmission",
+        "populateDelayedSubmission, buffer: %p, size: %lu, tag 0x%lx, tagMask: 0x%lx",
         buffer,
         length,
         tag,

--- a/cpp/src/request_tag.cpp
+++ b/cpp/src/request_tag.cpp
@@ -91,7 +91,7 @@ void RequestTag::callback(void* request, ucs_status_t status, const ucp_tag_recv
 void RequestTag::tagSendCallback(void* request, ucs_status_t status, void* arg)
 {
   Request* req = reinterpret_cast<Request*>(arg);
-  ucxx_trace_req_f(req->getOwnerString().c_str(), request, "tagSend", "tagSendCallback");
+  ucxx_trace_req_f(req->getOwnerString().c_str(), nullptr, request, "tagSend", "tagSendCallback");
   return req->callback(request, status);
 }
 
@@ -101,7 +101,7 @@ void RequestTag::tagRecvCallback(void* request,
                                  void* arg)
 {
   RequestTag* req = reinterpret_cast<RequestTag*>(arg);
-  ucxx_trace_req_f(req->getOwnerString().c_str(), request, "tagRecv", "tagRecvCallback");
+  ucxx_trace_req_f(req->getOwnerString().c_str(), nullptr, request, "tagRecv", "tagRecvCallback");
   return req->callback(request, status, info);
 }
 
@@ -170,6 +170,7 @@ void RequestTag::populateDelayedSubmission()
     if (_enablePythonFuture)
       ucxx_trace_req_f(
         _ownerString.c_str(),
+        this,
         _request,
         _operationName.c_str(),
         "buffer: %p, size: %lu, tag 0x%lx, tagMask: 0x%lx, future %p, future handle %p, "
@@ -183,6 +184,7 @@ void RequestTag::populateDelayedSubmission()
     else
       ucxx_trace_req_f(
         _ownerString.c_str(),
+        this,
         _request,
         _operationName.c_str(),
         "buffer: %p, size: %lu, tag 0x%lx, tagMask: 0x%lx, populateDelayedSubmission",

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -435,7 +435,7 @@ size_t Worker::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
     }
 
     if (!cancelSuccess)
-      ucxx_error("All attempts to cancel inflight requests failed on worker: %p, UCP handle: %p",
+      ucxx_debug("All attempts to cancel inflight requests failed on worker: %p, UCP handle: %p",
                  this,
                  _handle);
   } else {

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -88,8 +88,9 @@ void Worker::drainWorkerTagRecv()
 
   while ((message = ucp_tag_probe_nb(_handle, 0, 0, 1, &info)) != NULL) {
     ucxx_debug(
-      "ucxx::Worker::draingWorkerTagRecv, Worker: %p, UCP handle: %p, tag: 0x%lx, length: %lu, "
+      "ucxx::Worker::%s, Worker: %p, UCP handle: %p, tag: 0x%lx, length: %lu, "
       "draining tag receive messages",
+      __func__,
       this,
       _handle,
       info.sender_tag,
@@ -155,7 +156,8 @@ std::shared_ptr<Worker> createWorker(std::shared_ptr<Context> context,
 Worker::~Worker()
 {
   size_t canceled = cancelInflightRequests(3000000000 /* 3s */, 3);
-  ucxx_debug("ucxx::Worker::~Worker, Worker: %p, UCP handle: %p, canceled %lu requests",
+  ucxx_debug("ucxx::Worker::%s, Worker: %p, UCP handle: %p, canceled %lu requests",
+             __func__,
              this,
              _handle,
              canceled);
@@ -365,8 +367,9 @@ void Worker::startProgressThread(const bool pollingMode, const int epollTimeout)
 {
   if (_progressThread) {
     ucxx_debug(
-      "ucxx::Worker::startProgressThread, Worker: %p, UCP handle: %p, worker progress thread "
+      "ucxx::Worker::%s, Worker: %p, UCP handle: %p, worker progress thread "
       "already running",
+      __func__,
       this,
       _handle);
     return;
@@ -404,8 +407,9 @@ void Worker::stopProgressThread()
 {
   if (!_progressThread)
     ucxx_debug(
-      "ucxx::Worker::stopProgressThread, Worker: %p, UCP handle: %p, worker progress thread not "
+      "ucxx::Worker::%s, Worker: %p, UCP handle: %p, worker progress thread not "
       "running or already stopped",
+      __func__,
       this,
       _handle);
   else
@@ -451,8 +455,9 @@ size_t Worker::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
 
     if (!cancelSuccess)
       ucxx_debug(
-        "ucxx::Worker::cancelInflightRequests, Worker: %p, UCP handle: %p, all attempts to cancel "
+        "ucxx::Worker::%s, Worker: %p, UCP handle: %p, all attempts to cancel "
         "inflight requests failed",
+        __func__,
         this,
         _handle);
   } else {
@@ -472,8 +477,9 @@ void Worker::scheduleRequestCancel(TrackedRequestsPtr trackedRequests)
   {
     std::lock_guard<std::mutex> lock(_inflightRequestsMutex);
     ucxx_debug(
-      "ucxx::Worker::scheduleRequestCancel, Worker: %p, UCP handle: %p, scheduling cancelation of "
+      "ucxx::Worker::%s, Worker: %p, UCP handle: %p, scheduling cancelation of "
       "%lu requests",
+      __func__,
       this,
       _handle,
       trackedRequests->_inflight->size() + trackedRequests->_canceling->size());


### PR DESCRIPTION
Logging is a bit unorganized, having different formats and not always including useful information (such as the address of the object being logged). This change attempts to make logging a bit more descriptive and consistent where possible.