### PR TITLE
Use rapids-generate-version for package versions

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -19,7 +19,7 @@ rapids-logger "Begin C++ and Python builds"
 
 sccache --zero-stats
 
-rapids-conda-retry mambabuild \
+RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry mambabuild \
   conda/recipes/ucxx
 
 sccache --show-adv-stats

--- a/conda/recipes/ucxx/meta.yaml
+++ b/conda/recipes/ucxx/meta.yaml
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
-{% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
-{% set minor_version = version.split('.')[0] + '.' + version.split('.')[1] %}
+{% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}
 {% set cuda_version = '.'.join(environ['RAPIDS_CUDA_VERSION'].split('.')[:2]) %}
 {% set cuda_major = cuda_version.split('.')[0] %}
 {% set date_string = environ['RAPIDS_DATE_STRING'] %}
@@ -189,7 +188,7 @@ outputs:
     script: build_and_install_ucxx.sh
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
-      string: cuda{{ cuda_major }}_py{{ python }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+      string: cuda{{ cuda_major }}_py{{ python | replace(".", "") }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:
         - {{ compiler('cuda') }}
         - ucx


### PR DESCRIPTION
This uses the value of `RAPIDS_PACKAGE_VERSION` for conda package versions.