### PR TITLE
Fix license name

### DIFF
--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -13,7 +13,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache-2.0" }
+license = { text = "Apache 2.0" }
 requires-python = ">=3.9"
 dependencies = [
     "numba>=0.57.1",


### PR DESCRIPTION
Our scanner expects this license to use space instead of hyphen.