### PR TITLE
Add support for functions `ucp_get_nbx` and `ucp_put_nbx`

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -77,6 +77,7 @@ rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
 # * compiler options ------------------------------------------------------------------------------
 rapids_find_package(
   ucx REQUIRED
+  GLOBAL_TARGETS ucx::ucp ucx::ucs ucx::uct
   BUILD_EXPORT_SET ucxx-exports
   INSTALL_EXPORT_SET ucxx-exports
 )
@@ -119,6 +120,7 @@ add_library(
   src/request.cpp
   src/request_am.cpp
   src/request_helper.cpp
+  src/request_mem.cpp
   src/request_stream.cpp
   src/request_tag.cpp
   src/request_tag_multi.cpp
@@ -149,9 +151,9 @@ target_compile_options(
 # Specify include paths for the current target and dependents
 target_include_directories(
   ucxx
-  PUBLIC "$<BUILD_INTERFACE:${UCXX_SOURCE_DIR}/include>"
+  PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
          "$<BUILD_INTERFACE:${UCXX_GENERATED_INCLUDE_DIR}/include>"
-  PRIVATE "$<BUILD_INTERFACE:${UCXX_SOURCE_DIR}/src>"
+  PRIVATE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
   INTERFACE "$<INSTALL_INTERFACE:include>"
 )
 

--- a/cpp/include/ucxx/constructors.h
+++ b/cpp/include/ucxx/constructors.h
@@ -20,6 +20,7 @@ class Listener;
 class Notifier;
 class Request;
 class RequestAm;
+class RequestMem;
 class RequestStream;
 class RequestTag;
 class RequestTagMulti;
@@ -73,6 +74,16 @@ std::shared_ptr<RequestStream> createRequestStream(std::shared_ptr<Endpoint> end
                                                    void* buffer,
                                                    size_t length,
                                                    const bool enablePythonFuture);
+
+std::shared_ptr<RequestMem> createRequestMem(std::shared_ptr<Endpoint> endpoint,
+                                             bool send,
+                                             void* buffer,
+                                             size_t length,
+                                             uint64_t remote_addr,
+                                             ucp_rkey_h rkey,
+                                             const bool enablePythonFuture,
+                                             RequestCallbackUserFunction callbackFunction,
+                                             RequestCallbackUserData callbackData);
 
 std::shared_ptr<RequestTag> createRequestTag(std::shared_ptr<Component> endpointOrWorker,
                                              bool send,

--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -265,6 +265,22 @@ class Endpoint : public Component {
    */
   void setCloseCallback(std::function<void(void*)> closeCallback, void* closeCallbackArg);
 
+  std::shared_ptr<Request> memGet(void* buffer,
+                                  size_t length,
+                                  uint64_t remote_addr,
+                                  ucp_rkey_h rkey,
+                                  const bool enablePythonFuture                = false,
+                                  RequestCallbackUserFunction callbackFunction = nullptr,
+                                  RequestCallbackUserData callbackData         = nullptr);
+
+  std::shared_ptr<Request> memPut(void* buffer,
+                                  size_t length,
+                                  uint64_t remote_addr,
+                                  ucp_rkey_h rkey,
+                                  const bool enablePythonFuture                = false,
+                                  RequestCallbackUserFunction callbackFunction = nullptr,
+                                  RequestCallbackUserData callbackData         = nullptr);
+
   /**
    * @brief Enqueue an active message send operation.
    *

--- a/cpp/include/ucxx/request_mem.h
+++ b/cpp/include/ucxx/request_mem.h
@@ -1,0 +1,180 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#pragma once
+#include <memory>
+#include <utility>
+
+#include <ucp/api/ucp.h>
+
+#include <ucxx/delayed_submission.h>
+#include <ucxx/request.h>
+#include <ucxx/typedefs.h>
+
+namespace ucxx {
+
+class Buffer;
+
+namespace internal {
+class RecvMemMessage;
+}  // namespace internal
+
+class RequestMem : public Request {
+ private:
+  friend class internal::RecvMemMessage;
+
+  uint64_t _remote_addr{};
+  ucp_rkey_h _rkey{};
+
+  /**
+   * @brief Private constructor of `ucxx::RequestAm` send.
+   *
+   * This is the internal implementation of `ucxx::RequestAm` send constructor, made private
+   * not to be called directly. This constructor is made private to ensure all UCXX objects
+   * are shared pointers and the correct lifetime management of each one.
+   *
+   * Instead the user should use one of the following:
+   *
+   * - `ucxx::Endpoint::amSend()`
+   * - `ucxx::createRequestAmSend()`
+   *
+   * @throws ucxx::Error  if `endpoint` is not a valid `std::shared_ptr<ucxx::Endpoint>`.
+   *
+   * @param[in] endpoint            the parent endpoint.
+   * @param[in] buffer              a raw pointer to the data to be sent.
+   * @param[in] length              the size in bytes of the active message to be sent.
+   * @param[in] memoryType          the memory type of the buffer.
+   * @param[in] enablePythonFuture  whether a python future should be created and
+   *                                subsequently notified.
+   * @param[in] callbackFunction    user-defined callback function to call upon completion.
+   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
+   */
+  RequestMem(std::shared_ptr<Endpoint> endpoint,
+             bool send,
+             void* buffer,
+             size_t length,
+             uint64_t remote_addr,
+             ucp_rkey_h rkey,
+             const bool enablePythonFuture                = false,
+             RequestCallbackUserFunction callbackFunction = nullptr,
+             RequestCallbackUserData callbackData         = nullptr);
+
+ public:
+  /**
+   * @brief Constructor for `std::shared_ptr<ucxx::RequestAm>` send.
+   *
+   * The constructor for a `std::shared_ptr<ucxx::RequestAm>` object, creating a send active
+   * message request, returning a pointer to a request object that can be later awaited and
+   * checked for errors. This is a non-blocking operation, and the status of the transfer
+   * must be verified from the resulting request object before the data can be
+   * released.
+   *
+   * @throws ucxx::Error  if `endpoint` is not a valid
+   *                      `std::shared_ptr<ucxx::Endpoint>`.
+   *
+   * @param[in] endpoint            the parent endpoint.
+   * @param[in] buffer              a raw pointer to the data to be transferred.
+   * @param[in] length              the size in bytes of the tag message to be transferred.
+   * @param[in] memoryType          the memory type of the buffer.
+   * @param[in] enablePythonFuture  whether a python future should be created and
+   *                                subsequently notified.
+   * @param[in] callbackFunction    user-defined callback function to call upon completion.
+   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
+   *
+   * @returns The `shared_ptr<ucxx::RequestAm>` object
+   */
+  friend std::shared_ptr<RequestMem> createRequestMem(std::shared_ptr<Endpoint> endpoint,
+                                                      bool send,
+                                                      void* buffer,
+                                                      size_t length,
+                                                      uint64_t remote_addr,
+                                                      ucp_rkey_h rkey,
+                                                      const bool enablePythonFuture,
+                                                      RequestCallbackUserFunction callbackFunction,
+                                                      RequestCallbackUserData callbackData);
+
+  virtual void populateDelayedSubmission();
+
+  /**
+   * @brief Callback executed by UCX when a tag send request is completed.
+   *
+   * Callback executed by UCX when a tag send request is completed, that will dispatch
+   * `ucxx::Request::callback()`.
+   *
+   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * a public method so that UCX may access it. In future changes this will be moved to
+   * an internal object and remove this method from the public API.
+   *
+   * @param[in] request the UCX request pointer.
+   * @param[in] status  the completion status of the request.
+   * @param[in] arg     the pointer to the `ucxx::Request` object that created the
+   *                    transfer, effectively `this` pointer as seen by `request()`.
+   */
+  static void memPutCallback(void* request, ucs_status_t status, void* arg);
+
+  /**
+   * @brief Callback executed by UCX when a tag receive request is completed.
+   *
+   * Callback executed by UCX when a tag receive request is completed, that will dispatch
+   * `ucxx::RequestTag::callback()`.
+   *
+   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * a public method so that UCX may access it. In future changes this will be moved to
+   * an internal object and remove this method from the public API.
+   *
+   * @param[in] request the UCX request pointer.
+   * @param[in] status  the completion status of the request.
+   * @param[in] info    information of the completed transfer provided by UCX, includes
+   *                    length of message received used to verify for truncation.
+   * @param[in] arg     the pointer to the `ucxx::Request` object that created the
+   *                    transfer, effectively `this` pointer as seen by `request()`.
+   */
+  static void memGetCallback(void* request, ucs_status_t status, void* arg);
+
+  /**
+   * @brief Create and submit an active message send request.
+   *
+   * This is the method that should be called to actually submit an active message send
+   * request. It is meant to be called from `populateDelayedSubmission()`, which is decided
+   * at the discretion of `std::shared_ptr<ucxx::Worker>`. See `populateDelayedSubmission()`
+   * for more details.
+   */
+  void request();
+
+  //   /**
+  //    * @brief Receive callback registered by `ucxx::Worker`.
+  //    *
+  //    * This is the receive callback registered by the `ucxx::Worker` to handle incoming active
+  //    * messages. For each incoming active message, a proper buffer will be allocated based on
+  //    * the header sent by the remote endpoint using the default allocator or one registered by
+  //    * the user via `ucxx::Worker::registerAmAllocator()`. Following that, the message is
+  //    * immediately received onto the buffer and a `UCS_OK` or the proper error status is set
+  //    * onto the `RequestAm` that is returned to the user, or will be later handled by another
+  //    * callback when the message is ready. If the callback is executed when a user has already
+  //    * requested received of the active message, the buffer and status will be set on the
+  //    * earliest request, otherwise a new request is created and saved in a pool that will be
+  //    * already populated and ready for consumption or waiting for the internal callback when
+  //    * requested.
+  //    *
+  //    * This is always called by `ucp_worker_progress()`, and thus will happen in the same
+  //    * thread that is called from, when using the worker progress thread, this is called from
+  //    * the progress thread.
+  //    *
+  //    * param[in,out] arg  pointer to the `AmData` object held by the `ucxx::Worker` who
+  //    *                    registered this callback.
+  //    * param[in] header pointer to the header containing the sender buffer's memory type.
+  //    * param[in] header_length  length in bytes of the receive header.
+  //    * param[in] data pointer to the buffer containing the remote endpoint's send data.
+  //    * param[in] length the length in bytes of the message to be received.
+  //    * param[in] param  UCP parameters of the active message being received.
+  //    */
+  //   static ucs_status_t recvCallback(void* arg,
+  //                                    const void* header,
+  //                                    size_t header_length,
+  //                                    void* data,
+  //                                    size_t length,
+  //                                    const ucp_am_recv_param_t* param);
+};
+
+}  // namespace ucxx

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -16,6 +16,7 @@
 #include <ucxx/exception.h>
 #include <ucxx/listener.h>
 #include <ucxx/request_am.h>
+#include <ucxx/request_mem.h>
 #include <ucxx/request_stream.h>
 #include <ucxx/request_tag.h>
 #include <ucxx/request_tag_multi.h>
@@ -300,6 +301,46 @@ size_t Endpoint::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
   }
 
   return canceled;
+}
+
+std::shared_ptr<Request> Endpoint::memGet(void* buffer,
+                                          size_t length,
+                                          uint64_t remote_addr,
+                                          ucp_rkey_h rkey,
+                                          const bool enablePythonFuture,
+                                          RequestCallbackUserFunction callbackFunction,
+                                          RequestCallbackUserData callbackData)
+{
+  auto endpoint = std::dynamic_pointer_cast<Endpoint>(shared_from_this());
+  return registerInflightRequest(createRequestMem(endpoint,
+                                                  false,
+                                                  buffer,
+                                                  length,
+                                                  remote_addr,
+                                                  rkey,
+                                                  enablePythonFuture,
+                                                  callbackFunction,
+                                                  callbackData));
+}
+
+std::shared_ptr<Request> Endpoint::memPut(void* buffer,
+                                          size_t length,
+                                          uint64_t remote_addr,
+                                          ucp_rkey_h rkey,
+                                          const bool enablePythonFuture,
+                                          RequestCallbackUserFunction callbackFunction,
+                                          RequestCallbackUserData callbackData)
+{
+  auto endpoint = std::dynamic_pointer_cast<Endpoint>(shared_from_this());
+  return registerInflightRequest(createRequestMem(endpoint,
+                                                  true,
+                                                  buffer,
+                                                  length,
+                                                  remote_addr,
+                                                  rkey,
+                                                  enablePythonFuture,
+                                                  callbackFunction,
+                                                  callbackData));
 }
 
 std::shared_ptr<Request> Endpoint::amSend(void* buffer,

--- a/cpp/src/request_mem.cpp
+++ b/cpp/src/request_mem.cpp
@@ -1,0 +1,293 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#include <ucp/api/ucp.h>
+
+#include <ucxx/buffer.h>
+#include <ucxx/delayed_submission.h>
+#include <ucxx/request_mem.h>
+
+namespace ucxx {
+
+std::shared_ptr<RequestMem> createRequestMem(std::shared_ptr<Endpoint> endpoint,
+                                             bool send,
+                                             void* buffer,
+                                             size_t length,
+                                             uint64_t remote_addr,
+                                             ucp_rkey_h rkey,
+                                             const bool enablePythonFuture                = false,
+                                             RequestCallbackUserFunction callbackFunction = nullptr,
+                                             RequestCallbackUserData callbackData         = nullptr)
+{
+  auto req = std::shared_ptr<RequestMem>(new RequestMem(endpoint,
+                                                        send,
+                                                        buffer,
+                                                        length,
+                                                        remote_addr,
+                                                        rkey,
+                                                        enablePythonFuture,
+                                                        callbackFunction,
+                                                        callbackData));
+
+  // A delayed notification request is not populated immediately, instead it is
+  // delayed to allow the worker progress thread to set its status, and more
+  // importantly the Python future later on, so that we don't need the GIL here.
+  req->_worker->registerDelayedSubmission(
+    req, std::bind(std::mem_fn(&Request::populateDelayedSubmission), req.get()));
+
+  return req;
+}
+
+RequestMem::RequestMem(std::shared_ptr<Endpoint> endpoint,
+                       bool send,
+                       void* buffer,
+                       size_t length,
+                       uint64_t remote_addr,
+                       ucp_rkey_h rkey,
+                       const bool enablePythonFuture,
+                       RequestCallbackUserFunction callbackFunction,
+                       RequestCallbackUserData callbackData)
+  : Request(endpoint,
+            std::make_shared<DelayedSubmission>(send, buffer, length, 0),
+            std::string(send ? "memSend" : "memRecv"),
+            enablePythonFuture)
+{
+  if (_endpoint == nullptr)
+    throw ucxx::Error("An endpoint is required to perform remote memory put/get messages");
+
+  _callback     = callbackFunction;
+  _callbackData = callbackData;
+}
+
+// static void _memSendCallback(void* request, ucs_status_t status, void* user_data)
+// {
+//   Request* req = reinterpret_cast<Request*>(user_data);
+//   ucxx_trace_req_f(req->getOwnerString().c_str(), request, "memSend", "_memSendCallback");
+//   req->callback(request, status);
+// }
+
+// static void _recvCompletedCallback(void* request,
+//                                    ucs_status_t status,
+//                                    size_t length,
+//                                    void* user_data)
+// {
+//   internal::RecvMemMessage* recvMemMessage = static_cast<internal::RecvMemMessage*>(user_data);
+//   ucxx_trace_req_f(
+//     recvMemMessage->_request->getOwnerString().c_str(), request, "memRecv", "memRecvCallback");
+//   recvMemMessage->callback(request, status);
+// }
+
+// ucs_status_t RequestMem::recvCallback(void* arg,
+//                                       const void* header,
+//                                       size_t header_length,
+//                                       void* data,
+//                                       size_t length,
+//                                       const ucp_am_recv_param_t* param)
+// {
+//   internal::AmData* memData = static_cast<internal::MemData*>(arg);
+//   auto worker               = memData->_worker.lock();
+//   auto& ownerString         = memData->_ownerString;
+//   auto& recvPool            = memData->_recvPool;
+//   auto& recvWait            = memData->_recvWait;
+
+//   if ((param->recv_attr & UCP_AM_RECV_ATTR_FIELD_REPLY_EP) == 0)
+//     ucxx_error("UCP_AM_RECV_ATTR_FIELD_REPLY_EP not set");
+
+//   ucp_ep_h ep = param->reply_ep;
+
+//   bool is_rndv = param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV;
+
+//   std::shared_ptr<Buffer> buf{nullptr};
+//   auto allocatorType = *static_cast<const ucs_memory_type_t*>(header);
+
+//   std::shared_ptr<RequestMem> req{nullptr};
+
+//   {
+//     std::lock_guard<std::mutex> lock(memData->_mutex);
+
+//     auto reqs = recvWait.find(ep);
+//     if (reqs != recvWait.end() && !reqs->second.empty()) {
+//       req = reqs->second.front();
+//       reqs->second.pop();
+//       ucxx_trace_req("memRecv recvWait: %p", req.get());
+//     } else {
+//       req = std::shared_ptr<RequestMem>(
+//         new RequestMem(worker, worker->isFutureEnabled(), nullptr, nullptr));
+//       auto [queue, _] = recvPool.try_emplace(ep, std::queue<std::shared_ptr<RequestMem>>());
+//       queue->second.push(req);
+//       ucxx_trace_req("memRecv recvPool: %p", req.get());
+//     }
+//   }
+
+//   if (is_rndv) {
+//     if (memData->_allocators.find(allocatorType) == memData->_allocators.end()) {
+//       // TODO: Is a hard failure better?
+//       // ucxx_debug("Unsupported memory type %d", allocatorType);
+//       // internal::RecvMemMessage recvMemMessage(memData, ep, req, nullptr);
+//       // recvMemMessage.callback(nullptr, UCS_ERR_UNSUPPORTED);
+//       // return UCS_ERR_UNSUPPORTED;
+
+//       ucxx_trace_req("No allocator registered for memory type %d, falling back to host memory.",
+//                      allocatorType);
+//       allocatorType = UCS_MEMORY_TYPE_HOST;
+//     }
+
+//     std::shared_ptr<Buffer> buf = memData->_allocators.at(allocatorType)(length);
+
+//     auto recvMemMessage = std::make_shared<internal::RecvMemMessage>(memData, ep, req, buf);
+
+//     ucp_request_param_t request_param = {.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+//                                                          UCP_OP_ATTR_FIELD_USER_DATA |
+//                                                          UCP_OP_ATTR_FLAG_NO_IMM_CMPL,
+//                                          .cb        = {.recv_am = _recvCompletedCallback},
+//                                          .user_data = recvMemMessage.get()};
+
+//     ucs_status_ptr_t status =
+//       ucp_am_recv_data_nbx(worker->getHandle(), data, buf->data(), length, &request_param);
+
+//     if (req->_enablePythonFuture)
+//       ucxx_trace_req_f(ownerString.c_str(),
+//                        status,
+//                        "memRecv rndv",
+//                        "ep %p, buffer %p, size %lu, future %p, future handle %p, recvCallback",
+//                        ep,
+//                        buf->data(),
+//                        length,
+//                        req->_future.get(),
+//                        req->_future->getHandle());
+//     else
+//       ucxx_trace_req_f(ownerString.c_str(),
+//                        status,
+//                        "memRecv rndv",
+//                        "ep %p, buffer %p, size %lu, recvCallback",
+//                        ep,
+//                        buf->data(),
+//                        length);
+
+//     if (req->isCompleted()) {
+//       // The request completed/errored immediately
+//       ucs_status_t s = UCS_PTR_STATUS(status);
+//       recvMemMessage->callback(nullptr, s);
+
+//       return s;
+//     } else {
+//       // The request will be handled by the callback
+//       recvMemMessage->setUcpRequest(status);
+//       memData->_registerInflightRequest(req);
+
+//       {
+//         std::lock_guard<std::mutex> lock(memData->_mutex);
+//         memData->_recvMemMessageMap.emplace(req.get(), recvMemMessage);
+//       }
+
+//       return UCS_INPROGRESS;
+//     }
+//   } else {
+//     std::shared_ptr<Buffer> buf = memData->_allocators.at(UCS_MEMORY_TYPE_HOST)(length);
+//     if (length > 0) memcpy(buf->data(), data, length);
+
+//     if (req->_enablePythonFuture)
+//       ucxx_trace_req_f(ownerString.c_str(),
+//                        nullptr,
+//                        "memRecv eager",
+//                        "ep: %p, buffer %p, size %lu, future %p, future handle %p, recvCallback",
+//                        ep,
+//                        buf->data(),
+//                        length,
+//                        req->_future.get(),
+//                        req->_future->getHandle());
+//     else
+//       ucxx_trace_req_f(ownerString.c_str(),
+//                        nullptr,
+//                        "memRecv eager",
+//                        "ep: %p, buffer %p, size %lu, recvCallback",
+//                        ep,
+//                        buf->data(),
+//                        length);
+
+//     internal::RecvMemMessage recvMemMessage(memData, ep, req, buf);
+//     recvMemMessage.callback(nullptr, UCS_OK);
+//     return UCS_OK;
+//   }
+// }
+
+void RequestMem::memPutCallback(void* request, ucs_status_t status, void* arg)
+{
+  Request* req = reinterpret_cast<Request*>(arg);
+  ucxx_trace_req_f(req->getOwnerString().c_str(), request, "memSend", "memPutCallback");
+  return req->callback(request, status);
+}
+
+void RequestMem::memGetCallback(void* request, ucs_status_t status, void* arg)
+{
+  Request* req = reinterpret_cast<Request*>(arg);
+  ucxx_trace_req_f(req->getOwnerString().c_str(), request, "memRecv", "memGetCallback");
+  return req->callback(request, status);
+}
+
+void RequestMem::request()
+{
+  ucp_request_param_t param = {.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                                               UCP_OP_ATTR_FIELD_FLAGS |
+                                               UCP_OP_ATTR_FIELD_USER_DATA,
+                               .flags     = UCP_AM_SEND_FLAG_REPLY,
+                               .datatype  = ucp_dt_make_contig(1),
+                               .user_data = this};
+
+  void* request = nullptr;
+
+  if (_delayedSubmission->_send) {
+    param.cb.send = memPutCallback;
+    request       = ucp_put_nbx(_endpoint->getHandle(),
+                          _delayedSubmission->_buffer,
+                          _delayedSubmission->_length,
+                          _remote_addr,
+                          _rkey,
+                          &param);
+
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+    _request = request;
+  } else {
+    param.cb.send = memGetCallback;
+    request       = ucp_get_nbx(_endpoint->getHandle(),
+                          _delayedSubmission->_buffer,
+                          _delayedSubmission->_length,
+                          _remote_addr,
+                          _rkey,
+                          &param);
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(_mutex);
+  _request = request;
+}
+
+void RequestMem::populateDelayedSubmission()
+{
+  request();
+
+  if (_enablePythonFuture)
+    ucxx_trace_req_f(_ownerString.c_str(),
+                     _request,
+                     _operationName.c_str(),
+                     "buffer %p, size %lu, future %p, future handle %p, populateDelayedSubmission",
+                     _delayedSubmission->_buffer,
+                     _delayedSubmission->_length,
+                     _future.get(),
+                     _future->getHandle());
+  else
+    ucxx_trace_req_f(_ownerString.c_str(),
+                     _request,
+                     _operationName.c_str(),
+                     "buffer %p, size %lu, populateDelayedSubmission",
+                     _delayedSubmission->_buffer,
+                     _delayedSubmission->_length);
+
+  process();
+}
+
+}  // namespace ucxx

--- a/cpp/src/request_mem.cpp
+++ b/cpp/src/request_mem.cpp
@@ -55,7 +55,9 @@ RequestMem::RequestMem(std::shared_ptr<Endpoint> endpoint,
   : Request(endpoint,
             std::make_shared<DelayedSubmission>(send, buffer, length, 0),
             std::string(send ? "memSend" : "memRecv"),
-            enablePythonFuture)
+            enablePythonFuture),
+    _remote_addr(remote_addr),
+    _rkey(rkey)
 {
   if (_endpoint == nullptr)
     throw ucxx::Error("An endpoint is required to perform remote memory put/get messages");


### PR DESCRIPTION
This PR is a work in progress.

This PR adds support for 2 new UCX functions: `ucp_get_nbx` and `ucp_put_nbx`. The implementation follows the pattern established by the tagged send/receive functions.

There is still a lot of commented out code and no tests have been added. The new functions have only been tested locally in a feature branch for MRC.