### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -13,7 +13,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
 requires-python = ">=3.10"
 dependencies = [
     "numba>=0.59.1,<0.61.0a0",

--- a/python/libucxx/pyproject.toml
+++ b/python/libucxx/pyproject.toml
@@ -16,7 +16,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
 classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",

--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -16,7 +16,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
 requires-python = ">=3.10"
 dependencies = [
     "libucxx==0.43.*,>=0.0.0a0",


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
