### PR TITLE
Remove RMM logger CMake targets and use forward declaration

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -188,8 +188,7 @@ target_compile_definitions(
 # Enable RMM if necessary
 if(UCXX_ENABLE_RMM)
     target_link_libraries(ucxx
-      PUBLIC rmm::rmm rmm::rmm_logger
-      PRIVATE rmm::rmm_logger_impl
+      PUBLIC rmm::rmm
     )
 
     # Define spdlog level

--- a/cpp/include/ucxx/buffer.h
+++ b/cpp/include/ucxx/buffer.h
@@ -9,9 +9,9 @@
 
 #include <ucxx/log.h>
 
-#if UCXX_ENABLE_RMM
-#include <rmm/device_buffer.hpp>
-#endif
+namespace rmm {
+class device_buffer;
+}
 
 namespace ucxx {
 

--- a/cpp/include/ucxx/buffer.h
+++ b/cpp/include/ucxx/buffer.h
@@ -10,8 +10,9 @@
 #include <ucxx/log.h>
 
 namespace rmm {
+// Forward declaration to prevent symbols from being added to symbol table unnecessarily.
 class device_buffer;
-}
+}  // namespace rmm
 
 namespace ucxx {
 

--- a/cpp/tests/buffer.cpp
+++ b/cpp/tests/buffer.cpp
@@ -11,6 +11,10 @@
 
 #include <ucxx/api.h>
 
+#if UCXX_ENABLE_RMM
+#include <rmm/device_buffer.hpp>
+#endif
+
 namespace {
 
 class BufferAllocator : public ::testing::Test,

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -20,6 +20,10 @@
 #include "ucxx/constructors.h"
 #include "ucxx/utils/ucx.h"
 
+#if UCXX_ENABLE_RMM
+#include <rmm/device_buffer.hpp>
+#endif
+
 namespace {
 
 using ::testing::Combine;


### PR DESCRIPTION
Remove RMM logger CMake targets that are unused by UCXX, and thus prevent unnecessary linking to spdlog/fmt. Use a forward declaration for `rmm::device_buffer` to avoid symbols being added to the symbol table.