### PR TITLE
Update cuDF's `assert_eq` import

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
@@ -185,7 +185,7 @@ async def test_ping_pong_cudf(ucxx_loop, g):
     # *** ImportError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.11'
     # not found (required by python3.7/site-packages/pyarrow/../../../libarrow.so.12)
     cudf = pytest.importorskip("cudf")
-    from cudf.testing._utils import assert_eq
+    from cudf.testing import assert_eq
 
     cudf_obj = g(cudf)
 

--- a/python/ucxx/_lib_async/tests/test_custom_send_recv.py
+++ b/python/ucxx/_lib_async/tests/test_custom_send_recv.py
@@ -118,7 +118,7 @@ async def test_send_recv_cudf(event_loop, g):
     typ = type(msg)
     res = typ.deserialize(ucx_header, cudf_buffer)
 
-    from cudf.testing._utils import assert_eq
+    from cudf.testing import assert_eq
 
     assert_eq(res, msg)
     await uu.comm.ep.close()

--- a/python/ucxx/_lib_async/tests/test_send_recv_two_workers.py
+++ b/python/ucxx/_lib_async/tests/test_send_recv_two_workers.py
@@ -94,7 +94,7 @@ def client(port, func, comm_api):
     if isinstance(rx_cuda_obj, cupy.ndarray):
         cupy.testing.assert_allclose(rx_cuda_obj, pure_cuda_obj)
     else:
-        from cudf.testing._utils import assert_eq
+        from cudf.testing import assert_eq
 
         assert_eq(rx_cuda_obj, pure_cuda_obj)
 


### PR DESCRIPTION
https://github.com/rapidsai/cudf/pull/16063 has updated the import location of `assert_eq` to the public `cudf.testing.assert_eq`, this change updates imports accordingly.