### PR TITLE
Pin Distributed dev mode installed in CI

### DIFF
--- a/ci/test_common.sh
+++ b/ci/test_common.sh
@@ -166,7 +166,7 @@ install_distributed_dev_mode() {
   # to run non-public API tests in CI.
 
   rapids-logger "Install Distributed in developer mode"
-  git clone https://github.com/dask/distributed /tmp/distributed
+  git clone https://github.com/dask/distributed /tmp/distributed -b 2024.1.1
   pip install -e /tmp/distributed
   # `pip install -e` removes files under `distributed` but not the directory, later
   # causing failures to import modules.


### PR DESCRIPTION
We are currently still pinned to Dask/Distributed 2024.1.1 and discussions on if and how to unpin for RAPIDS 24.04/UCXX 0.37 are still ongoing. Meanwhile, we must install a version of Distributed that is compatible with the Dask version installed.