### PR TITLE
Forward-merge branch-0.36 to branch-0.37

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -98,6 +98,7 @@ build-dir = "build/{wheel_tag}"
 cmake.build-type = "Release"
 cmake.minimum-version = "3.26.4"
 ninja.make-fallback = true
+sdist.exclude = ["*tests*"]
 sdist.reproducible = true
 wheel.packages = ["ucxx"]
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.36` that creates a PR to keep `branch-0.37` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.