### PR TITLE
Remove invalid install locations

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -65,10 +65,6 @@ set_property(
 )
 message(VERBOSE "UCXX: RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'.")
 
-if(NOT UCXX_GENERATED_INCLUDE_DIR)
-    set(UCXX_GENERATED_INCLUDE_DIR ${UCXX_BINARY_DIR})
-endif()
-
 # ##################################################################################################
 # * conda environment -----------------------------------------------------------------------------
 rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
@@ -151,7 +147,6 @@ target_compile_options(
 target_include_directories(
   ucxx
   PUBLIC "$<BUILD_INTERFACE:${UCXX_SOURCE_DIR}/include>"
-         "$<BUILD_INTERFACE:${UCXX_GENERATED_INCLUDE_DIR}/include>"
   PRIVATE "$<BUILD_INTERFACE:${UCXX_SOURCE_DIR}/src>"
   INTERFACE "$<INSTALL_INTERFACE:include>"
 )

--- a/cpp/python/CMakeLists.txt
+++ b/cpp/python/CMakeLists.txt
@@ -43,8 +43,6 @@ target_include_directories(
   ucxx_python
   PUBLIC "$<BUILD_INTERFACE:${UCXX_SOURCE_DIR}/include>"
          "$<BUILD_INTERFACE:${UCXX_SOURCE_DIR}/python/include>"
-         "$<BUILD_INTERFACE:${UCXX_GENERATED_INCLUDE_DIR}/include>"
-         "$<BUILD_INTERFACE:${UCXX_GENERATED_INCLUDE_DIR}/python/include>"
   PRIVATE "$<BUILD_INTERFACE:${UCXX_SOURCE_DIR}/src>"
   INTERFACE "$<INSTALL_INTERFACE:include>"
 )


### PR DESCRIPTION
UCXX has no generated headers in the build directory, so these incorrect includes result in a build directory that is not directly usable as a dependency.