### PR TITLE
Migrate to `{{ stdlib("c") }}`

### DIFF
--- a/conda/recipes/ucxx/conda_build_config.yaml
+++ b/conda/recipes/ucxx/conda_build_config.yaml
@@ -10,7 +10,10 @@ cuda_compiler:
 cuda11_compiler:
   - nvcc
 
-sysroot_linux_64:
+c_stdlib:
+  - sysroot
+
+c_stdlib_version:
   - "2.17"
 
 cmake:

--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     {% endif %}
     - cuda-version ={{ cuda_version }}
     - ninja
-    - sysroot_{{ target_platform }}
+    - {{ stdlib("c") }}
   host:
     {% if cuda_major != "11" %}
     - cuda-cudart-dev
@@ -79,7 +79,7 @@ outputs:
         - {{ compiler('cuda') }}
         {% endif %}
         - cuda-version ={{ cuda_version }}
-        - sysroot_{{ target_platform }}
+        - {{ stdlib("c") }}
         - cmake
         - ninja
       host:
@@ -170,7 +170,7 @@ outputs:
         - {{ compiler('cuda') }}
         {% endif %}
         - cuda-version ={{ cuda_version }}
-        - sysroot_{{ target_platform }}
+        - {{ stdlib("c") }}
         - cmake
         - ninja
       host:
@@ -216,7 +216,7 @@ outputs:
         {% endif %}
         - cuda-version ={{ cuda_version }}
         - ninja
-        - sysroot_{{ target_platform }}
+        - {{ stdlib("c") }}
       host:
         - python
         - pip


### PR DESCRIPTION
The `sysroot*` syntax is getting phased out (conda-forge/conda-forge.github.io#2102).
The recommendation is to move to `{{ stdlib("c") }}`.

Ref https://github.com/rapidsai/build-planning/issues/39