### PR TITLE
fix tag reference in example

### DIFF
--- a/python/examples/basic.py
+++ b/python/examples/basic.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import argparse
@@ -224,12 +224,12 @@ def main():
         recv_bufs = recv_buffer_requests.py_buffers
     else:
         requests = [
-            listener_ep.tag_send(Array(send_bufs[0]), tag=ucx_api.UCXTag(0)),
-            listener_ep.tag_send(Array(send_bufs[1]), tag=ucx_api.UCXTag(1)),
-            listener_ep.tag_send(Array(send_bufs[2]), tag=ucx_api.UCXTag(2)),
-            ep.tag_recv(Array(recv_bufs[0]), tag=ucx_api.UCXTag(0)),
-            ep.tag_recv(Array(recv_bufs[1]), tag=ucx_api.UCXTag(1)),
-            ep.tag_recv(Array(recv_bufs[2]), tag=ucx_api.UCXTag(2)),
+            listener_ep.tag_send(Array(send_bufs[0]), tag=ucx_api.UCXXTag(0)),
+            listener_ep.tag_send(Array(send_bufs[1]), tag=ucx_api.UCXXTag(1)),
+            listener_ep.tag_send(Array(send_bufs[2]), tag=ucx_api.UCXXTag(2)),
+            ep.tag_recv(Array(recv_bufs[0]), tag=ucx_api.UCXXTag(0)),
+            ep.tag_recv(Array(recv_bufs[1]), tag=ucx_api.UCXXTag(1)),
+            ep.tag_recv(Array(recv_bufs[2]), tag=ucx_api.UCXXTag(2)),
         ]
 
         if args.asyncio_wait_future:
@@ -253,6 +253,8 @@ def main():
             xp.testing.assert_equal(recv_buf, send_buf)
         else:
             xp.testing.assert_array_equal(xp.asarray(recv_buf), send_buf)
+
+    print("Completed successfully")
 
 
 if __name__ == "__main__":

--- a/python/examples/basic.py
+++ b/python/examples/basic.py
@@ -254,8 +254,6 @@ def main():
         else:
             xp.testing.assert_array_equal(xp.asarray(recv_buf), send_buf)
 
-    print("Completed successfully")
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Running the example at `python/examples/basic.py` results in the following

```text
[1715298582.923398] [f059c9da14bb:1    :0]          parser.c:2033 UCX  WARN  unused environment variable: UCX_MEMTYPE_CACHE (maybe: UCX_MEMTYPE_CACHE?)
[1715298582.923398] [f059c9da14bb:1    :0]          parser.c:2033 UCX  WARN  (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
Traceback (most recent call last):
  File "/opt/work/./python/examples/basic.py", line 259, in <module>
    main()
  File "/opt/work/./python/examples/basic.py", line 227, in main
    listener_ep.tag_send(Array(send_bufs[0]), tag=ucx_api.UCXTag(0)),
AttributeError: module 'ucxx._lib.libucxx' has no attribute 'UCXTag'. Did you mean: 'UCXXTag'?
```

It looks to me like that suggestion is right, and that that class is callsed `UCXXTag`:

https://github.com/rapidsai/ucxx/blob/2195ceabf35b404b3ae6b09f784d1d312b4b6fce/python/ucxx/_lib/tag.pyx#L8

This PR proposes the following:

* fixing that reference
* adding a print statement at the end so that you know the example reached the end successfully without having to inspect the exit code of the process

## Notes for Reviewers

I found this because I was using this example to smoke test changes to the new ucx wheels: https://github.com/rapidsai/ucx-wheels/pull/5

### How I tested this

```shell
docker run \
    --rm \
    --gpus 1 \
    -v $(pwd):/opt/work \
    -w /opt/work \
    -it rapidsai/citestwheel:cuda12.2.2-ubuntu22.04-py3.10 \
    pip install 'ucxx-cu12==0.38.*,>=0.0.0a0' && python ./python/examples/basic.py
```
