### PR TITLE
Update cpplint version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
                 types_or: [file]
                 args: ['-fallback-style=none', '-style=file', '-i']
       - repo: https://github.com/cpplint/cpplint
-        rev: 1.6.1
+        rev: 2.0.0
         hooks:
               - id: cpplint
                 name: cpplint

--- a/cpp/python/src/exception.cpp
+++ b/cpp/python/src/exception.cpp
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <cstdio>
 #include <ios>
 #include <stdexcept>
 

--- a/cpp/python/src/worker.cpp
+++ b/cpp/python/src/worker.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <mutex>
 #include <sstream>
+#include <utility>
 
 #include <Python.h>
 

--- a/cpp/src/config.cpp
+++ b/cpp/src/config.cpp
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <cstdio>
 #include <sstream>
 #include <string>
 

--- a/cpp/src/context.cpp
+++ b/cpp/src/context.cpp
@@ -2,10 +2,12 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <ucxx/context.h>
 #include <ucxx/log.h>

--- a/cpp/src/delayed_submission.cpp
+++ b/cpp/src/delayed_submission.cpp
@@ -4,6 +4,7 @@
  */
 #include <memory>
 #include <mutex>
+#include <string>
 #include <utility>
 
 #include <ucp/api/ucp.h>

--- a/cpp/src/internal/request_am.cpp
+++ b/cpp/src/internal/request_am.cpp
@@ -8,6 +8,8 @@
 #include <ucxx/request_am.h>
 #include <ucxx/typedefs.h>
 
+#include <memory>
+
 namespace ucxx {
 
 namespace internal {

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -4,6 +4,7 @@
  */
 #include <memory>
 #include <netinet/in.h>
+#include <string>
 #include <utility>
 
 #include <ucp/api/ucp.h>
@@ -42,7 +43,7 @@ Listener::Listener(std::shared_ptr<Worker> worker,
   ucxx::utils::sockaddr_get_ip_port_str(&attr.sockaddr, ipString, portString, INET6_ADDRSTRLEN);
 
   _ip   = std::string(ipString);
-  _port = (uint16_t)atoi(portString);
+  _port = static_cast<uint16_t>(atoi(portString));
 
   setParent(worker);
 }

--- a/cpp/src/memory_handle.cpp
+++ b/cpp/src/memory_handle.cpp
@@ -45,7 +45,7 @@ MemoryHandle::MemoryHandle(std::shared_ptr<Context> context,
 
   utils::ucsErrorThrow(ucp_mem_query(_handle, &attr));
 
-  _baseAddress = (uint64_t)attr.address;
+  _baseAddress = reinterpret_cast<uint64_t>(attr.address);
   _size        = attr.length;
   _memoryType  = attr.mem_type;
 

--- a/cpp/src/remote_key.cpp
+++ b/cpp/src/remote_key.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include <ucp/api/ucp.h>
 
@@ -84,7 +85,7 @@ std::shared_ptr<RemoteKey> createRemoteKeyFromSerialized(std::shared_ptr<Endpoin
 
 size_t RemoteKey::getSize() const { return _memorySize; }
 
-uint64_t RemoteKey::getBaseAddress() { return (uint64_t)_memoryBaseAddress; }
+uint64_t RemoteKey::getBaseAddress() { return static_cast<uint64_t>(_memoryBaseAddress); }
 
 ucp_rkey_h RemoteKey::getHandle() { return _remoteKey; }
 

--- a/cpp/src/request_am.cpp
+++ b/cpp/src/request_am.cpp
@@ -4,9 +4,11 @@
  */
 #include <cstdio>
 #include <memory>
+#include <queue>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <ucp/api/ucp.h>
 

--- a/cpp/src/request_data.cpp
+++ b/cpp/src/request_data.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <stdexcept>
+#include <vector>
 
 #include <ucp/api/ucp.h>
 

--- a/cpp/src/request_stream.cpp
+++ b/cpp/src/request_stream.cpp
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <cstdio>
 #include <memory>
 #include <string>
 

--- a/cpp/src/request_tag_multi.cpp
+++ b/cpp/src/request_tag_multi.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <ucxx/buffer.h>

--- a/cpp/src/utils/sockaddr.cpp
+++ b/cpp/src/utils/sockaddr.cpp
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <arpa/inet.h>
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <netdb.h>
-#include <stdlib.h>
-#include <string.h>
+#include <string>
 #include <sys/socket.h>
 
 #include <ucxx/exception.h>

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <cstdio>
 #include <functional>
 #include <ios>
 #include <memory>

--- a/cpp/tests/buffer.cpp
+++ b/cpp/tests/buffer.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>
+#include <memory>
 #include <numeric>
 #include <utility>
 

--- a/cpp/tests/context.cpp
+++ b/cpp/tests/context.cpp
@@ -4,6 +4,7 @@
  */
 #include <cstdlib>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
This PR updates our pre-commit to use the latest version of cpplint. This brings in [my fix](https://github.com/cpplint/cpplint/pull/269) that ensures that the pre-commit hook actually works in all environments. Without that fix, depending on the version of Python and setuptools in the base environment the cpplint installation may fail.