### PR TITLE
Register custom marks with pytest.

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
@@ -27,8 +27,6 @@ import ucxx
 import distributed_ucxx  # noqa: E402
 from distributed_ucxx.utils_test import gen_test
 
-pytestmark = pytest.mark.gpu
-
 try:
     HOST = ucxx.get_address()
 except Exception:

--- a/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx_config.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx_config.py
@@ -13,8 +13,6 @@ from distributed.utils_test import popen
 from distributed_ucxx.ucxx import _prepare_ucx_config
 from distributed_ucxx.utils_test import gen_test
 
-pytestmark = pytest.mark.gpu
-
 try:
     HOST = get_ip()
 except Exception:

--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -118,3 +118,9 @@ exclude = [
 
 [tool.setuptools.dynamic]
 version = {file = "distributed_ucxx/VERSION"}
+
+[tool.pytest.ini_options]
+markers = [
+    "gpu",
+    "slow",
+]

--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -121,6 +121,5 @@ version = {file = "distributed_ucxx/VERSION"}
 
 [tool.pytest.ini_options]
 markers = [
-    "gpu",
     "slow",
 ]


### PR DESCRIPTION
This PR fixes some warnings in tests:

```
=============================== warnings summary ===============================
python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py:30
  /__w/ucxx/ucxx/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py:30: PytestUnknownMarkWarning: Unknown pytest.mark.gpu - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytestmark = pytest.mark.gpu

python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py:226
  /__w/ucxx/ucxx/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py:226: PytestUnknownMarkWarning: Unknown pytest.mark.slow - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.slow

python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py:285
  /__w/ucxx/ucxx/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py:285: PytestUnknownMarkWarning: Unknown pytest.mark.slow - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.slow

python/distributed-ucxx/distributed_ucxx/tests/test_ucxx_config.py:16
  /__w/ucxx/ucxx/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx_config.py:16: PytestUnknownMarkWarning: Unknown pytest.mark.gpu - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytestmark = pytest.mark.gpu
```
