### PR TITLE
refactor CUDA versions in dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -9,7 +9,8 @@ files:
       - build_cpp
       - build_python
       - checks
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - dev
       - py_version
       - run_python
@@ -18,12 +19,12 @@ files:
   test_cpp:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - test_cpp
   test_python:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - py_version
       - test_python
   checks:
@@ -92,7 +93,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - pre-commit
-  cudatoolkit:
+  cuda_version:
     specific:
       - output_types: conda
         matrices:
@@ -116,6 +117,8 @@ dependencies:
               cuda: "12.0"
             packages:
               - cuda-version=12.0
+  cuda:
+    specific:
       - output_types: conda
         matrices:
           - matrix:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/7.

Proposes splitting the `cuda-version` dependency in `dependencies.yaml` out to its own thing, separate from the bits of the CUDA Toolkit this project needs.

### Benefits of this change

* prevents accidental inclusion of multiple `cuda-version` version in environments
* reduces update effort (via enabling more use of globs like `"12.*"`)
* improves the chance that errors like "`conda` recipe is missing a dependency" are caught in CI