### PR TITLE
Register gpu marker with pytest

### DIFF
--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
 [build-system]
 build-backend = "rapids_build_backend.build"
 requires = [

--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -136,5 +136,6 @@ max_allowed_size_compressed = '75M'
 [tool.pytest.ini_options]
 markers = [
     "ignore_alive_references",
+    "gpu",
     "slow",
 ]


### PR DESCRIPTION
This will fix the warning seen in https://github.com/rapidsai/ucxx/actions/runs/13582599111/job/37971175348#step:10:610

```
../../../tmp/distributed/distributed/comm/tests/test_comms.py:573
  /tmp/distributed/distributed/comm/tests/test_comms.py:573: PytestUnknownMarkWarning: Unknown pytest.mark.gpu - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.gpu
```