### PR TITLE
make conda installs in CI stricter

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
+export UCXX_VERSION="$(rapids-version)"
+UCXX_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+
 ENV_YAML_DIR="$(mktemp -d)"
 
 rapids-dependency-file-generator \
@@ -23,11 +26,8 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
-  libucxx
+  "libucxx=${UCXX_VERSION}"
 
-export UCXX_VERSION="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2.\3/' VERSION)"
-export UCXX_VERSION_MAJOR_MINOR="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2/' VERSION)"
-export RAPIDS_VERSION_NUMBER="$UCXX_VERSION_MAJOR_MINOR"
 export RAPIDS_DOCS_DIR="$(mktemp -d)"
 
 rapids-logger "Build CPP docs"
@@ -37,4 +37,4 @@ mkdir -p "${RAPIDS_DOCS_DIR}/libucxx/html"
 mv html/* "${RAPIDS_DOCS_DIR}/libucxx/html"
 popd
 
-rapids-upload-docs
+RAPIDS_VERSION_NUMBER="${UCXX_VERSION_MAJOR_MINOR}" rapids-upload-docs

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-export UCXX_VERSION="$(rapids-version)"
-UCXX_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+export UCXX_VERSION="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2.\3/' VERSION)"
+UCXX_VERSION_MAJOR_MINOR="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2/' VERSION)"
 
 ENV_YAML_DIR="$(mktemp -d)"
 

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-export UCXX_VERSION="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2.\3/' VERSION)"
+export UCXX_VERSION="$(head -1 ./VERSION)"
 UCXX_VERSION_MAJOR_MINOR="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2/' VERSION)"
 
 ENV_YAML_DIR="$(mktemp -d)"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/test_common.sh"
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-UCXX_VERSION="$(rapids-version)"
+UCXX_VERSION="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2.\3/' VERSION)"
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/test_common.sh"
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-UCXX_VERSION="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2.\3/' VERSION)"
+UCXX_VERSION="$(head -1 ./VERSION)"
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -10,6 +10,8 @@ source "$(dirname "$0")/test_common.sh"
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
+UCXX_VERSION="$(rapids-version)"
+
 rapids-dependency-file-generator \
   --output conda \
   --file-key test_cpp \
@@ -29,7 +31,9 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
-  libucxx libucxx-examples libucxx-tests
+  "libucxx=${UCXX_VERSION}" \
+  "libucxx-examples=${UCXX_VERSION}" \
+  "libucxx-tests=${UCXX_VERSION}"
 
 print_ucx_config
 

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/test_common.sh"
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-UCXX_VERSION="$(rapids-version)"
+UCXX_VERSION="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2.\3/' VERSION)"
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/test_common.sh"
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-UCXX_VERSION="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2.\3/' VERSION)"
+UCXX_VERSION="$(head -1 ./VERSION)"
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -10,6 +10,8 @@ source "$(dirname "$0")/test_common.sh"
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
+UCXX_VERSION="$(rapids-version)"
+
 rapids-dependency-file-generator \
   --output conda \
   --file-key test_python \
@@ -27,7 +29,8 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
-  libucxx ucxx
+  "libucxx=${UCXX_VERSION}" \
+  "ucxx=${UCXX_VERSION}"
 
 print_ucx_config
 

--- a/ci/test_python_distributed.sh
+++ b/ci/test_python_distributed.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/test_common.sh"
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-UCXX_VERSION="$(rapids-version)"
+UCXX_VERSION="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2.\3/' VERSION)"
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_python_distributed.sh
+++ b/ci/test_python_distributed.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/test_common.sh"
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-UCXX_VERSION="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2.\3/' VERSION)"
+UCXX_VERSION="$(head -1 ./VERSION)"
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_python_distributed.sh
+++ b/ci/test_python_distributed.sh
@@ -10,6 +10,8 @@ source "$(dirname "$0")/test_common.sh"
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
+UCXX_VERSION="$(rapids-version)"
+
 rapids-dependency-file-generator \
   --output conda \
   --file-key test_python_distributed \
@@ -27,7 +29,9 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
-  libucxx ucxx distributed-ucxx
+  "libucxx=${UCXX_VERSION}" \
+  "ucxx=${UCXX_VERSION}" \
+  "distributed-ucxx=${UCXX_VERSION}"
 
 print_ucx_config
 


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/106

Proposes specifying the RAPIDS version in `conda install` calls in CI that install CI artifacts, to reduce the risk of CI jobs picking up artifacts from other releases.