### PR TITLE
Mark C++ constructors and getters `[[nodiscard]]`

### DIFF
--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -63,7 +63,8 @@ class Address : public Component {
    *
    * @returns The `shared_ptr<ucxx::Address>` object.
    */
-  friend std::shared_ptr<Address> createAddressFromWorker(std::shared_ptr<Worker> worker);
+  [[nodiscard]] friend std::shared_ptr<Address> createAddressFromWorker(
+    std::shared_ptr<Worker> worker);
 
   /**
    * @brief Constructor for `shared_ptr<ucxx::Address>` from string.
@@ -75,7 +76,7 @@ class Address : public Component {
    *
    * @returns The `shared_ptr<ucxx::Address>` object.
    */
-  friend std::shared_ptr<Address> createAddressFromString(std::string addressString);
+  [[nodiscard]] friend std::shared_ptr<Address> createAddressFromString(std::string addressString);
 
   /**
    * @brief Get the underlying `ucp_address_t*` handle.
@@ -92,7 +93,7 @@ class Address : public Component {
    *
    * @returns The underlying `ucp_address_t` handle.
    */
-  ucp_address_t* getHandle() const;
+  [[nodiscard]] ucp_address_t* getHandle() const;
 
   /**
    * @brief Get the length of the `ucp_address_t*` handle.
@@ -102,7 +103,7 @@ class Address : public Component {
    *
    * @returns The length of the `ucp_address_t*` handle in bytes.
    */
-  size_t getLength() const;
+  [[nodiscard]] size_t getLength() const;
 
   /**
    * @brief Get the address as a string.
@@ -112,7 +113,7 @@ class Address : public Component {
    *
    * @returns The underlying `ucp_address_t` handle.
    */
-  std::string getString() const;
+  [[nodiscard]] std::string getString() const;
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/buffer.h
+++ b/cpp/include/ucxx/buffer.h
@@ -72,7 +72,7 @@ class Buffer {
    *
    * @return the type of buffer the object holds
    */
-  BufferType getType() const noexcept;
+  [[nodiscard]] BufferType getType() const noexcept;
 
   /**
    * @brief Get the size of the contained buffer.
@@ -81,7 +81,7 @@ class Buffer {
    *
    * @return the size of the contained buffer.
    */
-  size_t getSize() const noexcept;
+  [[nodiscard]] size_t getSize() const noexcept;
 
   /**
    * @brief Abstract method returning void pointer to buffer.
@@ -92,7 +92,7 @@ class Buffer {
    *
    * @return the void pointer to the buffer.
    */
-  virtual void* data() = 0;
+  [[nodiscard]] virtual void* data() = 0;
 };
 
 /**
@@ -159,7 +159,7 @@ class HostBuffer : public Buffer {
    *
    * @return the void pointer to the buffer.
    */
-  void* release();
+  [[nodiscard]] void* release();
 
   /**
    * @brief Get a pointer to the allocated raw host buffer.
@@ -180,7 +180,7 @@ class HostBuffer : public Buffer {
    *
    * @return the void pointer to the buffer.
    */
-  virtual void* data();
+  [[nodiscard]] virtual void* data();
 };
 
 #if UCXX_ENABLE_RMM
@@ -242,7 +242,7 @@ class RMMBuffer : public Buffer {
    *
    * @return the void pointer to the buffer.
    */
-  std::unique_ptr<rmm::device_buffer> release();
+  [[nodiscard]] std::unique_ptr<rmm::device_buffer> release();
 
   /**
    * @brief Get a pointer to the allocated raw device buffer.
@@ -264,7 +264,7 @@ class RMMBuffer : public Buffer {
    *
    * @return the void pointer to the device buffer.
    */
-  virtual void* data();
+  [[nodiscard]] virtual void* data();
 };
 #endif
 
