### PR TITLE
Prevent canceling uncancelable generic callbacks

### DIFF
--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -420,8 +420,12 @@ class Worker : public Component {
    * If `period` is `0` this is a blocking call that only returns when the callback has been
    * executed and will always return `true`, and if `period` is a positive integer the time
    * in nanoseconds will be waited for the callback to complete and return `true` in the
-   * successful case or `false` otherwise. `period` only applies if the worker progress
-   * thread is running, otherwise the callback is immediately executed.
+   * successful case or `false` otherwise. However, if the callback is not cancelable
+   * anymore (i.e., it has already started), this method will keep retrying and may never
+   * return if the callback never completes, it is unsafe to return as this would allow the
+   * caller to destroy the callback and its resources causing undefined behavior. `period`
+   * only applies if the worker progress thread is running, otherwise the callback is
+   * immediately executed.
    *
    * @param[in] callback  the callback to execute before progressing the worker.
    * @param[in] period    the time in nanoseconds to wait for the callback to complete.
@@ -445,8 +449,12 @@ class Worker : public Component {
    * If `period` is `0` this is a blocking call that only returns when the callback has been
    * executed and will always return `true`, and if `period` is a positive integer the time
    * in nanoseconds will be waited for the callback to complete and return `true` in the
-   * successful case or `false` otherwise. `period` only applies if the worker progress
-   * thread is running, otherwise the callback is immediately executed.
+   * successful case or `false` otherwise. However, if the callback is not cancelable
+   * anymore (i.e., it has already started), this method will keep retrying and may never
+   * return if the callback never completes, it is unsafe to return as this would allow the
+   * caller to destroy the callback and its resources causing undefined behavior. `period`
+   * only applies if the worker progress thread is running, otherwise the callback is
+   * immediately executed.
    *
    * @param[in] callback  the callback to execute before progressing the worker.
    * @param[in] period    the time in nanoseconds to wait for the callback to complete.

--- a/cpp/src/delayed_submission.cpp
+++ b/cpp/src/delayed_submission.cpp
@@ -94,6 +94,6 @@ ItemIdType DelayedSubmissionCollection::registerGenericPost(DelayedSubmissionCal
 
 void DelayedSubmissionCollection::cancelGenericPre(ItemIdType id) { _genericPre.cancel(id); }
 
-void DelayedSubmissionCollection::cancelGenericPost(ItemIdType id) { _genericPre.cancel(id); }
+void DelayedSubmissionCollection::cancelGenericPost(ItemIdType id) { _genericPost.cancel(id); }
 
 }  // namespace ucxx

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -97,6 +97,8 @@ void endpointErrorCallback(void* arg, ucp_ep_h ep, ucs_status_t status)
                ep,
                status,
                ucs_status_string(status));
+
+  std::swap(endpoint->_handle, endpoint->_originalHandle);
 }
 
 Endpoint::Endpoint(std::shared_ptr<Component> workerOrListener, bool endpointErrorHandling)
@@ -136,10 +138,12 @@ void Endpoint::create(ucp_ep_params_t* params)
             3000000000 /* 3s */))
         break;
 
-      if (i == maxAttempts - 1)
+      if (i == maxAttempts - 1) {
+        status = UCS_ERR_TIMED_OUT;
         ucxx_error("Timeout waiting for ucp_ep_create, all attempts failed");
-      else
+      } else {
         ucxx_warn("Timeout waiting for ucp_ep_create, retrying");
+      }
     }
     utils::ucsErrorThrow(status);
   } else {

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -97,8 +97,6 @@ void endpointErrorCallback(void* arg, ucp_ep_h ep, ucs_status_t status)
                ep,
                status,
                ucs_status_string(status));
