### PR TITLE
Make `tagProbe` non-blocking

### DIFF
--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -688,6 +688,10 @@ class Worker : public Component {
    * by a corresponding `ucp_tag_recv_*` call. Additionally, returns information about the
    * tag message.
    *
+   * Note this is a non-blocking call, if this is being used to actively check for an
+   * incoming message the worker should be constantly progress until a valid probe is
+   * returned.
+   *
    * @code{.cpp}
    * // `worker` is `std::shared_ptr<ucxx::Worker>`
    * auto probe = worker->tagProbe(0);

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -583,19 +583,6 @@ TagRecvInfo::TagRecvInfo(const ucp_tag_recv_info_t& info)
 
 std::pair<bool, TagRecvInfo> Worker::tagProbe(const Tag tag, const TagMask tagMask)
 {
-  if (!isProgressThreadRunning()) {
-    progress();
-  } else {
-    /**
-     * To ensure the worker was progressed at least once, we must make sure a callback runs
-     * pre-progressing, and another one runs post-progress. Running post-progress only may
-     * indicate the progress thread has immediately finished executing and post-progress
-     * ran without a further progress operation.
-     */
-    std::ignore = registerGenericPre([]() {}, 3000000000 /* 3s */);
-    std::ignore = registerGenericPost([]() {}, 3000000000 /* 3s */);
-  }
-
   ucp_tag_recv_info_t info;
   ucp_tag_message_h tag_message = ucp_tag_probe_nb(_handle, tag, tagMask, 0, &info);
 

--- a/python/ucxx/ucxx/_lib_async/tests/test_probe.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_probe.py
@@ -25,7 +25,8 @@ async def test_message_probe(transfer_api):
             assert ep._ep.am_probe() is True
             received = bytes(await ep.am_recv())
         else:
-            assert ep._ctx.worker.tag_probe(Tag(ep._tags["msg_recv"])) is True
+            while ep._ctx.worker.tag_probe(Tag(ep._tags["msg_recv"])) is False:
+                ucxx.progress()
             received = bytearray(10)
             await ep.recv(received)
         assert received == msg

--- a/python/ucxx/ucxx/_lib_async/tests/test_probe.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_probe.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import asyncio


### PR DESCRIPTION
Make `tagProbe` non-blocking, the old way it was implemented enforced progressing the worker, which is not something we should do given the whole UCXX API is asynchronous.