@@ -279,6 +279,6 @@ class RMMBuffer : public Buffer {
  *
  * @returns the `std::shared_ptr` to the allocated buffer.
  */
-std::shared_ptr<Buffer> allocateBuffer(BufferType bufferType, const size_t size);
+[[nodiscard]] std::shared_ptr<Buffer> allocateBuffer(BufferType bufferType, const size_t size);
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/component.h
+++ b/cpp/include/ucxx/component.h
@@ -37,7 +37,7 @@ class Component : public std::enable_shared_from_this<Component> {
    *
    * @returns the reference-counted pointer to the parent.
    */
-  std::shared_ptr<Component> getParent() const;
+  [[nodiscard]] std::shared_ptr<Component> getParent() const;
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/config.h
+++ b/cpp/include/ucxx/config.h
@@ -29,10 +29,8 @@ class Config {
    *
    * @param[in] userOptions user-defined options overriding defaults and environment
    *                        variable modifiers.
-   *
-   * @returns The handle to the UCP configurations defined for the process.
    */
-  ucp_config_t* readUCXConfig(ConfigMap userOptions);
+  void readUCXConfig(ConfigMap userOptions);
 
   /**
    * @brief Parse UCP configurations and convert them to a map.
@@ -42,7 +40,7 @@ class Config {
    *
    * @returns The map to the UCP configurations defined for the process.
    */
-  ConfigMap ucxConfigToMap();
+  [[nodiscard]] ConfigMap ucxConfigToMap();
 
  public:
   Config()                         = delete;
@@ -72,7 +70,7 @@ class Config {
    *
    * @returns The map to the UCP configurations defined for the process.
    */
-  ConfigMap get();
+  [[nodiscard]] ConfigMap get();
 
   /**
    * @brief Get the underlying `ucp_config_t*` handle
@@ -89,7 +87,7 @@ class Config {
    *
    * @return The underlying `ucp_config_t*` handle.
    */
-  ucp_config_t* getHandle();
+  [[nodiscard]] ucp_config_t* getHandle();
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/context.h
+++ b/cpp/include/ucxx/context.h
@@ -72,7 +72,8 @@ class Context : public Component {
    * @param[in] featureFlags feature flags to be used at UCP context construction time.
    * @return The `shared_ptr<ucxx::Context>` object
    */
-  friend std::shared_ptr<Context> createContext(ConfigMap ucxConfig, const uint64_t featureFlags);
+  [[nodiscard]] friend std::shared_ptr<Context> createContext(ConfigMap ucxConfig,
+                                                              const uint64_t featureFlags);
 
   /**
    * @brief `ucxx::Context` destructor
@@ -92,7 +93,7 @@ class Context : public Component {
    *
    * @return A `ConfigMap` corresponding to the context's configuration.
    */
-  ConfigMap getConfig();
+  [[nodiscard]] ConfigMap getConfig();
 
   /**
    * @brief Get the underlying `ucp_context_h` handle
@@ -109,7 +110,7 @@ class Context : public Component {
    *
    * @return The underlying `ucp_context_h` handle
    */
-  ucp_context_h getHandle();
+  [[nodiscard]] ucp_context_h getHandle();
 
   /**
    * @brief Get information from UCP context.
@@ -125,7 +126,7 @@ class Context : public Component {
    *
    * @return String containing context information
    */
-  std::string getInfo();
+  [[nodiscard]] std::string getInfo();
 
   /**
    * @brief Get feature flags that were used to construct the UCP context.
@@ -141,7 +142,7 @@ class Context : public Component {
    *
    * @return Feature flags for this context
    */
-  uint64_t getFeatureFlags() const;
+  [[nodiscard]] uint64_t getFeatureFlags() const;
 
   /**
    * @brief Query whether CUDA support is available.
@@ -157,7 +158,7 @@ class Context : public Component {
    *
    * @return Whether CUDA support is available.
    */
-  bool hasCudaSupport() const;
+  [[nodiscard]] bool hasCudaSupport() const;
 
   /**
    * @brief Create a new `ucxx::Worker`.
@@ -177,8 +178,8 @@ class Context : public Component {
    *                         `ucxx::Request`, currently used only by `ucxx::python::Worker`.
    * @return Shared pointer to the `ucxx::Worker` object.
    */
-  std::shared_ptr<Worker> createWorker(const bool enableDelayedSubmission = false,
-                                       const bool enableFuture            = false);
+  [[nodiscard]] std::shared_ptr<Worker> createWorker(const bool enableDelayedSubmission = false,
+                                                     const bool enableFuture            = false);
 
   /**
    * @brief Create a new `std::shared_ptr<ucxx::memoryHandle>`.
@@ -217,7 +218,7 @@ class Context : public Component {
    *
    * @returns The `shared_ptr<ucxx::MemoryHandle>` object
    */
-  std::shared_ptr<MemoryHandle> createMemoryHandle(
+  [[nodiscard]] std::shared_ptr<MemoryHandle> createMemoryHandle(
     const size_t size, void* buffer, const ucs_memory_type_t memoryType = UCS_MEMORY_TYPE_HOST);
 };
 

--- a/cpp/include/ucxx/delayed_submission.h
+++ b/cpp/include/ucxx/delayed_submission.h
@@ -321,7 +321,7 @@ class DelayedSubmissionCollection {
    *
    * @returns the ID of the scheduled item which can be used cancelation requests.
    */
-  ItemIdType registerGenericPre(DelayedSubmissionCallbackType callback);
+  [[nodiscard]] ItemIdType registerGenericPre(DelayedSubmissionCallbackType callback);
 
   /**
    * @brief Register a generic callback to execute during `processPost()`.
@@ -333,7 +333,7 @@ class DelayedSubmissionCollection {
    *
    * @returns the ID of the scheduled item which can be used cancelation requests.
    */
-  ItemIdType registerGenericPost(DelayedSubmissionCallbackType callback);
+  [[nodiscard]] ItemIdType registerGenericPost(DelayedSubmissionCallbackType callback);
 
   /**
    * @brief Cancel a generic callback scheduled for `processPre()` execution.
@@ -369,7 +369,7 @@ class DelayedSubmissionCollection {
    *
    * @returns `true` if a delayed request submission is enabled, `false` otherwise.
    */
-  bool isDelayedRequestSubmissionEnabled() const;
+  [[nodiscard]] bool isDelayedRequestSubmissionEnabled() const;
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -112,7 +112,7 @@ class Endpoint : public Component {
    *
    * @return the request that was registered (i.e., the `request` argument itself).
    */
-  std::shared_ptr<Request> registerInflightRequest(std::shared_ptr<Request> request);
+  [[nodiscard]] std::shared_ptr<Request> registerInflightRequest(std::shared_ptr<Request> request);
 
   /**
    * @brief The error callback registered at endpoint creation time.
@@ -157,10 +157,11 @@ class Endpoint : public Component {
    *
    * @returns The `shared_ptr<ucxx::Endpoint>` object
    */
-  friend std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> worker,
-                                                              std::string ipAddress,
-                                                              uint16_t port,
-                                                              bool endpointErrorHandling);
+  [[nodiscard]] friend std::shared_ptr<Endpoint> createEndpointFromHostname(
+    std::shared_ptr<Worker> worker,
+    std::string ipAddress,
+    uint16_t port,
+    bool endpointErrorHandling);
 
   /**
    * @brief Constructor for `shared_ptr<ucxx::Endpoint>`.
@@ -184,9 +185,8 @@ class Endpoint : public Component {
    *
    * @returns The `shared_ptr<ucxx::Endpoint>` object
    */
-  friend std::shared_ptr<Endpoint> createEndpointFromConnRequest(std::shared_ptr<Listener> listener,
-                                                                 ucp_conn_request_h connRequest,
-                                                                 bool endpointErrorHandling);
+  [[nodiscard]] friend std::shared_ptr<Endpoint> createEndpointFromConnRequest(
+    std::shared_ptr<Listener> listener, ucp_conn_request_h connRequest, bool endpointErrorHandling);
 
   /**
    * @brief Constructor for `shared_ptr<ucxx::Endpoint>`.
@@ -207,9 +207,8 @@ class Endpoint : public Component {
    *
    * @returns The `shared_ptr<ucxx::Endpoint>` object
    */
-  friend std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(std::shared_ptr<Worker> worker,
-                                                                   std::shared_ptr<Address> address,
-                                                                   bool endpointErrorHandling);
+  [[nodiscard]] friend std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(
+    std::shared_ptr<Worker> worker, std::shared_ptr<Address> address, bool endpointErrorHandling);
 
   /**
    * @brief Get the underlying `ucp_ep_h` handle.
@@ -226,7 +225,7 @@ class Endpoint : public Component {
    *
    * @returns The underlying `ucp_ep_h` handle.
    */
-  ucp_ep_h getHandle();
+  [[nodiscard]] ucp_ep_h getHandle();
 
   /**
    * @brief Check whether the endpoint is still alive.
@@ -239,7 +238,7 @@ class Endpoint : public Component {
    * @returns whether the endpoint is still alive if endpoint enables error handling, always
    *          returns `true` if error handling is disabled.
    */
-  bool isAlive() const;
+  [[nodiscard]] bool isAlive() const;
 
   /**
    * @brief Raises an exception if an error occurred.
@@ -287,7 +286,7 @@ class Endpoint : public Component {
    *
    * @returns Number of requests that are in process of cancelation.
    */
-  size_t getCancelingSize() const;
+  [[nodiscard]] size_t getCancelingSize() const;
 
   /**
    * @brief Cancel inflight requests.
@@ -363,7 +362,7 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> amSend(
+  [[nodiscard]] std::shared_ptr<Request> amSend(
     void* buffer,
     const size_t length,
     const ucs_memory_type_t memoryType,
@@ -393,9 +392,10 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion state and data.
    */
-  std::shared_ptr<Request> amRecv(const bool enablePythonFuture                = false,
-                                  RequestCallbackUserFunction callbackFunction = nullptr,
-                                  RequestCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> amRecv(
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Enqueue a memory put operation.
@@ -419,13 +419,14 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> memPut(void* buffer,
-                                  size_t length,
-                                  uint64_t remote_addr,
-                                  ucp_rkey_h rkey,
-                                  const bool enablePythonFuture                = false,
-                                  RequestCallbackUserFunction callbackFunction = nullptr,
-                                  RequestCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> memPut(
+    void* buffer,
+    size_t length,
+    uint64_t remote_addr,
+    ucp_rkey_h rkey,
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Enqueue a memory put operation.
@@ -451,13 +452,14 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> memPut(void* buffer,
-                                  size_t length,
-                                  std::shared_ptr<ucxx::RemoteKey> remoteKey,
-                                  uint64_t remoteAddrOffset                    = 0,
-                                  const bool enablePythonFuture                = false,
-                                  RequestCallbackUserFunction callbackFunction = nullptr,
-                                  RequestCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> memPut(
+    void* buffer,
+    size_t length,
+    std::shared_ptr<ucxx::RemoteKey> remoteKey,
+    uint64_t remoteAddrOffset                    = 0,
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Enqueue a memory get operation.
@@ -481,13 +483,14 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> memGet(void* buffer,
-                                  size_t length,
-                                  uint64_t remoteAddr,
-                                  ucp_rkey_h rkey,
-                                  const bool enablePythonFuture                = false,
-                                  RequestCallbackUserFunction callbackFunction = nullptr,
-                                  RequestCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> memGet(
+    void* buffer,
+    size_t length,
+    uint64_t remoteAddr,
+    ucp_rkey_h rkey,
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Enqueue a memory get operation.
@@ -513,13 +516,14 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> memGet(void* buffer,
-                                  size_t length,
-                                  std::shared_ptr<ucxx::RemoteKey> remoteKey,
-                                  uint64_t remoteAddrOffset                    = 0,
-                                  const bool enablePythonFuture                = false,
-                                  RequestCallbackUserFunction callbackFunction = nullptr,
-                                  RequestCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> memGet(
+    void* buffer,
+    size_t length,
+    std::shared_ptr<ucxx::RemoteKey> remoteKey,
+    uint64_t remoteAddrOffset                    = 0,
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Enqueue a stream send operation.
@@ -540,7 +544,9 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> streamSend(void* buffer, size_t length, const bool enablePythonFuture);
+  [[nodiscard]] std::shared_ptr<Request> streamSend(void* buffer,
+                                                    size_t length,
+                                                    const bool enablePythonFuture);
 
   /**
    * @brief Enqueue a stream receive operation.
@@ -562,7 +568,9 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> streamRecv(void* buffer, size_t length, const bool enablePythonFuture);
+  [[nodiscard]] std::shared_ptr<Request> streamRecv(void* buffer,
+                                                    size_t length,
+                                                    const bool enablePythonFuture);
 
   /**
    * @brief Enqueue a tag send operation.
@@ -586,12 +594,13 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> tagSend(void* buffer,
-                                   size_t length,
-                                   Tag tag,
-                                   const bool enablePythonFuture                = false,
-                                   RequestCallbackUserFunction callbackFunction = nullptr,
-                                   RequestCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> tagSend(
+    void* buffer,
+    size_t length,
+    Tag tag,
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Enqueue a tag receive operation.
@@ -617,13 +626,14 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> tagRecv(void* buffer,
-                                   size_t length,
-                                   Tag tag,
-                                   TagMask tagMask,
-                                   const bool enablePythonFuture                = false,
-                                   RequestCallbackUserFunction callbackFunction = nullptr,
-                                   RequestCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> tagRecv(
+    void* buffer,
+    size_t length,
+    Tag tag,
+    TagMask tagMask,
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Enqueue a multi-buffer tag send operation.
@@ -658,11 +668,11 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> tagMultiSend(const std::vector<void*>& buffer,
-                                        const std::vector<size_t>& size,
-                                        const std::vector<int>& isCUDA,
-                                        const Tag tag,
-                                        const bool enablePythonFuture);
+  [[nodiscard]] std::shared_ptr<Request> tagMultiSend(const std::vector<void*>& buffer,
+                                                      const std::vector<size_t>& size,
+                                                      const std::vector<int>& isCUDA,
+                                                      const Tag tag,
+                                                      const bool enablePythonFuture);
 
   /**
    * @brief Enqueue a multi-buffer tag receive operation.
@@ -686,9 +696,9 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> tagMultiRecv(const Tag tag,
-                                        const TagMask tagMask,
-                                        const bool enablePythonFuture);
+  [[nodiscard]] std::shared_ptr<Request> tagMultiRecv(const Tag tag,
+                                                      const TagMask tagMask,
+                                                      const bool enablePythonFuture);
 
   /**
    * @brief Enqueue a flush operation.
@@ -711,9 +721,10 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> flush(const bool enablePythonFuture                = false,
-                                 RequestCallbackUserFunction callbackFunction = nullptr,
-                                 RequestCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> flush(
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Get `ucxx::Worker` component from a worker or listener object.
@@ -725,7 +736,7 @@ class Endpoint : public Component {
    *
    * @returns The `std::shared_ptr<ucxx::Worker>` which the endpoint is associated with.
    */
-  std::shared_ptr<Worker> getWorker();
+  [[nodiscard]] std::shared_ptr<Worker> getWorker();
 
   /**
    * @brief Enqueue a non-blocking endpoint close operation.
@@ -767,9 +778,10 @@ class Endpoint : public Component {
    *          `nullptr` if the endpoint has already closed or is already in process of
    *          closing.
    */
-  std::shared_ptr<Request> close(const bool enablePythonFuture                      = false,
-                                 EndpointCloseCallbackUserFunction callbackFunction = nullptr,
-                                 EndpointCloseCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> close(
+    const bool enablePythonFuture                      = false,
+    EndpointCloseCallbackUserFunction callbackFunction = nullptr,
+    EndpointCloseCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Close the endpoint while keeping the object alive.

--- a/cpp/include/ucxx/future.h
+++ b/cpp/include/ucxx/future.h
@@ -85,7 +85,7 @@ class Future : public std::enable_shared_from_this<Future> {
    *
    * @returns The underlying handle.
    */
-  virtual void* getHandle() = 0;
+  [[nodiscard]] virtual void* getHandle() = 0;
 
   /**
    * @brief Get the underlying handle and release ownership.
@@ -98,7 +98,7 @@ class Future : public std::enable_shared_from_this<Future> {
    *
    * @returns The underlying handle.
    */
-  virtual void* release() = 0;
+  [[nodiscard]] virtual void* release() = 0;
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/header.h
+++ b/cpp/include/ucxx/header.h
@@ -78,7 +78,7 @@ class Header {
    *
    * @returns the size of the underlying data.
    */
-  static size_t dataSize();
+  [[nodiscard]] static size_t dataSize();
 
   /**
    * @brief Get the serialized data.
@@ -87,7 +87,7 @@ class Header {
    *
    * @returns the serialized data.
    */
-  const std::string serialize() const;
+  [[nodiscard]] const std::string serialize() const;
 
   /**
    * @brief Convenience method to build headers given arbitrary-sized input.
@@ -101,8 +101,8 @@ class Header {
    *
    * @returns A vector of one or more `ucxx::Header` objects.
    */
-  static std::vector<Header> buildHeaders(const std::vector<size_t>& size,
-                                          const std::vector<int>& isCUDA);
+  [[nodiscard]] static std::vector<Header> buildHeaders(const std::vector<size_t>& size,
+                                                        const std::vector<int>& isCUDA);
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/inflight_requests.h
+++ b/cpp/include/ucxx/inflight_requests.h
@@ -89,7 +89,7 @@ class InflightRequests {
    *
    * @returns The number of pending inflight requests.
    */
-  size_t size();
+  [[nodiscard]] size_t size();
 
   /**
    * @brief Insert an inflight requests to the container.
@@ -142,7 +142,7 @@ class InflightRequests {
    *
    * @returns The internally-tracked containers.
    */
-  TrackedRequestsPtr release();
+  [[nodiscard]] TrackedRequestsPtr release();
 
   /**
    * @brief Get count of requests in process of cancelation.
@@ -154,7 +154,7 @@ class InflightRequests {
    *
    * @returns The count of requests that are in process of cancelation.
    */
-  size_t getCancelingSize();
+  [[nodiscard]] size_t getCancelingSize();
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/listener.h
+++ b/cpp/include/ucxx/listener.h
@@ -92,10 +92,11 @@ class Listener : public Component {
    *
    * @returns The `shared_ptr<ucxx::Listener>` object.
    */
-  friend std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
-                                                  uint16_t port,
-                                                  ucp_listener_conn_callback_t callback,
-                                                  void* callbackArgs);
+  [[nodiscard]] friend std::shared_ptr<Listener> createListener(
+    std::shared_ptr<Worker> worker,
+    uint16_t port,
+    ucp_listener_conn_callback_t callback,
+    void* callbackArgs);
 
   /**
    * @brief Constructor for `shared_ptr<ucxx::Endpoint>`.
@@ -118,8 +119,8 @@ class Listener : public Component {
    *
    * @returns The `shared_ptr<ucxx::Endpoint>` object.
    */
-  std::shared_ptr<Endpoint> createEndpointFromConnRequest(ucp_conn_request_h connRequest,
-                                                          bool endpointErrorHandling = true);
+  [[nodiscard]] std::shared_ptr<Endpoint> createEndpointFromConnRequest(
+    ucp_conn_request_h connRequest, bool endpointErrorHandling = true);
 
   /**
    * @brief Get the underlying `ucp_listener_h` handle.
@@ -136,7 +137,7 @@ class Listener : public Component {
    *
    * @returns The underlying `ucp_listener_h` handle.
    */
-  ucp_listener_h getHandle();
+  [[nodiscard]] ucp_listener_h getHandle();
 
   /**
    * @brief Get the port to which the listener is bound to.
@@ -145,7 +146,7 @@ class Listener : public Component {
    *
    * @returns the port to which the listener is bound to.
    */
-  uint16_t getPort();
+  [[nodiscard]] uint16_t getPort();
 
   /**
    * @brief Get the IP address to which the listener is bound to.
@@ -154,7 +155,7 @@ class Listener : public Component {
    *
    * @returns the IP address to which the listener is bound to.
    */
-  std::string getIp();
+  [[nodiscard]] std::string getIp();
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/memory_handle.h
+++ b/cpp/include/ucxx/memory_handle.h
@@ -109,10 +109,11 @@ class MemoryHandle : public Component {
    *
    * @returns The `shared_ptr<ucxx::MemoryHandle>` object
    */
-  friend std::shared_ptr<MemoryHandle> createMemoryHandle(std::shared_ptr<Context> context,
-                                                          const size_t size,
-                                                          void* buffer,
-                                                          const ucs_memory_type_t memoryType);
+  [[nodiscard]] friend std::shared_ptr<MemoryHandle> createMemoryHandle(
+    std::shared_ptr<Context> context,
+    const size_t size,
+    void* buffer,
+    const ucs_memory_type_t memoryType);
 
   ~MemoryHandle();
 
@@ -131,7 +132,7 @@ class MemoryHandle : public Component {
    *
    * @returns The underlying `ucp_mem_h` handle.
    */
-  ucp_mem_h getHandle();
+  [[nodiscard]] ucp_mem_h getHandle();
 
   /**
    * @brief Get the size of the memory allocation.
@@ -146,7 +147,7 @@ class MemoryHandle : public Component {
    *
    * @returns The size of the memory allocation.
    */
-  size_t getSize() const;
+  [[nodiscard]] size_t getSize() const;
 
   /**
    * @brief Get the base address of the memory allocation.
@@ -162,11 +163,11 @@ class MemoryHandle : public Component {
    *
    * @returns The base address of the memory allocation.
    */
-  uint64_t getBaseAddress();
+  [[nodiscard]] uint64_t getBaseAddress();
 
-  ucs_memory_type_t getMemoryType();
+  [[nodiscard]] ucs_memory_type_t getMemoryType();
 
-  std::shared_ptr<RemoteKey> createRemoteKey();
+  [[nodiscard]] std::shared_ptr<RemoteKey> createRemoteKey();
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/remote_key.h
+++ b/cpp/include/ucxx/remote_key.h
@@ -112,7 +112,7 @@ class RemoteKey : public Component {
    *
    * @returns The `shared_ptr<ucxx::RemoteKey>` object
    */
-  friend std::shared_ptr<RemoteKey> createRemoteKeyFromMemoryHandle(
+  [[nodiscard]] friend std::shared_ptr<RemoteKey> createRemoteKeyFromMemoryHandle(
     std::shared_ptr<MemoryHandle> memoryHandle);
 
   /**
@@ -140,7 +140,7 @@ class RemoteKey : public Component {
    *
    * @returns The `shared_ptr<ucxx::RemoteKey>` object
    */
-  friend std::shared_ptr<RemoteKey> createRemoteKeyFromSerialized(
+  [[nodiscard]] friend std::shared_ptr<RemoteKey> createRemoteKeyFromSerialized(
     std::shared_ptr<Endpoint> endpoint, SerializedRemoteKey serializedRemoteKey);
 
   ~RemoteKey();
@@ -160,7 +160,7 @@ class RemoteKey : public Component {
    *
    * @returns The underlying `ucp_mem_h` handle.
    */
-  ucp_rkey_h getHandle();
+  [[nodiscard]] ucp_rkey_h getHandle();
 
   /**
    * @brief Get the size of the memory allocation.
@@ -175,7 +175,7 @@ class RemoteKey : public Component {
    *
    * @returns The size of the memory allocation.
    */
-  size_t getSize() const;
+  [[nodiscard]] size_t getSize() const;
 
   /**
    * @brief Get the base address of the memory allocation.
@@ -191,7 +191,7 @@ class RemoteKey : public Component {
    *
    * @returns The base address of the memory allocation.
    */
-  uint64_t getBaseAddress();
+  [[nodiscard]] uint64_t getBaseAddress();
 
   /**
    * @brief Serialize the remote key.
@@ -206,7 +206,7 @@ class RemoteKey : public Component {
    *
    * @returns The serialized remote key.
    */
-  SerializedRemoteKey serialize() const;
+  [[nodiscard]] SerializedRemoteKey serialize() const;
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/request.h
+++ b/cpp/include/ucxx/request.h
@@ -134,7 +134,7 @@ class Request : public Component {
    *
    * @return the current status of the request.
    */
-  ucs_status_t getStatus();
+  [[nodiscard]] ucs_status_t getStatus();
 
   /**
    * @brief Return the future used to check on state.
@@ -144,7 +144,7 @@ class Request : public Component {
    *
    * @returns the Python future object or `nullptr`.
    */
-  void* getFuture();
+  [[nodiscard]] void* getFuture();
 
   /**
    * @brief Check whether the request completed with an error.
@@ -168,7 +168,7 @@ class Request : public Component {
    *
    * @return whether the request has completed.
    */
-  bool isCompleted();
+  [[nodiscard]] bool isCompleted();
 
   /**
    * @brief Callback executed by UCX when request is completed.
@@ -207,7 +207,7 @@ class Request : public Component {
    *
    * @returns the formatted string containing the owner type and its handle.
    */
-  const std::string& getOwnerString() const;
+  [[nodiscard]] const std::string& getOwnerString() const;
 
   /**
    * @brief Get the received buffer.
@@ -221,7 +221,7 @@ class Request : public Component {
    *
    * @return The received buffer (if applicable) or `nullptr`.
    */
-  virtual std::shared_ptr<Buffer> getRecvBuffer();
+  [[nodiscard]] virtual std::shared_ptr<Buffer> getRecvBuffer();
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/request_am.h
+++ b/cpp/include/ucxx/request_am.h
@@ -89,7 +89,7 @@ class RequestAm : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestAm>` object
    */
-  friend std::shared_ptr<RequestAm> createRequestAm(
+  [[nodiscard]] friend std::shared_ptr<RequestAm> createRequestAm(
     std::shared_ptr<Endpoint> endpoint,
     const std::variant<data::AmSend, data::AmReceive> requestData,
     const bool enablePythonFuture,
@@ -135,14 +135,14 @@ class RequestAm : public Request {
    * param[in] length the length in bytes of the message to be received.
    * param[in] param  UCP parameters of the active message being received.
    */
-  static ucs_status_t recvCallback(void* arg,
-                                   const void* header,
-                                   size_t header_length,
-                                   void* data,
-                                   size_t length,
-                                   const ucp_am_recv_param_t* param);
+  [[nodiscard]] static ucs_status_t recvCallback(void* arg,
+                                                 const void* header,
+                                                 size_t header_length,
+                                                 void* data,
+                                                 size_t length,
+                                                 const ucp_am_recv_param_t* param);
 
-  std::shared_ptr<Buffer> getRecvBuffer() override;
+  [[nodiscard]] std::shared_ptr<Buffer> getRecvBuffer() override;
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/request_endpoint_close.h
+++ b/cpp/include/ucxx/request_endpoint_close.h
@@ -75,7 +75,7 @@ class RequestEndpointClose : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestEndpointClose>` object.
    */
-  friend std::shared_ptr<RequestEndpointClose> createRequestEndpointClose(
+  [[nodiscard]] friend std::shared_ptr<RequestEndpointClose> createRequestEndpointClose(
     std::shared_ptr<Endpoint> endpoint,
     const data::EndpointClose requestData,
     const bool enablePythonFuture,

--- a/cpp/include/ucxx/request_flush.h
+++ b/cpp/include/ucxx/request_flush.h
@@ -86,7 +86,7 @@ class RequestFlush : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestFlush>` object
    */
-  friend std::shared_ptr<RequestFlush> createRequestFlush(
+  [[nodiscard]] friend std::shared_ptr<RequestFlush> createRequestFlush(
     std::shared_ptr<Component> endpointOrWorker,
     const data::Flush requestData,
     const bool enablePythonFuture,

--- a/cpp/include/ucxx/request_mem.h
+++ b/cpp/include/ucxx/request_mem.h
@@ -88,7 +88,7 @@ class RequestMem : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestTag>` object
    */
-  friend std::shared_ptr<RequestMem> createRequestMem(
+  [[nodiscard]] friend std::shared_ptr<RequestMem> createRequestMem(
     std::shared_ptr<Endpoint> endpoint,
     const std::variant<data::MemPut, data::MemGet> requestData,
     const bool enablePythonFuture,

--- a/cpp/include/ucxx/request_stream.h
+++ b/cpp/include/ucxx/request_stream.h
@@ -67,7 +67,7 @@ class RequestStream : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestStream>` object
    */
-  friend std::shared_ptr<RequestStream> createRequestStream(
+  [[nodiscard]] friend std::shared_ptr<RequestStream> createRequestStream(
     std::shared_ptr<Endpoint> endpoint,
     const std::variant<data::StreamSend, data::StreamReceive> requestData,
     const bool enablePythonFuture);

--- a/cpp/include/ucxx/request_tag.h
+++ b/cpp/include/ucxx/request_tag.h
@@ -84,7 +84,7 @@ class RequestTag : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestTag>` object
    */
-  friend std::shared_ptr<RequestTag> createRequestTag(
+  [[nodiscard]] friend std::shared_ptr<RequestTag> createRequestTag(
     std::shared_ptr<Component> endpointOrWorker,
     const std::variant<data::TagSend, data::TagReceive> requestData,
     const bool enablePythonFuture,

--- a/cpp/include/ucxx/request_tag_multi.h
+++ b/cpp/include/ucxx/request_tag_multi.h
@@ -171,7 +171,7 @@ class RequestTagMulti : public Request {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  friend std::shared_ptr<RequestTagMulti> createRequestTagMulti(
+  [[nodiscard]] friend std::shared_ptr<RequestTagMulti> createRequestTagMulti(
     std::shared_ptr<Endpoint> endpoint,
     const std::variant<data::TagMultiSend, data::TagMultiReceive> requestData,
     const bool enablePythonFuture);

--- a/cpp/include/ucxx/utils/file_descriptor.h
+++ b/cpp/include/ucxx/utils/file_descriptor.h
@@ -21,7 +21,7 @@ namespace utils {
  *
  * @returns The file descriptor created.
  */
-FILE* createTextFileDescriptor();
+[[nodiscard]] FILE* createTextFileDescriptor();
 
 /**
  * @brief Decode text file descriptor.
@@ -32,7 +32,7 @@ FILE* createTextFileDescriptor();
  *
  * @returns The string with a copy of the file descriptor contents.
  */
-std::string decodeTextFileDescriptor(FILE* textFileDescriptor);
+[[nodiscard]] std::string decodeTextFileDescriptor(FILE* textFileDescriptor);
 
 }  // namespace utils
 

--- a/cpp/include/ucxx/utils/python.h
+++ b/cpp/include/ucxx/utils/python.h
@@ -19,7 +19,7 @@ namespace utils {
  *
  * @returns whether Python support is available.
  */
-bool isPythonAvailable();
+[[nodiscard]] bool isPythonAvailable();
 
 }  // namespace utils
 

--- a/cpp/include/ucxx/utils/sockaddr.h
+++ b/cpp/include/ucxx/utils/sockaddr.h
@@ -22,8 +22,8 @@ namespace utils {
  *
  * @returns unique pointer wrapping a `struct addrinfo` (frees the addrinfo when out of scope)
  */
-std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> get_addrinfo(const char* ip_address,
-                                                                          uint16_t port);
+[[nodiscard]] std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)> get_addrinfo(
+  const char* ip_address, uint16_t port);
 
 /**
  * @brief Get socket address and port of a socket address storage.

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -102,7 +102,7 @@ class Worker : public Component {
    *
    * @returns Request to be subsequently checked for the completion state and data.
    */
-  std::shared_ptr<RequestAm> getAmRecv(
+  [[nodiscard]] std::shared_ptr<RequestAm> getAmRecv(
     ucp_ep_h ep, std::function<std::shared_ptr<RequestAm>()> createAmRecvRequestFunction);
 
   /**
@@ -123,7 +123,7 @@ class Worker : public Component {
    *
    * @return the request that was registered (i.e., the `request` argument itself).
    */
-  std::shared_ptr<Request> registerInflightRequest(std::shared_ptr<Request> request);
+  [[nodiscard]] std::shared_ptr<Request> registerInflightRequest(std::shared_ptr<Request> request);
 
   /**
    * @brief Progress the worker until all communication events are completed.
@@ -187,9 +187,9 @@ class Worker : public Component {
    *                         `ucxx::Request`, currently used only by `ucxx::python::Worker`.
    * @returns The `shared_ptr<ucxx::Worker>` object
    */
-  friend std::shared_ptr<Worker> createWorker(std::shared_ptr<Context> context,
-                                              const bool enableDelayedSubmission,
-                                              const bool enableFuture);
+  [[nodiscard]] friend std::shared_ptr<Worker> createWorker(std::shared_ptr<Context> context,
+                                                            const bool enableDelayedSubmission,
+                                                            const bool enableFuture);
 
   /**
    * @brief `ucxx::Worker` destructor.
@@ -211,7 +211,7 @@ class Worker : public Component {
    *
    * @returns The underlying `ucp_worker_h` handle.
    */
-  ucp_worker_h getHandle();
+  [[nodiscard]] ucp_worker_h getHandle();
 
   /**
    * @brief Get information about the underlying `ucp_worker_h` object.
@@ -221,7 +221,7 @@ class Worker : public Component {
    *
    * @returns String containing information about the UCP worker.
    */
-  std::string getInfo();
+  [[nodiscard]] std::string getInfo();
 
   /**
    * @brief Initialize blocking progress mode.
@@ -428,7 +428,8 @@ class Worker : public Component {
    *
    * @returns `true` if the callback was successfully executed or `false` if timed out.
    */
-  bool registerGenericPre(DelayedSubmissionCallbackType callback, uint64_t period = 0);
+  [[nodiscard]] bool registerGenericPre(DelayedSubmissionCallbackType callback,
+                                        uint64_t period = 0);
 
   /**
    * @brief Register callback to be executed in progress thread before progressing.
@@ -452,7 +453,8 @@ class Worker : public Component {
    *
    * @returns `true` if the callback was successfully executed or `false` if timed out.
    */
-  bool registerGenericPost(DelayedSubmissionCallbackType callback, uint64_t period = 0);
+  [[nodiscard]] bool registerGenericPost(DelayedSubmissionCallbackType callback,
+                                         uint64_t period = 0);
 
   /**
    * @brief Inquire if worker has been created with delayed submission enabled.
@@ -461,7 +463,7 @@ class Worker : public Component {
    *
    * @returns `true` if delayed submission is enabled, `false` otherwise.
    */
-  bool isDelayedRequestSubmissionEnabled() const;
+  [[nodiscard]] bool isDelayedRequestSubmissionEnabled() const;
 
   /**
    * @brief Inquire if worker has been created with future support.
@@ -470,7 +472,7 @@ class Worker : public Component {
    *
    * @returns `true` if future support is enabled, `false` otherwise.
    */
-  bool isFutureEnabled() const;
+  [[nodiscard]] bool isFutureEnabled() const;
 
   /**
    * @brief Populate the future pool.
@@ -496,7 +498,7 @@ class Worker : public Component {
    *
    * @returns The `shared_ptr<ucxx::python::Future>` object
    */
-  virtual std::shared_ptr<Future> getFuture();
+  [[nodiscard]] virtual std::shared_ptr<Future> getFuture();
 
   /**
    * @brief Block until a request event.
@@ -512,7 +514,7 @@ class Worker : public Component {
    *          `RequestNotifierWaitStats::Timeout` if a timeout occurred, or
    *          `RequestNotifierWaitStats::Shutdown` if shutdown has initiated.
    */
-  virtual RequestNotifierWaitState waitRequestNotifier(uint64_t periodNs);
+  [[nodiscard]] virtual RequestNotifierWaitState waitRequestNotifier(uint64_t periodNs);
 
   /**
    * @brief Notify futures of each completed communication request.
@@ -580,7 +582,7 @@ class Worker : public Component {
    *
    * @returns `true` if a progress thread is running, `false` otherwise.
    */
-  bool isProgressThreadRunning();
+  [[nodiscard]] bool isProgressThreadRunning();
 
   /**
    * @brief Get the progress thread ID.
@@ -589,7 +591,7 @@ class Worker : public Component {
    *
    * @returns the progress thread ID.
    */
-  std::thread::id getProgressThreadId();
+  [[nodiscard]] std::thread::id getProgressThreadId();
 
   /**
    * @brief Cancel inflight requests.
@@ -660,7 +662,7 @@ class Worker : public Component {
    *
    * @returns `true` if any uncaught messages were received, `false` otherwise.
    */
-  bool tagProbe(const Tag tag);
+  [[nodiscard]] bool tagProbe(const Tag tag);
 
   /**
    * @brief Enqueue a tag receive operation.
@@ -686,13 +688,14 @@ class Worker : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> tagRecv(void* buffer,
-                                   size_t length,
-                                   Tag tag,
-                                   TagMask tagMask,
-                                   const bool enableFuture                      = false,
-                                   RequestCallbackUserFunction callbackFunction = nullptr,
-                                   RequestCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> tagRecv(
+    void* buffer,
+    size_t length,
+    Tag tag,
+    TagMask tagMask,
+    const bool enableFuture                      = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Get the address of the UCX worker object.
@@ -705,7 +708,7 @@ class Worker : public Component {
    *
    * @returns The address of the local worker.
    */
-  std::shared_ptr<Address> getAddress();
+  [[nodiscard]] std::shared_ptr<Address> getAddress();
 
   /**
    * @brief Create endpoint to worker listening on specific IP and port.
@@ -731,9 +734,8 @@ class Worker : public Component {
    *
    * @returns The `shared_ptr<ucxx::Endpoint>` object
    */
-  std::shared_ptr<Endpoint> createEndpointFromHostname(std::string ipAddress,
-                                                       uint16_t port,
-                                                       bool endpointErrorHandling = true);
+  [[nodiscard]] std::shared_ptr<Endpoint> createEndpointFromHostname(
+    std::string ipAddress, uint16_t port, bool endpointErrorHandling = true);
 
   /**
    * @brief Create endpoint to worker located at UCX address.
@@ -763,8 +765,8 @@ class Worker : public Component {
    *
    * @returns The `shared_ptr<ucxx::Endpoint>` object
    */
-  std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(std::shared_ptr<Address> address,
-                                                            bool endpointErrorHandling = true);
+  [[nodiscard]] std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(
+    std::shared_ptr<Address> address, bool endpointErrorHandling = true);
 
   /**
    * @brief Listen for remote connections on given port.
@@ -783,9 +785,9 @@ class Worker : public Component {
    *
    * @returns The `shared_ptr<ucxx::Listener>` object
    */
-  std::shared_ptr<Listener> createListener(uint16_t port,
-                                           ucp_listener_conn_callback_t callback,
-                                           void* callbackArgs);
+  [[nodiscard]] std::shared_ptr<Listener> createListener(uint16_t port,
+                                                         ucp_listener_conn_callback_t callback,
+                                                         void* callbackArgs);
 
   /**
    * @brief Register allocator for active messages.
@@ -874,7 +876,7 @@ class Worker : public Component {
    *
    * @returns `true` if any uncaught messages were received, `false` otherwise.
    */
-  bool amProbe(const ucp_ep_h endpointHandle) const;
+  [[nodiscard]] bool amProbe(const ucp_ep_h endpointHandle) const;
 
   /**
    * @brief Enqueue a flush operation.
@@ -897,9 +899,10 @@ class Worker : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  std::shared_ptr<Request> flush(const bool enablePythonFuture                = false,
-                                 RequestCallbackUserFunction callbackFunction = nullptr,
-                                 RequestCallbackUserData callbackData         = nullptr);
+  [[nodiscard]] std::shared_ptr<Request> flush(
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/worker_progress_thread.h
+++ b/cpp/include/ucxx/worker_progress_thread.h
@@ -153,16 +153,16 @@ class WorkerProgressThread {
    *
    * @returns Whether polling mode is enabled.
    */
-  bool pollingMode() const;
+  [[nodiscard]] bool pollingMode() const;
 
   /**
    * @brief Returns the ID of the progress thread.
    *
    * @returns the progress thread ID.
    */
-  std::thread::id getId() const;
+  [[nodiscard]] std::thread::id getId() const;
 
-  bool isRunning() const;
+  [[nodiscard]] bool isRunning() const;
 
   void stop();
 };

--- a/cpp/python/include/ucxx/python/exception.h
+++ b/cpp/python/include/ucxx/python/exception.h
@@ -75,7 +75,7 @@ void raise_py_error();
  *
  * @param[in] status UCS status from which to get exception.
  */
-PyObject* get_python_exception_from_ucs_status(ucs_status_t status);
+[[nodiscard]] PyObject* get_python_exception_from_ucs_status(ucs_status_t status);
 
 }  // namespace python
 

--- a/cpp/python/include/ucxx/python/future.h
+++ b/cpp/python/include/ucxx/python/future.h
@@ -21,7 +21,7 @@ namespace python {
  *
  * @returns The Python asyncio future object.
  */
-PyObject* create_python_future() noexcept;
+[[nodiscard]] PyObject* create_python_future() noexcept;
 
 /**
  * @brief Set the result of a Python future.
@@ -37,7 +37,7 @@ PyObject* create_python_future() noexcept;
  *
  * @returns The result of the call to `_asyncio.Future.set_result()`.
  */
-PyObject* future_set_result(PyObject* future, PyObject* value) noexcept;
+[[nodiscard]] PyObject* future_set_result(PyObject* future, PyObject* value) noexcept;
 
 /**
  * @brief Set the exception of a Python future.
@@ -53,7 +53,9 @@ PyObject* future_set_result(PyObject* future, PyObject* value) noexcept;
  *
  * @returns The result of the call to `_asyncio.Future.set_result()`.
  */
-PyObject* future_set_exception(PyObject* future, PyObject* exception, const char* message) noexcept;
+[[nodiscard]] PyObject* future_set_exception(PyObject* future,
+                                             PyObject* exception,
+                                             const char* message) noexcept;
 
 /**
  * @brief Create a Python asyncio future with associated event loop.
@@ -68,7 +70,7 @@ PyObject* future_set_exception(PyObject* future, PyObject* exception, const char
  *
  * @returns The Python asyncio future object.
  */
-PyObject* create_python_future_with_event_loop(PyObject* event_loop) noexcept;
+[[nodiscard]] PyObject* create_python_future_with_event_loop(PyObject* event_loop) noexcept;
 
 /**
  * @brief Set the result of a Python future with associated event loop.
@@ -86,9 +88,9 @@ PyObject* create_python_future_with_event_loop(PyObject* event_loop) noexcept;
  *
  * @returns The result of the call to `_asyncio.Future.set_result()`.
  */
-PyObject* future_set_result_with_event_loop(PyObject* event_loop,
-                                            PyObject* future,
-                                            PyObject* value) noexcept;
+[[nodiscard]] PyObject* future_set_result_with_event_loop(PyObject* event_loop,
+                                                          PyObject* future,
+                                                          PyObject* value) noexcept;
 
 /**
  * @brief Set the exception of a Python future with associated event loop.
@@ -106,10 +108,10 @@ PyObject* future_set_result_with_event_loop(PyObject* event_loop,
  *
  * @returns The result of the call to `_asyncio.Future.set_result()`.
  */
-PyObject* future_set_exception_with_event_loop(PyObject* event_loop,
-                                               PyObject* future,
-                                               PyObject* exception,
-                                               const char* message) noexcept;
+[[nodiscard]] PyObject* future_set_exception_with_event_loop(PyObject* event_loop,
+                                                             PyObject* future,
+                                                             PyObject* exception,
+                                                             const char* message) noexcept;
 
 }  // namespace python
 

--- a/cpp/python/include/ucxx/python/notifier.h
+++ b/cpp/python/include/ucxx/python/notifier.h
@@ -51,7 +51,7 @@ class Notifier : public ::ucxx::Notifier {
    * WARNING: Use with caution, if no event ever occurs it will be impossible to continue
    * the thread.
    */
-  RequestNotifierWaitState waitRequestNotifierWithoutTimeout();
+  [[nodiscard]] RequestNotifierWaitState waitRequestNotifierWithoutTimeout();
 
   /**
    * @brief Wait for a new event with a timeout.
@@ -61,7 +61,7 @@ class Notifier : public ::ucxx::Notifier {
    *
    * @param[in] period the time to wait for an event before unblocking.
    */
-  RequestNotifierWaitState waitRequestNotifierWithTimeout(uint64_t period);
+  [[nodiscard]] RequestNotifierWaitState waitRequestNotifierWithTimeout(uint64_t period);
 
  public:
   Notifier(const Notifier&)            = delete;
@@ -84,7 +84,7 @@ class Notifier : public ::ucxx::Notifier {
    *
    * @returns The `shared_ptr<ucxx::python::Notifier>` object
    */
-  friend std::shared_ptr<::ucxx::Notifier> createNotifier();
+  [[nodiscard]] friend std::shared_ptr<::ucxx::Notifier> createNotifier();
 
   /**
    * @brief Virtual destructor.
@@ -120,7 +120,7 @@ class Notifier : public ::ucxx::Notifier {
    *
    * @param[in] period the time in nanoseconds to wait for an event before unblocking.
    */
-  RequestNotifierWaitState waitRequestNotifier(uint64_t period) override;
+  [[nodiscard]] RequestNotifierWaitState waitRequestNotifier(uint64_t period) override;
 
   /**
    * @brief Notify event loop of all pending completed Python futures.

--- a/cpp/python/include/ucxx/python/python_future.h
+++ b/cpp/python/include/ucxx/python/python_future.h
@@ -64,7 +64,8 @@ class Future : public ::ucxx::Future {
    *
    * @returns The `shared_ptr<ucxx::python::Worker>` object
    */
-  friend std::shared_ptr<::ucxx::Future> createFuture(std::shared_ptr<::ucxx::Notifier> notifier);
+  [[nodiscard]] friend std::shared_ptr<::ucxx::Future> createFuture(
+    std::shared_ptr<::ucxx::Notifier> notifier);
 
   /**
    * @brief Constructor of `shared_ptr<ucxx::python::Future>`.
@@ -80,7 +81,7 @@ class Future : public ::ucxx::Future {
    *
    * @returns The `shared_ptr<ucxx::python::Worker>` object
    */
-  friend std::shared_ptr<::ucxx::Future> createFutureWithEventLoop(
+  [[nodiscard]] friend std::shared_ptr<::ucxx::Future> createFutureWithEventLoop(
     PyObject* asyncioEventLoop, std::shared_ptr<::ucxx::Notifier> notifier);
 
   /**
@@ -127,7 +128,7 @@ class Future : public ::ucxx::Future {
    *
    * @returns The underlying `PyObject*` handle.
    */
-  void* getHandle();
+  [[nodiscard]] void* getHandle();
 
   /**
    * @brief Get the underlying `PyObject*` handle and release ownership.
@@ -140,7 +141,7 @@ class Future : public ::ucxx::Future {
    *
    * @returns The underlying `PyObject*` handle.
    */
-  void* release();
+  [[nodiscard]] void* release();
 };
 
 }  // namespace python

--- a/cpp/python/include/ucxx/python/python_future_task.h
+++ b/cpp/python/include/ucxx/python/python_future_task.h
@@ -206,7 +206,7 @@ struct PythonFutureTask {
    *
    * @returns The underlying C++ future.
    */
-  std::future<ReturnType>& getFuture()
+  [[nodiscard]] std::future<ReturnType>& getFuture()
   {
     if (_handle == nullptr) throw std::runtime_error("Invalid object or already released");
 
@@ -227,7 +227,7 @@ struct PythonFutureTask {
    *
    * @returns The underlying `PyObject*` handle.
    */
-  PyObject* getHandle()
+  [[nodiscard]] PyObject* getHandle()
   {
     if (_handle == nullptr) throw std::runtime_error("Invalid object or already released");
 
@@ -245,7 +245,7 @@ struct PythonFutureTask {
    *
    * @returns The underlying `PyObject*` handle.
    */
-  PyObject* release()
+  [[nodiscard]] PyObject* release()
   {
     if (_handle == nullptr) throw std::runtime_error("Invalid object or already released");
 
@@ -322,7 +322,7 @@ class PythonFutureTask : public std::enable_shared_from_this<PythonFutureTask<Re
    *
    * @returns The underlying C++ future.
    */
-  std::future<ReturnType>& getFuture() { return _detail->getFuture(); }
+  [[nodiscard]] std::future<ReturnType>& getFuture() { return _detail->getFuture(); }
 
   /**
    * @brief Get the underlying future `PyObject*` handle but does not release ownership.
@@ -338,7 +338,7 @@ class PythonFutureTask : public std::enable_shared_from_this<PythonFutureTask<Re
    *
    * @returns The underlying `PyObject*` handle.
    */
-  PyObject* getHandle() { return _detail->getHandle(); }
+  [[nodiscard]] PyObject* getHandle() { return _detail->getHandle(); }
 
   /**
    * @brief Get the underlying future `PyObject*` handle and release ownership.
@@ -351,7 +351,7 @@ class PythonFutureTask : public std::enable_shared_from_this<PythonFutureTask<Re
    *
    * @returns The underlying `PyObject*` handle.
    */
-  PyObject* release() { return _detail->release(); }
+  [[nodiscard]] PyObject* release() { return _detail->release(); }
 };
 
 }  // namespace python

--- a/cpp/python/include/ucxx/python/python_future_task_collector.h
+++ b/cpp/python/include/ucxx/python/python_future_task_collector.h
@@ -34,7 +34,7 @@ class PythonFutureTaskCollector {
    * `PythonFutureTaskCollector` is a singleton and thus must not be directly instantiated.
    * Instead, users should call this static method to get a reference to its instance.
    */
-  static PythonFutureTaskCollector& get();
+  [[nodiscard]] static PythonFutureTaskCollector& get();
 
   /**
    * Push a Python handle to be later collected.

--- a/cpp/python/include/ucxx/python/worker.h
+++ b/cpp/python/include/ucxx/python/worker.h
@@ -82,9 +82,8 @@ class Worker : public ::ucxx::Worker {
    *
    * @returns The `shared_ptr<ucxx::python::Worker>` object
    */
-  friend std::shared_ptr<::ucxx::Worker> createWorker(std::shared_ptr<Context> context,
-                                                      const bool enableDelayedSubmission,
-                                                      const bool enableFuture);
+  [[nodiscard]] friend std::shared_ptr<::ucxx::Worker> createWorker(
+    std::shared_ptr<Context> context, const bool enableDelayedSubmission, const bool enableFuture);
 
   /**
    * @brief Populate the Python future pool.
@@ -105,7 +104,7 @@ class Worker : public ::ucxx::Worker {
    *
    * @returns The `shared_ptr<ucxx::python::Future>` object
    */
-  std::shared_ptr<::ucxx::Future> getFuture() override;
+  [[nodiscard]] std::shared_ptr<::ucxx::Future> getFuture() override;
 
   /**
    * @brief Block until a request event.
@@ -119,7 +118,7 @@ class Worker : public ::ucxx::Worker {
    *          `RequestNotifierWaitStats::Timeout` if a timeout occurred, or
    *          `RequestNotifierWaitStats::Shutdown` if shutdown has initiated.
    */
-  RequestNotifierWaitState waitRequestNotifier(uint64_t periodNs) override;
+  [[nodiscard]] RequestNotifierWaitState waitRequestNotifier(uint64_t periodNs) override;
 
   /**
    * @brief Notify Python futures of each completed communication request.

--- a/cpp/python/src/python_future.cpp
+++ b/cpp/python/src/python_future.cpp
@@ -4,7 +4,6 @@
  */
 #include <memory>
 #include <stdexcept>
-#include <tuple>
 #include <utility>
 
 #include <Python.h>

--- a/cpp/python/src/python_future.cpp
+++ b/cpp/python/src/python_future.cpp
@@ -4,6 +4,7 @@
  */
 #include <memory>
 #include <stdexcept>
+#include <tuple>
 #include <utility>
 
 #include <Python.h>
@@ -59,18 +60,19 @@ void Future::set(ucs_status_t status)
                  ucs_status_string(status));
   if (status == UCS_OK) {
     if (_asyncioEventLoop == nullptr)
-      future_set_result(_handle, Py_True);
+      std::ignore = future_set_result(_handle, Py_True);
     else
-      future_set_result_with_event_loop(_asyncioEventLoop, _handle, Py_True);
+      std::ignore = future_set_result_with_event_loop(_asyncioEventLoop, _handle, Py_True);
   } else {
     if (_asyncioEventLoop == nullptr)
-      future_set_exception(
+      std::ignore = future_set_exception(
         _handle, get_python_exception_from_ucs_status(status), ucs_status_string(status));
     else
-      future_set_exception_with_event_loop(_asyncioEventLoop,
-                                           _handle,
-                                           get_python_exception_from_ucs_status(status),
-                                           ucs_status_string(status));
+      std::ignore =
+        future_set_exception_with_event_loop(_asyncioEventLoop,
+                                             _handle,
+                                             get_python_exception_from_ucs_status(status),
+                                             ucs_status_string(status));
   }
 }
 

--- a/cpp/src/config.cpp
+++ b/cpp/src/config.cpp
@@ -12,7 +12,7 @@
 
 namespace ucxx {
 
-ucp_config_t* Config::readUCXConfig(ConfigMap userOptions)
+void Config::readUCXConfig(ConfigMap userOptions)
 {
   ucs_status_t status;
 
@@ -32,8 +32,6 @@ ucp_config_t* Config::readUCXConfig(ConfigMap userOptions)
         utils::ucsErrorThrow(status);
     }
   }
-
-  return _handle;
 }
 
 ConfigMap Config::ucxConfigToMap()
@@ -60,7 +58,7 @@ Config::Config(ConfigMap userOptions) { readUCXConfig(userOptions); }
 
 Config::~Config()
 {
-  if (this->_handle != nullptr) ucp_config_release(this->_handle);
+  if (_handle != nullptr) ucp_config_release(_handle);
 }
 
 ConfigMap Config::get() { return ucxConfigToMap(); }

--- a/cpp/src/delayed_submission.cpp
+++ b/cpp/src/delayed_submission.cpp
@@ -4,6 +4,7 @@
  */
 #include <memory>
 #include <mutex>
+#include <tuple>
 #include <utility>
 
 #include <ucp/api/ucp.h>
@@ -79,7 +80,7 @@ void DelayedSubmissionCollection::processPost() { _genericPost.process(); }
 void DelayedSubmissionCollection::registerRequest(std::shared_ptr<Request> request,
                                                   DelayedSubmissionCallbackType callback)
 {
-  _requests.schedule({request, callback});
+  std::ignore = _requests.schedule({request, callback});
 }
 
 ItemIdType DelayedSubmissionCollection::registerGenericPre(DelayedSubmissionCallbackType callback)

--- a/cpp/src/delayed_submission.cpp
+++ b/cpp/src/delayed_submission.cpp
@@ -4,7 +4,6 @@
  */
 #include <memory>
 #include <mutex>
-#include <tuple>
 #include <utility>
 
 #include <ucp/api/ucp.h>

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -4,8 +4,7 @@
  */
 #include <memory>
 #include <netinet/in.h>
-#include <string>
-#include <tuple>
+#include <utility>
 
 #include <ucp/api/ucp.h>
 

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -5,6 +5,8 @@
 #include <memory>
 #include <netinet/in.h>
 #include <string>
+#include <tuple>
+
 #include <ucp/api/ucp.h>
 
 #include <ucxx/exception.h>
@@ -51,9 +53,10 @@ Listener::~Listener()
   auto worker = std::static_pointer_cast<Worker>(_parent);
 
   if (worker->isProgressThreadRunning()) {
-    worker->registerGenericPre([this]() { ucp_listener_destroy(_handle); }, 10000000000 /* 10s */);
+    std::ignore = worker->registerGenericPre([this]() { ucp_listener_destroy(_handle); },
+                                             10000000000 /* 10s */);
 
-    worker->registerGenericPost([]() {}, 10000000000 /* 10s */);
+    std::ignore = worker->registerGenericPost([]() {}, 10000000000 /* 10s */);
   } else {
     ucp_listener_destroy(_handle);
     worker->progress();

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -9,6 +9,7 @@
 #include <queue>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -48,7 +49,7 @@ Worker::Worker(std::shared_ptr<Context> context,
     unsigned int AM_MSG_ID            = 0;
     _amData                           = std::make_shared<internal::AmData>();
     _amData->_registerInflightRequest = [this](std::shared_ptr<Request> req) {
-      this->registerInflightRequest(req);
+      return registerInflightRequest(req);
     };
     registerAmAllocator(UCS_MEMORY_TYPE_HOST,
                         [](size_t length) { return std::make_shared<HostBuffer>(length); });
@@ -549,8 +550,8 @@ bool Worker::tagProbe(const Tag tag)
      * indicate the progress thread has immediately finished executing and post-progress
      * ran without a further progress operation.
      */
-    registerGenericPre([]() {}, 3000000000 /* 3s */);
-    registerGenericPost([]() {}, 3000000000 /* 3s */);
+    std::ignore = registerGenericPre([]() {}, 3000000000 /* 3s */);
+    std::ignore = registerGenericPost([]() {}, 3000000000 /* 3s */);
   }
 
   ucp_tag_recv_info_t info;

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -9,7 +9,6 @@
 #include <queue>
 #include <sstream>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 

--- a/cpp/tests/buffer.cpp
+++ b/cpp/tests/buffer.cpp
@@ -4,7 +4,6 @@
  */
 #include <algorithm>
 #include <numeric>
-#include <tuple>
 #include <utility>
 
 #include <gtest/gtest.h>

--- a/cpp/tests/buffer.cpp
+++ b/cpp/tests/buffer.cpp
@@ -4,6 +4,7 @@
  */
 #include <algorithm>
 #include <numeric>
+#include <tuple>
 #include <utility>
 
 #include <gtest/gtest.h>
@@ -125,7 +126,7 @@ TEST_P(BufferAllocator, TestThrowAfterRelease)
     auto releasedBuffer = buffer->release();
 
     EXPECT_THROW(buffer->data(), std::runtime_error);
-    EXPECT_THROW(buffer->release(), std::runtime_error);
+    EXPECT_THROW(std::ignore = buffer->release(), std::runtime_error);
 
     free(releasedBuffer);
   } else if (_type == ucxx::BufferType::RMM) {


### PR DESCRIPTION
Improve compile-time error reports by marking appropriate C++ constructors and getters with `[[nodiscard]]`.