### PR TITLE
Fix `ucxx` constraints

### DIFF
--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -200,6 +200,11 @@ outputs:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_py{{ python }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:
+        {% if cuda_major == "11" %}
+        - {{ compiler('cuda11') }}
+        {% else %}
+        - {{ compiler('cuda') }}
+        {% endif %}
         - ucx
     requirements:
       build:

--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -206,7 +206,9 @@ outputs:
         - cmake
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        {% if cuda_major != "11" %}
+        {% if cuda_major == "11" %}
+        - {{ compiler('cuda11') }} ={{ cuda_version }}
+        {% else %}
         - {{ compiler('cuda') }}
         {% endif %}
         - cuda-version ={{ cuda_version }}


### PR DESCRIPTION
`ucxx`'s CUDA compiler dependency added a `cuda-version` constraint at runtime that meant packages could only be installed with the same CUDA version `ucxx` was built with or newer. As a result CUDA 12.2 builds of `ucxx` required that CUDA 12.2+ would be used at runtime

However as we use [CUDA Compatibility]( https://docs.nvidia.com/deploy/cuda-compatibility/index.html ) in RAPIDS, we know that even if we built with CUDA 12.2, we can still use packages for other CUDA 12.x

This was largely handled for other dependencies as part of PR ( https://github.com/rapidsai/ucxx/pull/161 ). However this wasn't handled for `ucxx`, which was likely in part as it was handling the CUDA compiler dependency differently from the other packages here. More history about `ucxx`'s CUDA compiler dependency in PR: https://github.com/rapidsai/ucxx/pull/108

This change aligns how CUDA compiler is handled across packages to make this more consistent. Also it ignores the CUDA compiler constraints added at runtime. In all cases the packages handle this themselves by requiring `cuda-version` (properly constrained) and when CUDA 11 is concerned they add `cudatoolkit`

Thus this change should fix CI issues that were seen due to this overly constrained `cuda-version` by relaxing that constraint