### PR TITLE
WIP: [DO NOT MERGE] Update fmt (to 11.0.2) and spdlog (to 1.14.1).

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -21,7 +21,7 @@ dependencies:
 - dask-cuda==24.10.*,>=0.0.0a0
 - dask-cudf==24.10.*,>=0.0.0a0
 - doxygen=1.9.1
-- fmt>=10.1.1,<11
+- fmt>=11.0.2,<12
 - librmm==24.10.*,>=0.0.0a0
 - libtool
 - ninja
@@ -40,6 +40,6 @@ dependencies:
 - rmm==24.10.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - setuptools>=64.0.0
-- spdlog>=1.12.0,<1.13
+- spdlog>=1.14.1,<1.15
 - ucx>=1.15.0,<1.18
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -21,7 +21,7 @@ dependencies:
 - dask-cuda==24.10.*,>=0.0.0a0
 - dask-cudf==24.10.*,>=0.0.0a0
 - doxygen=1.9.1
-- fmt>=10.1.1,<11
+- fmt>=11.0.2,<12
 - librmm==24.10.*,>=0.0.0a0
 - libtool
 - ninja
@@ -40,6 +40,6 @@ dependencies:
 - rmm==24.10.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - setuptools>=64.0.0
-- spdlog>=1.12.0,<1.13
+- spdlog>=1.14.1,<1.15
 - ucx>=1.15.0,<1.18
 name: all_cuda-125_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -156,10 +156,10 @@ dependencies:
           - c-compiler
           - cxx-compiler
           - &cmake_ver cmake>=3.26.4,!=3.30.0
-          - fmt>=10.1.1,<11
+          - fmt>=11.0.2,<12
           - librmm==24.10.*,>=0.0.0a0
           - ninja
-          - spdlog>=1.12.0,<1.13
+          - spdlog>=1.14.1,<1.15
       - output_types: [requirements, pyproject]
         packages:
           - *cmake_ver

--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -10,6 +10,8 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
+  set(rapids-cmake-repo jameslamb/rapids-cmake)
+  set(rapids-cmake-branch fmt-and-spdlog)
 # =============================================================================
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/UCXX_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-24.10/RAPIDS.cmake


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/56

Now that most of `conda-forge` has been updated to `fmt >=11.0.1,<12` and `spdlog>=1.14.1,<1.15` (https://github.com/rapidsai/build-planning/issues/56#issuecomment-2334281452), we're attempting to upgrade RAPIDS to similar versions of those libraries.
This improves the likelihood that RAPIDS will be installable alongside newer versions of its
dependencies and complementary packages on conda-forge.

## Notes for Reviewers

This PR is testing changes made in https://github.com/rapidsai/rapids-cmake/pull/689.
It shouldn't be merged until those `rapids-cmake` changes are merged and any
testing-specific details have been removed.
