### PR TITLE
Fix license name in libucxx wheel

### DIFF
--- a/python/libucxx/pyproject.toml
+++ b/python/libucxx/pyproject.toml
@@ -16,7 +16,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = { text = "BSD-3-Clause" }
 classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",


### PR DESCRIPTION
Updates the license name in `libucxx` to match the actual license