-
-  std::swap(endpoint->_handle, endpoint->_originalHandle);
 }
 
 Endpoint::Endpoint(std::shared_ptr<Component> workerOrListener, bool endpointErrorHandling)

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -381,7 +381,7 @@ bool Worker::registerGenericPost(DelayedSubmissionCallbackType callback, uint64_
       auto ret = callbackNotifier.wait(period, signalWorkerFunction);
 
       try {
-        if (!ret) _delayedSubmissionCollection->cancelGenericPre(id);
+        if (!ret) _delayedSubmissionCollection->cancelGenericPost(id);
         return ret;
       } catch (const std::runtime_error& e) {
         if (++retryCount % 10 == 0)

--- a/cpp/src/worker_progress_thread.cpp
+++ b/cpp/src/worker_progress_thread.cpp
@@ -83,7 +83,7 @@ void WorkerProgressThread::stop()
   });
   _signalWorkerFunction();
   if (!callbackNotifierPost.wait(3000000000)) {
-    _delayedSubmissionCollection->cancelGenericPre(idPost);
+    _delayedSubmissionCollection->cancelGenericPost(idPost);
   }
 
   _thread.join();

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -18,6 +18,18 @@ namespace {
 using ::testing::Combine;
 using ::testing::Values;
 
+enum class GenericCallbackType {
+  None = 0,
+  Pre,
+  Post,
+  PrePost,
+  PostPre,
+};
+
+struct ExtraParams {
+  GenericCallbackType genericCallbackType{GenericCallbackType::None};
+};
+
 class WorkerTest : public ::testing::Test {
  protected:
   std::shared_ptr<ucxx::Context> _context{
@@ -44,16 +56,18 @@ class WorkerCapabilityTest : public ::testing::Test,
   }
 };
 
-class WorkerProgressTest : public WorkerTest,
-                           public ::testing::WithParamInterface<std::tuple<bool, ProgressMode>> {
+class WorkerProgressTest
+  : public WorkerTest,
+    public ::testing::WithParamInterface<std::tuple<bool, ProgressMode, ExtraParams>> {
  protected:
   std::function<void()> _progressWorker;
   bool _enableDelayedSubmission;
   ProgressMode _progressMode;
+  ExtraParams _extraParams;
 
   void SetUp()
   {
-    std::tie(_enableDelayedSubmission, _progressMode) = GetParam();
+    std::tie(_enableDelayedSubmission, _progressMode, _extraParams) = GetParam();
 
     _worker = _context->createWorker(_enableDelayedSubmission);
 
@@ -69,6 +83,8 @@ class WorkerProgressTest : public WorkerTest,
 };
 
 class WorkerGenericCallbackTest : public WorkerProgressTest {};
+
+class WorkerGenericCallbackSingleTest : public WorkerProgressTest {};
 
 TEST_F(WorkerTest, HandleIsValid) { ASSERT_TRUE(_worker->getHandle() != nullptr); }
 
@@ -323,38 +339,33 @@ TEST_P(WorkerProgressTest, ProgressTagMulti)
   }
 }
 
-TEST_P(WorkerGenericCallbackTest, RegisterGenericPre)
+TEST_P(WorkerGenericCallbackTest, RegisterGeneric)
 {
-  bool done     = false;
-  auto callback = [&done]() { done = true; };
+  bool done1     = false;
+  bool done2     = false;
+  auto callback1 = [&done1]() { done1 = true; };
+  auto callback2 = [&done2]() { done2 = true; };
 
-  ASSERT_TRUE(_worker->registerGenericPre(callback));
-  ASSERT_TRUE(done);
+  if (_extraParams.genericCallbackType == GenericCallbackType::Pre) {
+    ASSERT_TRUE(_worker->registerGenericPre(callback1));
+    ASSERT_TRUE(done1);
+  } else if (_extraParams.genericCallbackType == GenericCallbackType::Post) {
+    ASSERT_TRUE(_worker->registerGenericPre(callback1));
+    ASSERT_TRUE(done1);
+  } else if (_extraParams.genericCallbackType == GenericCallbackType::PrePost) {
+    ASSERT_TRUE(_worker->registerGenericPre(callback1));
+    ASSERT_TRUE(_worker->registerGenericPost(callback2));
+    ASSERT_TRUE(done1);
+    ASSERT_TRUE(done2);
+  } else if (_extraParams.genericCallbackType == GenericCallbackType::PostPre) {
+    ASSERT_TRUE(_worker->registerGenericPost(callback1));
+    ASSERT_TRUE(_worker->registerGenericPre(callback2));
+    ASSERT_TRUE(done1);
+    ASSERT_TRUE(done2);
+  }
 }
 
-TEST_P(WorkerGenericCallbackTest, RegisterGenericPost)
-{
-  bool done     = false;
-  auto callback = [&done]() { done = true; };
-
-  ASSERT_TRUE(_worker->registerGenericPost(callback));
-  ASSERT_TRUE(done);
-}
-
-TEST_P(WorkerGenericCallbackTest, RegisterGenericPrePost)
-{
-  bool donePre      = false;
-  bool donePost     = false;
-  auto callbackPre  = [&donePre]() { donePre = true; };
-  auto callbackPost = [&donePost]() { donePost = true; };
-
-  ASSERT_TRUE(_worker->registerGenericPre(callbackPre));
-  ASSERT_TRUE(_worker->registerGenericPost(callbackPost));
-  ASSERT_TRUE(donePre);
-  ASSERT_TRUE(donePost);
-}
-
-TEST_P(WorkerGenericCallbackTest, RegisterGenericPreCancel)
+TEST_P(WorkerGenericCallbackTest, RegisterGenericCancel)
 {
   bool threadStarted   = false;
   bool terminateThread = false;
@@ -378,7 +389,13 @@ TEST_P(WorkerGenericCallbackTest, RegisterGenericPreCancel)
         }
       };
 
