### PR TITLE
Drop `numpy` from `requirements/host`

### DIFF
--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -223,7 +223,6 @@ outputs:
         - pip
         - scikit-build-core >=0.7.0
         - cython >=3.0.0
-        - numpy 1.23
         - {{ pin_subpackage('libucxx', exact=True) }}
         - ucx
         - rapids-build-backend >=0.3.0,<0.4.0.dev0
@@ -240,7 +239,7 @@ outputs:
         - ucx >=1.15.0,<1.16.0
         - {{ pin_subpackage('libucxx', exact=True) }}
         - {{ pin_compatible('rmm', max_pin='x.x') }}
-        - {{ pin_compatible('numpy') }}
+        - numpy>=1.23,<2.0a0
         - pynvml >=11.4.1
       run_constrained:
         - cupy >=9.5.0


### PR DESCRIPTION
Partially addresses issue: https://github.com/rapidsai/build-planning/issues/82

As UCXX no longer needs NumPy during the build, make sure the Conda packages do not use it when building UCXX.