### PR TITLE
handle more RAPIDS version formats in update-version.sh, refactor dependencies.yaml

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -53,10 +53,9 @@ DEPENDENCIES=(
   rmm
 )
 for DEP in "${DEPENDENCIES[@]}"; do
-  for FILE in dependencies.yaml conda/environments/*.yaml; do
-    sed_runner "/-.* ${DEP}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}\.*/g" ${FILE};
-  done
-  sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}\.*\"/g" python/pyproject.toml;
+  for FILE in dependencies.yaml conda/environments/*.yaml python/pyproject.toml; do
+    sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*/g" "${FILE}"
+  done;
 done
 
 # rapids-cmake version

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -15,13 +15,14 @@ dependencies:
 - cuda-version=11.8
 - cudatoolkit
 - cudf==24.4.*
-- cupy
+- cupy>=12.0.0
 - cxx-compiler
 - cython>=3.0.0
 - dask
 - dask-cuda==24.4.*
 - dask-cudf==24.4.*
 - distributed
+- doxygen=1.10.0
 - fmt>=10.1.1,<11
 - gmock>=1.13.0
 - gtest>=1.13.0

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -15,13 +15,14 @@ dependencies:
 - cuda-cudart-dev
 - cuda-version=12.0
 - cudf==24.4.*
-- cupy
+- cupy>=12.0.0
 - cxx-compiler
 - cython>=3.0.0
 - dask
 - dask-cuda==24.4.*
 - dask-cudf==24.4.*
 - distributed
+- doxygen=1.10.0
 - fmt>=10.1.1,<11
 - gmock>=1.13.0
 - gtest>=1.13.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -12,10 +12,13 @@ files:
       - cuda
       - cuda_version
       - dev
+      - docs
       - py_version
       - run_python
       - test_cpp
       - test_python
+      - depends_on_cupy
+      - depends_on_cudf
   test_cpp:
     output: none
     includes:
@@ -27,10 +30,17 @@ files:
       - cuda_version
       - py_version
       - test_python
+      - depends_on_cupy
+      - depends_on_cudf
   checks:
     output: none
     includes:
       - checks
+      - py_version
+  docs:
+    output: none
+    includes:
+      - docs
       - py_version
   py_build:
     output: pyproject
@@ -54,6 +64,8 @@ files:
       key: test
     includes:
       - test_python
+      - depends_on_cupy
+      - depends_on_cudf
 channels:
   - rapidsai
   - rapidsai-nightly
@@ -76,18 +88,30 @@ dependencies:
           - spdlog>=1.12.0,<1.13
   build_python:
     common:
+      - output_types: [conda]
+        packages:
+          - &rmm_conda rmm==24.4.*
       - output_types: [conda, requirements, pyproject]
         packages:
           - *cmake_ver
           - cython>=3.0.0
           - ninja
-          - rmm==24.4.*
       - output_types: conda
         packages:
           - scikit-build-core>=0.7.0
       - output_types: [requirements, pyproject]
         packages:
           - scikit-build-core[pyproject]>=0.7.0
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix: {cuda: "12.*"}
+            packages:
+              - rmm-cu12==24.4.*
+          - matrix: {cuda: "11.*"}
+            packages:
+              - rmm-cu11==24.4.*
+          - {matrix: null, packages: [*rmm_conda]}
   checks:
     common:
       - output_types: [conda, requirements]
@@ -144,6 +168,13 @@ dependencies:
           - autoconf
           # UCXX Build
           - pkg-config
+          # Docs Build
+          - &doxygen doxygen=1.10.0 # pre-commit hook needs a specific version.
+  docs:
+    common:
+      - output_types: [conda]
+        packages:
+          - *doxygen
   py_version:
     specific:
       - output_types: conda
@@ -180,11 +211,45 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - cloudpickle
-          - cudf==24.4.*
-          - cupy
           - dask
           - distributed
           - numba>=0.57.1
           - pytest
           - pytest-asyncio
           - pytest-rerunfailures
+  depends_on_cupy:
+    common:
+      - output_types: conda
+        packages:
+          - cupy>=12.0.0
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix: {cuda: "12.*"}
+            packages:
+              - cupy-cuda12x>=12.0.0
+          - matrix: {cuda: "11.*"}
+            packages:
+              - cupy-cuda11x>=12.0.0
+          - {matrix: null, packages: [cupy-cuda11x>=12.0.0]}
+  depends_on_cudf:
+    common:
+      - output_types: conda
+        packages:
+          - &cudf_conda cudf==24.4.*
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          # This index is needed for rmm, cubinlinker, ptxcompiler.
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix: {cuda: "12.*"}
+            packages:
+              - cudf-cu12==24.4.*
+          - matrix: {cuda: "11.*"}
+            packages:
+              - cudf-cu11==24.4.*
+          - {matrix: null, packages: [*cudf_conda]}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 test = [
     "cloudpickle",
     "cudf==24.4.*",
-    "cupy",
+    "cupy-cuda11x>=12.0.0",
     "dask",
     "distributed",
     "numba>=0.57.1",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/13.

Updates `update-version.sh` to correctly handle RAPIDS dependencies like `cudf-cu12==24.2.*`.

This also pulls in some dependency refactoring originally added in #161, which allows greater use of dependencies.yaml globs (and therefore less maintenance effort to support new CUDA versions).

### How I tested this

The portability of this updated `sed` command was tested here: https://github.com/rapidsai/cudf/pull/14825#issuecomment-1904735849.

In this repo, I ran the following:

```shell
./ci/release/update-version.sh '0.36.00'
git diff

./ci/release/update-version.sh '0.37.00
git diff
```

Confirmed that that first `git diff` changed all the things I expected, and that second one showed 0 changes.