-      ASSERT_TRUE(_worker->registerGenericPre(threadCallback));
+      if (_extraParams.genericCallbackType == GenericCallbackType::Pre ||
+          _extraParams.genericCallbackType == GenericCallbackType::PrePost) {
+        ASSERT_TRUE(_worker->registerGenericPre(threadCallback));
+      } else if (_extraParams.genericCallbackType == GenericCallbackType::Post ||
+                 _extraParams.genericCallbackType == GenericCallbackType::PostPre) {
+        ASSERT_TRUE(_worker->registerGenericPost(threadCallback));
+      }
     });
 
   {
@@ -388,7 +405,14 @@ TEST_P(WorkerGenericCallbackTest, RegisterGenericPreCancel)
   }
 
   // The thread should be running, therefore the callback will be canceled before running.
-  ASSERT_FALSE(_worker->registerGenericPre(callback, 1));
+  // Note here `PrePost`/`PostPre` order is the opposite as from `thread`.
+  if (_extraParams.genericCallbackType == GenericCallbackType::Pre ||
+      _extraParams.genericCallbackType == GenericCallbackType::PostPre) {
+    ASSERT_FALSE(_worker->registerGenericPre(callback, 1));
+  } else if (_extraParams.genericCallbackType == GenericCallbackType::Post ||
+             _extraParams.genericCallbackType == GenericCallbackType::PrePost) {
+    ASSERT_FALSE(_worker->registerGenericPost(callback, 1));
+  }
   ASSERT_FALSE(done);
 
   // Unblock thread to terminate.
@@ -397,11 +421,18 @@ TEST_P(WorkerGenericCallbackTest, RegisterGenericPreCancel)
   thread.join();
 
   // Nothing should be blocking the progress thread now, the callback should succeed.
-  ASSERT_TRUE(_worker->registerGenericPre(callback));
+  // Note here `PrePost`/`PostPre` order is the opposite as from `thread`.
+  if (_extraParams.genericCallbackType == GenericCallbackType::Pre ||
+      _extraParams.genericCallbackType == GenericCallbackType::PostPre) {
+    ASSERT_TRUE(_worker->registerGenericPre(callback));
+  } else if (_extraParams.genericCallbackType == GenericCallbackType::Post ||
+             _extraParams.genericCallbackType == GenericCallbackType::PrePost) {
+    ASSERT_TRUE(_worker->registerGenericPost(callback));
+  }
   ASSERT_TRUE(done);
 }
 
