### PR TITLE
Update to CCCL 2.7.0-rc2.

### DIFF
--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -11,6 +11,10 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+
+set(rapids-cmake-repo bdice/rapids-cmake)
+set(rapids-cmake-branch cccl-2.7.0-rc2)
+
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/UCXX_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-24.12/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/UCXX_RAPIDS.cmake


### PR DESCRIPTION
This PR updates to CCCL 2.7.0-rc2. Do not merge until all of RAPIDS is ready to update.

Part of https://github.com/rapidsai/build-planning/issues/115.
