### PR TITLE
Fix tests on new Distributed releases

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/tests/test_nanny.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_nanny.py
@@ -21,4 +21,4 @@ async def test_nanny_closed_by_keyboard_interrupt(ucxx_loop):
         ) as n:
             await n.process.stopped.wait()
             # Check that the scheduler has been notified about the closed worker
-            assert "remove-worker" in str(s.events)
+            assert "remove-worker" in str(s.get_events())


### PR DESCRIPTION
Latest changes in Distributed have broken `test_nanny_closed_by_keyboard_interrupt` as it used a member attribute that is now supposed to be accessed via a method, the test is now updated to rely on the new behavior.