### PR TITLE
Update update-version.sh to use packaging lib

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -20,8 +20,8 @@ NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 NEXT_RAPIDS_SHORT_TAG="$(curl -sL https://version.gpuci.io/ucx-py/${NEXT_SHORT_TAG})"
 
 # Need to distutils-normalize the versions for some use cases
-NEXT_SHORT_TAG_PEP440=$(python -c "from setuptools.extern import packaging; print(packaging.version.Version('${NEXT_SHORT_TAG}'))")
-NEXT_RAPIDS_SHORT_TAG_PEP440=$(python -c "from setuptools.extern import packaging; print(packaging.version.Version('${NEXT_RAPIDS_SHORT_TAG}'))")
+NEXT_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(Version('${NEXT_SHORT_TAG}'))")
+NEXT_RAPIDS_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(Version('${NEXT_RAPIDS_SHORT_TAG}'))")
 echo "Next tag is ${NEXT_RAPIDS_SHORT_TAG_PEP440}"
 
 echo "Preparing release: $NEXT_FULL_TAG"


### PR DESCRIPTION
This PR updates the update-version.sh script to use the packaging library, given that setuptools is no longer included by default in Python 3.12.
