### PR TITLE
remove system-installed UCX headers in wheel build environment

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -8,7 +8,16 @@ package_dir=$2
 
 # Clear out system ucx files to ensure that we're getting ucx from the wheel.
 rm -rf /usr/lib64/ucx
-rm -rf /usr/lib64/libuc*
+rm -rf /usr/lib64/libucm.*
+rm -rf /usr/lib64/libucp.*
+rm -rf /usr/lib64/libucs.*
+rm -rf /usr/lib64/libucs_signal.*
+rm -rf /usr/lib64/libuct.*
+
+rm -rf /usr/include/ucm
+rm -rf /usr/include/ucp
+rm -rf /usr/include/ucs
+rm -rf /usr/include/uct
 
 source rapids-configure-sccache
 source rapids-date-string


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/57.

Follow-up to #226.

Proposes the following changes for wheel builds:

* removing system-installed UCX *headers*
* making the code to remove system-installed UCX libraries a bit more specific
   - *(to minimize the risk of accidentally deleting some non-UCX thing who name matches the pattern `libuc*`)*

## Notes for Reviewers

Before applying similar changes to `ucx-py`, I noticed it being compiled with the system-installed headers but then linking against the libraries provided by the `libucx` wheels: https://github.com/rapidsai/ucx-py/pull/1041#discussion_r1596916903

This change should reduce the risk of that happening.

### How I tested this

Poked around the filesystem that `build_wheel.sh` runs in by pulling one of our standard wheel-building container images used in CI.

```shell
docker run \
    --rm \
    -v $(pwd):/opt/work \
    -w /opt/work \
    -it rapidsai/ci-wheel:cuda12.2.2-rockylinux8-py3.10 \
    bash

find /usr -type f -name 'libucm*'
# /usr/lib64/libucm.la
# /usr/lib64/libucm.a
# /usr/lib64/libucm.so.0.0.0
# /usr/lib64/ucx/libucm_cuda.a
# /usr/lib64/ucx/libucm_cuda.la
# /usr/lib64/ucx/libucm_cuda.so.0.0.0

find /usr -type d -name 'uct'
# /usr/include/uct
```