### PR TITLE
skip CMake 3.30.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - automake
 - c-compiler
 - cloudpickle
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-version=11.8
 - cudatoolkit
 - cudf==24.8.*,>=0.0.0a0

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - automake
 - c-compiler
 - cloudpickle
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-version=12.2
 - cudf==24.8.*,>=0.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -130,7 +130,7 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - &cmake_ver cmake>=3.26.4
+          - &cmake_ver cmake>=3.26.4,!=3.30.0
           - fmt>=10.1.1,<11
           - librmm==24.8.*,>=0.0.0a0
           - ninja

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -95,7 +95,7 @@ skip = [
 build-backend = "scikit_build_core.build"
 dependencies-file = "../dependencies.yaml"
 requires = [
-    "cmake>=3.26.4",
+    "cmake>=3.26.4,!=3.30.0",
     "cython>=3.0.0",
     "libucx==1.15.0",
     "ninja",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/80

Adds constraints to avoid pulling in CMake 3.30.0, for the reasons described in that issue.
