### PR TITLE
Remove `std::mutex()` from list-initialization

### DIFF
--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -55,9 +55,9 @@ class Endpoint : public Component {
   bool _endpointErrorHandling{true};  ///< Whether the endpoint enables error handling
   std::unique_ptr<InflightRequests> _inflightRequests{
     std::make_unique<InflightRequests>()};  ///< The inflight requests
-  std::mutex _mutex{std::mutex()};  ///< Mutex used during close to prevent race conditions between
-                                    ///< application thread and `ucxx::Endpoint::setCloseCallback()`
-                                    ///< that may run asynchronously on another thread.
+  std::mutex _mutex{};  ///< Mutex used during close to prevent race conditions between
+                        ///< application thread and `ucxx::Endpoint::setCloseCallback()`
+                        ///< that may run asynchronously on another thread.
   ucs_status_t _status{UCS_INPROGRESS};  ///< Endpoint status
   std::atomic<bool> _closing{false};     ///< Prevent calling close multiple concurrent times.
   EndpointCloseCallbackUserFunction _closeCallback{nullptr};  ///< Close callback to call


### PR DESCRIPTION
Remove the `std::mutex()` constructor call from list-initialization in `ucxx::Endpoint`. This is totally unnecessary and may cause issues with some compilers (or compiler options):

```
...
error: function "std::mutex::mutex(const std::mutex &)" (declared at line 94 of /opt/conda/envs/base/lib/gcc/x86_64-conda-linux-gnu/11.4.0/include/c++/bits/std_mutex.h) cannot be referenced -- it is a deleted function
```