### PR TITLE
Switch to AM in `exchange_peer_info()`

### DIFF
--- a/python/ucxx/ucxx/_lib_async/application_context.py
+++ b/python/ucxx/ucxx/_lib_async/application_context.py
@@ -365,7 +365,7 @@ class ApplicationContext:
                 msg_tag=msg_tag,
                 ctrl_tag=ctrl_tag,
                 listener=False,
-                stream_timeout=exchange_peer_info_timeout,
+                timeout=exchange_peer_info_timeout,
             )
         except UCXMessageTruncatedError as e:
             # A truncated message occurs if the remote endpoint closed before

--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -146,7 +146,7 @@ async def _listener_handler_coroutine(
             msg_tag=msg_tag,
             ctrl_tag=ctrl_tag,
             listener=True,
-            stream_timeout=exchange_peer_info_timeout,
+            timeout=exchange_peer_info_timeout,
         )
     except UCXMessageTruncatedError:
         # A truncated message occurs if the remote endpoint closed before


### PR DESCRIPTION
The UCX stream API currently has only one use in UCXX: exchanging peer information during endpoint establishment phase. The stream API is generally less well-supported and limited w.r.t. transports supported, etc. At scale, using the stream API has shown to be fragile, and although we were never definitively able to confirm the issues were entirely due to the stream messages, using active messages to exchange peer information should provide us with more confidence in the long-term.