-TEST_P(WorkerGenericCallbackTest, RegisterGenericPreUncancelable)
+TEST_P(WorkerGenericCallbackSingleTest, RegisterGenericPreUncancelable)
 {
   bool terminateThread = false;
   bool match           = false;
@@ -419,7 +450,10 @@ TEST_P(WorkerGenericCallbackTest, RegisterGenericPreUncancelable)
 
     // This will submit the callback and attempt to cancel once every 1ms,
     // a warning is logged when multiples of 10 attempts to cancel are made.
-    ASSERT_TRUE(_worker->registerGenericPre(threadCallback, 1000000 /* 1ms */));
+    if (_extraParams.genericCallbackType == GenericCallbackType::Pre)
+      ASSERT_TRUE(_worker->registerGenericPre(threadCallback, 1000000 /* 1ms */));
+    else if (_extraParams.genericCallbackType == GenericCallbackType::Post)
+      ASSERT_TRUE(_worker->registerGenericPost(threadCallback, 1000000 /* 1ms */));
   });
 
   loopWithTimeout(std::chrono::milliseconds(5000), [&match] {
@@ -450,16 +484,31 @@ INSTANTIATE_TEST_SUITE_P(ProgressModes,
                                         ProgressMode::Blocking,
                                         ProgressMode::Wait,
                                         ProgressMode::ThreadPolling,
-                                        ProgressMode::ThreadBlocking)));
+                                        ProgressMode::ThreadBlocking),
+                                 Values(ExtraParams{})));
+
+INSTANTIATE_TEST_SUITE_P(DelayedSubmission,
+                         WorkerProgressTest,
+                         Combine(Values(true),
+                                 Values(ProgressMode::ThreadPolling, ProgressMode::ThreadBlocking),
+                                 Values(ExtraParams{})));
 
 INSTANTIATE_TEST_SUITE_P(
   GenericCallbacks,
   WorkerGenericCallbackTest,
-  Combine(Values(false), Values(ProgressMode::ThreadPolling, ProgressMode::ThreadBlocking)));
+  Combine(Values(false, true),
+          Values(ProgressMode::ThreadPolling, ProgressMode::ThreadBlocking),
+          Values(ExtraParams{.genericCallbackType = GenericCallbackType::Pre},
+                 ExtraParams{.genericCallbackType = GenericCallbackType::Post},
+                 ExtraParams{.genericCallbackType = GenericCallbackType::PrePost},
+                 ExtraParams{.genericCallbackType = GenericCallbackType::PostPre})));
 
 INSTANTIATE_TEST_SUITE_P(
-  DelayedSubmission,
-  WorkerProgressTest,
-  Combine(Values(true), Values(ProgressMode::ThreadPolling, ProgressMode::ThreadBlocking)));
+  GenericCallbacksSingle,
+  WorkerGenericCallbackSingleTest,
+  Combine(Values(false, true),
+          Values(ProgressMode::ThreadPolling, ProgressMode::ThreadBlocking),
+          Values(ExtraParams{.genericCallbackType = GenericCallbackType::Pre},
+                 ExtraParams{.genericCallbackType = GenericCallbackType::Post})));
 
 }  // namespace


### PR DESCRIPTION
Generic callbacks should not be canceled once they start running. The guarantee provided by `ucxx::Worker` is that once the function returns it should be safe to destroy the callback and all its associated resources, which becomes invalid if the callback is scheduled for cancellation but it is already running, therefore, it's a requirement to check whether the callback is already executing and block it until it's finished. If the callback never completes this may cause an irrecoverable hang which cannot be dealt with from UCXX since it's impossible to stop a callback from executing once it has started, it's the user's responsibility to guarantee the callback must return. A warning is raised after multiples of 10 attempts have been tried to cancel a callback that is being executed and canceling did not succeed, so that the user is informed of what is happening.

The most notable issue is somewhat frequently observable in CI, where the Python async test `test_from_worker_address_multinode` would segfault, in particular with larger amount of endpoints. This was observable in those tests more frequently because there's a large amount of endpoints being created simultaneously by multiple processes, putting more pressure in the resources and causing endpoint creation to take several seconds to complete. In those cases the generic callback executing `ucp_ep_create` would take longer than the default timeout of 3 seconds and in some cases that would be interpreted as the callback timed out, since `ucp_ep_create` itself took longer than 3 seconds, causing the worker to attempt to cancel the callback while it was still executing. With this change, the callback will still timeout but only if it didn't start executing yet, if `ucp_ep_create` ends up never returning, this will cause a deadlock in the application but there's no way for UCXX to recover on its own and warnings are raised, although those hypothetical deadlocks have not been observed in local tests so far. Segfaults should not occur in this situation anymore.

Additionally, unit tests for generic callbacks are now included, which previously were a gap in the testing suite.