### PR TITLE
Make libnuma optional

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -68,6 +68,7 @@ elif [[ ${package_name} == "ucxx" ]]; then
     LIBUCM=$(unzip -l $WHL | awk 'match($4, /libucm-[^\.]+\./) { print substr($4, RSTART) }')
     LIBUCT=$(unzip -l $WHL | awk 'match($4, /libuct-[^\.]+\./) { print substr($4, RSTART) }')
     LIBUCS=$(unzip -l $WHL | awk 'match($4, /libucs-[^\.]+\./) { print substr($4, RSTART) }')
+    LIBNUMA=$(unzip -l $WHL | awk 'match($4, /libnuma-[^\.]+\./) { print substr($4, RSTART) }')
 
     # Extract the libraries that have already been patched in by auditwheel
     mkdir -p repair_dist/ucxx_${RAPIDS_PY_CUDA_SUFFIX}.libs/ucx
@@ -104,6 +105,9 @@ elif [[ ${package_name} == "ucxx" ]]; then
             patchelf --replace-needed libuct.so.0 $LIBUCT $f
             patchelf --replace-needed libucs.so.0 $LIBUCS $f
             patchelf --replace-needed libucm.so.0 $LIBUCM $f
+            if [[ -z "$LIBNUMA" ]]; then
+                patchelf --replace-needed libnuma.so.1 $LIBNUMA $f
+            fi
             patchelf --add-rpath '$ORIGIN/..' $f
         fi
     done

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -105,7 +105,7 @@ elif [[ ${package_name} == "ucxx" ]]; then
             patchelf --replace-needed libuct.so.0 $LIBUCT $f
             patchelf --replace-needed libucs.so.0 $LIBUCS $f
             patchelf --replace-needed libucm.so.0 $LIBUCM $f
-            if [[ -z "$LIBNUMA" ]]; then
+            if [[ -n "$LIBNUMA" ]]; then
                 patchelf --replace-needed libnuma.so.1 $LIBNUMA $f
             fi
             patchelf --add-rpath '$ORIGIN/..' $f

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -68,7 +68,6 @@ elif [[ ${package_name} == "ucxx" ]]; then
     LIBUCM=$(unzip -l $WHL | awk 'match($4, /libucm-[^\.]+\./) { print substr($4, RSTART) }')
     LIBUCT=$(unzip -l $WHL | awk 'match($4, /libuct-[^\.]+\./) { print substr($4, RSTART) }')
     LIBUCS=$(unzip -l $WHL | awk 'match($4, /libucs-[^\.]+\./) { print substr($4, RSTART) }')
-    LIBNUMA=$(unzip -l $WHL | awk 'match($4, /libnuma-[^\.]+\./) { print substr($4, RSTART) }')
 
     # Extract the libraries that have already been patched in by auditwheel
     mkdir -p repair_dist/ucxx_${RAPIDS_PY_CUDA_SUFFIX}.libs/ucx
@@ -105,7 +104,6 @@ elif [[ ${package_name} == "ucxx" ]]; then
             patchelf --replace-needed libuct.so.0 $LIBUCT $f
             patchelf --replace-needed libucs.so.0 $LIBUCS $f
             patchelf --replace-needed libucm.so.0 $LIBUCM $f
-            patchelf --replace-needed libnuma.so.1 $LIBNUMA $f
             patchelf --add-rpath '$ORIGIN/..' $f
         fi
     done


### PR DESCRIPTION
libucx 1.15 made libnuma optional. Only include libnuma in the wheel if our libucx depends on it.