### PR TITLE
avoid unnecessary wheel builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,8 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_libucxx.sh
+      # build for every combination of arch and CUDA version, but only for the latest Python
+      matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
   wheel-publish-libucxx:
     needs: wheel-build-libucxx
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -98,6 +98,8 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel_libucxx.sh
+      # build for every combination of arch and CUDA version, but only for the latest Python
+      matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
   wheel-build-ucxx:
     needs: wheel-build-libucxx
     secrets: inherit


### PR DESCRIPTION
Follow-up to #260.

Contributes to https://github.com/rapidsai/build-planning/issues/33

Limits `libucxx` wheel-building to just running once per combination of `(CUDA version, CPU architecture)`... cutting out 8 unnecessary CI jobs per commit.

## Notes for Reviewers

### Why is this safe to do?

Unlike wheels that have Cython code, `libucxx` wheels don't depend on the Python minor version

https://github.com/rapidsai/ucxx/blob/ec860d901f944625e506d85adc0e08021fa4ffd4/python/libucxx/pyproject.toml#L48

e.g., they have tags like

```text
libucxx_cu12-0.42.0a18-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
```

Similar filters are being used for most C++ wheel builds across RAPIDS, e.g. https://github.com/rapidsai/cudf/blob/a95fbc88f94df24c3418766fbbea5b6633ff2328/.github/workflows/pr.yaml#L222-L230