### PR TITLE
Use UCX wheels

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -18,8 +18,6 @@ commit=$(git rev-parse HEAD)
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
-libucx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="${RAPIDS_PY_CUDA_SUFFIX}" rapids-get-pr-wheel-artifact ucx-wheels 1 cpp)
-
 # This is the version of the suffix with a preceding hyphen. It's used
 # everywhere except in the final wheel name.
 PACKAGE_CUDA_SUFFIX="-${RAPIDS_PY_CUDA_SUFFIX}"
@@ -59,7 +57,7 @@ if [[ ${package_name} == "distributed-ucxx" ]]; then
     RAPIDS_PY_WHEEL_NAME="distributed_ucxx_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 ${package_dir}/dist
 elif [[ ${package_name} == "ucxx" ]]; then
     SKBUILD_CMAKE_ARGS="-DUCXX_ENABLE_RMM=ON" \
-        python -m pip wheel "${package_dir}"/ -w "${package_dir}"/dist -vvv --no-deps --disable-pip-version-check --find-links ${libucx_wheelhouse}
+        python -m pip wheel "${package_dir}"/ -w "${package_dir}"/dist -vvv --no-deps --disable-pip-version-check
 
     python -m auditwheel repair -w ${package_dir}/final_dist --exclude "libucp.so.0" ${package_dir}/dist/*
 

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -18,7 +18,6 @@ commit=$(git rev-parse HEAD)
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
-librmm_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="${RAPIDS_PY_CUDA_SUFFIX}" rapids-get-pr-wheel-artifact rmm 1529 cpp)
 libucx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="${RAPIDS_PY_CUDA_SUFFIX}" rapids-get-pr-wheel-artifact ucx-wheels 1 cpp)
 
 # This is the version of the suffix with a preceding hyphen. It's used
@@ -60,7 +59,7 @@ if [[ ${package_name} == "distributed-ucxx" ]]; then
     RAPIDS_PY_WHEEL_NAME="distributed_ucxx_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 ${package_dir}/dist
 elif [[ ${package_name} == "ucxx" ]]; then
     SKBUILD_CMAKE_ARGS="-DUCXX_ENABLE_RMM=ON" \
-        python -m pip wheel "${package_dir}"/ -w "${package_dir}"/dist -vvv --no-deps --disable-pip-version-check --find-links ${librmm_wheelhouse} --find-links ${libucx_wheelhouse}
+        python -m pip wheel "${package_dir}"/ -w "${package_dir}"/dist -vvv --no-deps --disable-pip-version-check --find-links ${libucx_wheelhouse}
 
     python -m auditwheel repair -w ${package_dir}/final_dist --exclude "libucp.so.0" ${package_dir}/dist/*
 

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -6,8 +6,15 @@ set -euo pipefail
 package_name=$1
 package_dir=$2
 
+# Clear out system ucx files to ensure that we're getting ucx from the wheel.
+rm -rf /usr/lib64/ucx
+rm -rf /usr/lib64/libuc*
+
 source rapids-configure-sccache
 source rapids-date-string
+
+librmm_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="${RAPIDS_PY_CUDA_SUFFIX}" rapids-get-pr-wheel-artifact rmm 1529 cpp)
+libucx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="${RAPIDS_PY_CUDA_SUFFIX}" rapids-get-pr-wheel-artifact ucx-wheels 1 cpp)
 
 version=$(rapids-generate-version)
 commit=$(git rev-parse HEAD)
@@ -52,90 +59,9 @@ if [[ ${package_name} == "distributed-ucxx" ]]; then
     RAPIDS_PY_WHEEL_NAME="distributed_ucxx_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 ${package_dir}/dist
 elif [[ ${package_name} == "ucxx" ]]; then
     SKBUILD_CMAKE_ARGS="-DUCXX_ENABLE_RMM=ON" \
-        python -m pip wheel "${package_dir}"/ -w "${package_dir}"/dist -vvv --no-deps --disable-pip-version-check
+        python -m pip wheel "${package_dir}"/ -w "${package_dir}"/dist -vvv --no-deps --disable-pip-version-check --find-links ${librmm_wheelhouse} --find-links ${libucx_wheelhouse}
 
     python -m auditwheel repair -w ${package_dir}/final_dist ${package_dir}/dist/*
-
-    # Auditwheel rewrites dynamic libraries that are referenced at link time in the
-    # package. However, UCX loads a number of sub-libraries at runtime via dlopen;
-    # these are not picked up by auditwheel. Since we have a priori knowledge of
-    # what these libraries are, we mimic the behaviour of auditwheel by using the
-    # same hash-based uniqueness scheme and rewriting the link paths.
-
-    WHL=$(realpath ${package_dir}/final_dist/ucxx*manylinux*.whl)
-
-    # first grab the auditwheel hashes for libuc{tms}
-    LIBUCM=$(unzip -l $WHL | awk 'match($4, /libucm-[^\.]+\./) { print substr($4, RSTART) }')
-    LIBUCT=$(unzip -l $WHL | awk 'match($4, /libuct-[^\.]+\./) { print substr($4, RSTART) }')
-    LIBUCS=$(unzip -l $WHL | awk 'match($4, /libucs-[^\.]+\./) { print substr($4, RSTART) }')
-
-    # Extract the libraries that have already been patched in by auditwheel
-    mkdir -p repair_dist/ucxx_${RAPIDS_PY_CUDA_SUFFIX}.libs/ucx
-    unzip $WHL "ucxx_${RAPIDS_PY_CUDA_SUFFIX}.libs/*.so*" -d repair_dist/
-
-    # Patch the RPATH to include ORIGIN for each library
-    pushd repair_dist/ucxx_${RAPIDS_PY_CUDA_SUFFIX}.libs
-    for f in libu*.so*
-    do
-        if [[ -f $f ]]; then
-            patchelf --add-rpath '$ORIGIN' $f
-        fi
-    done
-
-    popd
-
-    # Now copy in all the extra libraries that are only ever loaded at runtime
-    pushd repair_dist/ucxx_${RAPIDS_PY_CUDA_SUFFIX}.libs/ucx
-    if [[ -d /usr/lib64/ucx ]]; then
-        cp -P /usr/lib64/ucx/* .
-    elif [[ -d /usr/lib/ucx ]]; then
-        cp -P /usr/lib/ucx/* .
-    else
-        echo "Could not find ucx libraries"
-        exit 1
-    fi
-
-    # we link against <python>/lib/site-packages/ucxx_${RAPIDS_PY_CUDA_SUFFIX}.lib/libuc{ptsm}
-    # we also amend the rpath to search one directory above to *find* libuc{tsm}
-    for f in libu*.so*
-    do
-        # Avoid patching symlinks, which is redundant
-        if [[ ! -L $f ]]; then
-            patchelf --replace-needed libuct.so.0 $LIBUCT $f
-            patchelf --replace-needed libucs.so.0 $LIBUCS $f
-            patchelf --replace-needed libucm.so.0 $LIBUCM $f
-            patchelf --add-rpath '$ORIGIN/..' $f
-        fi
-    done
-
-    # Bring in cudart as well. To avoid symbol collision with other libraries e.g.
-    # cupy we mimic auditwheel by renaming the libraries to include the hashes of
-    # their names. Since there will typically be a chain of symlinks
-    # libcudart.so->libcudart.so.X->libcudart.so.X.Y.Z we need to follow the chain
-    # and rename all of them.
-
-    find /usr/local/cuda/ -name "libcudart*.so*" | xargs cp -P -t .
-    src=libcudart.so
-    hash=$(sha256sum ${src} | awk '{print substr($1, 0, 8)}')
-    target=$(basename $(readlink -f ${src}))
-
-    mv ${target} ${target/libcudart/libcudart-${hash}}
-    while readlink ${src} > /dev/null; do
-        target=$(readlink ${src})
-        ln -s ${target/libcudart/libcudart-${hash}} ${src/libcudart/libcudart-${hash}}
-        rm -f ${src}
-        src=${target}
-    done
-
-    to_rewrite=$(ldd libuct_cuda.so | awk '/libcudart/ { print $1 }')
-    patchelf --replace-needed ${to_rewrite} libcudart-${hash}.so libuct_cuda.so
-    patchelf --add-rpath '$ORIGIN' libuct_cuda.so
-
-    popd
-
-    pushd repair_dist
-    zip -r $WHL ucxx_${RAPIDS_PY_CUDA_SUFFIX}.libs/
-    popd
 
     RAPIDS_PY_WHEEL_NAME="ucxx_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 ${package_dir}/final_dist
 else

--- a/ci/test_wheel_distributed_ucxx.sh
+++ b/ci/test_wheel_distributed_ucxx.sh
@@ -10,9 +10,8 @@ source "$(dirname "$0")/test_common.sh"
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
-libucx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="${RAPIDS_PY_CUDA_SUFFIX}" rapids-get-pr-wheel-artifact ucx-wheels 1 cpp)
 ucxx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="ucxx_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./local-ucxx-dep)
-python -m pip install "${package_name}-${RAPIDS_PY_CUDA_SUFFIX}[test]>=0.0.0a0" --find-links dist/ --find-links "${libucx_wheelhouse}" --find-links "${ucxx_wheelhouse}"
+python -m pip install "${package_name}-${RAPIDS_PY_CUDA_SUFFIX}[test]>=0.0.0a0" --find-links dist/ --find-links "${ucxx_wheelhouse}"
 
 rapids-logger "Distributed Tests"
 

--- a/ci/test_wheel_distributed_ucxx.sh
+++ b/ci/test_wheel_distributed_ucxx.sh
@@ -7,15 +7,12 @@ package_name="distributed_ucxx"
 
 source "$(dirname "$0")/test_common.sh"
 
-mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+
 RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
-
-# Install previously built ucxx wheel
-ucxx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="ucxx_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./local-ucxx-dep)
 libucx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="${RAPIDS_PY_CUDA_SUFFIX}" rapids-get-pr-wheel-artifact ucx-wheels 1 cpp)
-
-python -m pip install "${package_name}-${RAPIDS_PY_CUDA_SUFFIX}[test]" --find-links dist/ --find-links "${libucx_wheelhouse}" --find-links "${ucxx_wheelhouse}"
+ucxx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="ucxx_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./local-ucxx-dep)
+python -m pip install "${package_name}-${RAPIDS_PY_CUDA_SUFFIX}[test]>=0.0.0a0" --find-links dist/ --find-links "${libucx_wheelhouse}" --find-links "${ucxx_wheelhouse}"
 
 rapids-logger "Distributed Tests"
 

--- a/ci/test_wheel_ucxx.sh
+++ b/ci/test_wheel_ucxx.sh
@@ -7,13 +7,11 @@ package_name="ucxx"
 
 source "$(dirname "$0")/test_common.sh"
 
-mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+
 RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
-
 libucx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="${RAPIDS_PY_CUDA_SUFFIX}" rapids-get-pr-wheel-artifact ucx-wheels 1 cpp)
-
-python -m pip install "${package_name}-${RAPIDS_PY_CUDA_SUFFIX}[test]" --find-links dist/ --find-links "${libucx_wheelhouse}"
+python -m pip install "${package_name}-${RAPIDS_PY_CUDA_SUFFIX}[test]>=0.0.0a0" --find-links dist/ --find-links "${libucx_wheelhouse}"
 
 rapids-logger "Python Core Tests"
 run_py_tests

--- a/ci/test_wheel_ucxx.sh
+++ b/ci/test_wheel_ucxx.sh
@@ -3,16 +3,17 @@
 
 set -euo pipefail
 
-PROJECT_NAME="ucxx"
+package_name="ucxx"
 
 source "$(dirname "$0")/test_common.sh"
 
 mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
-RAPIDS_PY_WHEEL_NAME="${PROJECT_NAME}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
+RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
 
-# echo to expand wildcard before adding `[extra]` requires for pip
-python -m pip install $(echo ./dist/${PROJECT_NAME}*.whl)[test]
+libucx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="${RAPIDS_PY_CUDA_SUFFIX}" rapids-get-pr-wheel-artifact ucx-wheels 1 cpp)
+
+python -m pip install "${package_name}-${RAPIDS_PY_CUDA_SUFFIX}[test]" --find-links dist/ --find-links "${libucx_wheelhouse}"
 
 rapids-logger "Python Core Tests"
 run_py_tests

--- a/ci/test_wheel_ucxx.sh
+++ b/ci/test_wheel_ucxx.sh
@@ -10,8 +10,7 @@ source "$(dirname "$0")/test_common.sh"
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
-libucx_wheelhouse=$(RAPIDS_PY_WHEEL_NAME="${RAPIDS_PY_CUDA_SUFFIX}" rapids-get-pr-wheel-artifact ucx-wheels 1 cpp)
-python -m pip install "${package_name}-${RAPIDS_PY_CUDA_SUFFIX}[test]>=0.0.0a0" --find-links dist/ --find-links "${libucx_wheelhouse}"
+python -m pip install "${package_name}-${RAPIDS_PY_CUDA_SUFFIX}[test]>=0.0.0a0" --find-links dist/
 
 rapids-logger "Python Core Tests"
 run_py_tests

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -41,5 +41,5 @@ dependencies:
 - setuptools>=64.0.0
 - spdlog>=1.12.0,<1.13
 - tomli
-- ucx
+- ucx>=1.15.0
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -41,5 +41,5 @@ dependencies:
 - setuptools>=64.0.0
 - spdlog>=1.12.0,<1.13
 - tomli
-- ucx
+- ucx>=1.15.0
 name: all_cuda-122_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -61,6 +61,7 @@ files:
       table: build-system
     includes:
       - build_python_ucxx
+      - ucx_wheel
       - depends_on_rmm
   py_run_ucxx:
     output: pyproject
@@ -69,6 +70,7 @@ files:
       table: project
     includes:
       - run_python_ucxx
+      - ucx_wheel
       - depends_on_rmm
   py_test_ucxx:
     output: pyproject
@@ -123,6 +125,12 @@ dependencies:
           - librmm==24.6.*
           - ninja
           - spdlog>=1.12.0,<1.13
+  ucx_wheel:
+    common:
+      - output_types: [requirements, pyproject]
+        packages:
+          # TODO: Figure out versioning
+          - libucx
   build_python_ucxx:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -130,7 +130,7 @@ dependencies:
       - output_types: [requirements, pyproject]
         packages:
           # TODO: Figure out versioning
-          - libucx
+          - libucx==1.14.1
   build_python_ucxx:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -20,9 +20,10 @@ files:
       - test_cpp
       - test_python_ucxx
       - test_python_distributed_ucxx
+      - depends_on_cudf
       - depends_on_cupy
       - depends_on_rmm
-      - depends_on_cudf
+      - depends_on_ucx_run
   test_cpp:
     output: none
     includes:
@@ -61,8 +62,8 @@ files:
       table: build-system
     includes:
       - build_python_ucxx
-      - ucx_wheel
       - depends_on_rmm
+      - depends_on_ucx_build
   py_run_ucxx:
     output: pyproject
     pyproject_dir: python
@@ -70,8 +71,8 @@ files:
       table: project
     includes:
       - run_python_ucxx
-      - ucx_wheel
       - depends_on_rmm
+      - depends_on_ucx_run
   py_test_ucxx:
     output: pyproject
     pyproject_dir: python
@@ -125,12 +126,6 @@ dependencies:
           - librmm==24.6.*
           - ninja
           - spdlog>=1.12.0,<1.13
-  ucx_wheel:
-    common:
-      - output_types: [requirements, pyproject]
-        packages:
-          # TODO: Figure out versioning
-          - libucx==1.14.1
   build_python_ucxx:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -242,9 +237,6 @@ dependencies:
         packages:
           - &numpy numpy>=1.23,<2.0a0
           - pynvml>=11.4.1
-      - output_types: [conda]
-        packages:
-          - ucx
   run_python_distributed_ucxx:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -348,3 +340,47 @@ dependencies:
             packages:
               - ucxx-cu11==0.38.*
           - {matrix: null, packages: [*ucxx_conda]}
+  depends_on_ucx_build:
+    common:
+      - output_types: conda
+        packages:
+          - &ucx_conda_build ucx==1.15.0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix: {cuda: "12.*"}
+            packages:
+              - libucx-cu12==1.15.0
+          - matrix: {cuda: "11.*"}
+            packages:
+              - libucx-cu11==1.15.0
+          - matrix: null
+            packages: 
+              - libucx==1.15.0
+  depends_on_ucx_run:
+    common:
+      - output_types: conda
+        packages:
+          - &ucx_conda_run ucx>=1.15.0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix: {cuda: "12.*"}
+            packages:
+              - libucx-cu12>=1.15.0
+          - matrix: {cuda: "11.*"}
+            packages:
+              - libucx-cu11>=1.15.0
+          - matrix: null
+            packages: 
+              - libucx>=1.15.0

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "scikit_build_core.build"
 requires = [
     "cmake>=3.26.4",
     "cython>=3.0.0",
+    "libucx",
     "ninja",
     "rmm==24.6.*",
     "scikit-build-core[pyproject]>=0.7.0",
@@ -22,6 +23,7 @@ authors = [
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.9"
 dependencies = [
+    "libucx",
     "numpy>=1.23,<2.0a0",
     "pynvml>=11.4.1",
     "rmm==24.6.*",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 requires = [
     "cmake>=3.26.4",
     "cython>=3.0.0",
-    "libucx",
+    "libucx==1.14.1",
     "ninja",
     "rmm==24.6.*",
     "scikit-build-core[pyproject]>=0.7.0",
@@ -23,7 +23,7 @@ authors = [
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.9"
 dependencies = [
-    "libucx",
+    "libucx==1.14.1",
     "numpy>=1.23,<2.0a0",
     "pynvml>=11.4.1",
     "rmm==24.6.*",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 requires = [
     "cmake>=3.26.4",
     "cython>=3.0.0",
-    "libucx==1.14.1",
+    "libucx==1.15.0",
     "ninja",
     "rmm==24.6.*",
     "scikit-build-core[pyproject]>=0.7.0",
@@ -23,7 +23,7 @@ authors = [
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.9"
 dependencies = [
-    "libucx==1.14.1",
+    "libucx>=1.15.0",
     "numpy>=1.23,<2.0a0",
     "pynvml>=11.4.1",
     "rmm==24.6.*",

--- a/python/ucxx/__init__.py
+++ b/python/ucxx/__init__.py
@@ -6,6 +6,17 @@
 import logging
 import os
 
+# If libucx was installed as a wheel, we must request it to load the library symbols.
+# Otherwise, we assume that the library was installed in a system path that ld can find.
+try:
+    import libucx
+except ModuleNotFoundError:
+    pass
+else:
+    libucx.load_library()
+    del libucx
+
+
 logger = logging.getLogger("ucx")
 
 # Notice, if we have to update environment variables we need to do it


### PR DESCRIPTION
This PR updates UCX to stop bundling UCX libraries, instead preferring to get them from the new UCX wheels that we are publishing from https://github.com/rapidsai/ucx-wheels.