### PR TITLE
Restore `*.pxd` files in ucxx wheel

### DIFF
--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -73,7 +73,7 @@ ninja.make-fallback = true
 sdist.exclude = ["*tests*"]
 sdist.reproducible = true
 wheel.packages = ["ucxx"]
-wheel.exclude = ["*.pyx", "*.pxd", "CMakeLists.txt"]
+wheel.exclude = ["*.pyx", "CMakeLists.txt"]
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"


### PR DESCRIPTION
`*.pxd` files were mistakenly removed in https://github.com/rapidsai/ucxx/pull/260. Resume installing them in the ucxx wheel.