### PR TITLE
Increase Python core tests timeout

### DIFF
--- a/ci/test_common.sh
+++ b/ci/test_common.sh
@@ -117,9 +117,9 @@ run_cpp_port_retry() {
 
 #################################### Python ####################################
 run_py_tests() {
-  CMD_LINE="timeout 2m python -m pytest -vs python/ucxx/ucxx/_lib/tests/"
+  CMD_LINE="timeout 4m python -m pytest -vs python/ucxx/ucxx/_lib/tests/"
   log_command "${CMD_LINE}"
-  timeout 2m python -m pytest -vs python/ucxx/ucxx/_lib/tests/
+  timeout 4m python -m pytest -vs python/ucxx/ucxx/_lib/tests/
 }
 
 run_py_tests_async() {


### PR DESCRIPTION
The timeout for Python core tests seems now too tight, possibly due to high CI load at times. Double timeout from 2 minutes to 4 minutes.