### PR TITLE
Enable label checker ops-bot plugin

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -3,7 +3,7 @@
 
 auto_merger: true
 branch_checker: false
-label_checker: false
+label_checker: true
 release_drafter: false
 recently_updated: true
 forward_merger: true


### PR DESCRIPTION
Activates the label-checker function described here: https://docs.rapids.ai/resources/label-checker/