### PR TITLE
Update script input name

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -65,7 +65,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.04
     with:
       build_type: pull-request
-      test_script: "ci/test_python_distributed.sh"
+      script: "ci/test_python_distributed.sh"
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
   wheel-build-ucxx:
     needs: checks

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.04
     with:
       build_type: nightly
-      test_script: "ci/test_python_distributed.sh"
+      script: "ci/test_python_distributed.sh"
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}


### PR DESCRIPTION
This PR updates the script inputs in the relevant workflows from `build_script` and `test_script` to `script`. 

Depends on https://github.com/rapidsai/shared-workflows/pull/191
