### PR TITLE
Fix issues creating endpoints and with wireup

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/ucxx.py
@@ -527,6 +527,7 @@ class UCXXConnector(Connector):
             ucxx.exceptions.UCXCloseError,
             ucxx.exceptions.UCXCanceledError,
             ucxx.exceptions.UCXConnectionResetError,
+            ucxx.exceptions.UCXMessageTruncatedError,
             ucxx.exceptions.UCXNotConnectedError,
             ucxx.exceptions.UCXUnreachableError,
         ):

--- a/python/ucxx/ucxx/_lib/tests/test_server_client.py
+++ b/python/ucxx/ucxx/_lib/tests/test_server_client.py
@@ -48,6 +48,8 @@ def _echo_server(get_queue, put_queue, transfer_api, msg_size, progress_mode):
         feature_flags.append(ucx_api.Feature.AM)
     elif transfer_api == "stream":
         feature_flags.append(ucx_api.Feature.STREAM)
+    else:
+        feature_flags.append(ucx_api.Feature.TAG)
 
     ctx = ucx_api.UCXContext(feature_flags=tuple(feature_flags))
     worker = ucx_api.UCXWorker(ctx)
@@ -114,11 +116,13 @@ def _echo_server(get_queue, put_queue, transfer_api, msg_size, progress_mode):
 
 def _echo_client(transfer_api, msg_size, progress_mode, port):
     # TAG is always used for wireup
-    feature_flags = [ucx_api.Feature.WAKEUP, ucx_api.Feature.TAG]
+    feature_flags = [ucx_api.Feature.WAKEUP]
     if transfer_api == "am":
         feature_flags.append(ucx_api.Feature.AM)
-    if transfer_api == "stream":
+    elif transfer_api == "stream":
         feature_flags.append(ucx_api.Feature.STREAM)
+    else:
+        feature_flags.append(ucx_api.Feature.TAG)
 
     ctx = ucx_api.UCXContext(feature_flags=tuple(feature_flags))
     worker = ucx_api.UCXWorker(ctx)

--- a/python/ucxx/ucxx/_lib_async/application_context.py
+++ b/python/ucxx/ucxx/_lib_async/application_context.py
@@ -365,11 +365,14 @@ class ApplicationContext:
                 listener=False,
                 stream_timeout=exchange_peer_info_timeout,
             )
-        except UCXMessageTruncatedError:
+        except UCXMessageTruncatedError as e:
             # A truncated message occurs if the remote endpoint closed before
             # exchanging peer info, in that case we should raise the endpoint
-            # error instead.
+            # error, if available.
             ucx_ep.raise_on_error()
+            # If no endpoint error is available, re-raise exception.
+            raise e
+
         tags = {
             "msg_send": peer_info["msg_tag"],
             "msg_recv": msg_tag,


### PR DESCRIPTION
Fix bug with `create_endpoint`, where a `UCXMessageTruncatedError` may not be properly raised, as well as its use in `distributed-ucxx` not raising the exception expected by `distributed`.

Additionally, fix wireup issues in tests, where only sending (or receiving) a wireup message does not seem to suffice, but sending _and_ receiving suffices to prevent errors in tests.