### PR TITLE
Fix update-version.sh

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -57,6 +57,7 @@ UCXX_DEPENDENCIES=(
   libucxx-examples
   libucxx-tests
   ucxx
+  ucxx-tests
 )
 for FILE in dependencies.yaml conda/environments/*.yaml; do
   for DEP in "${DEPENDENCIES[@]}"; do


### PR DESCRIPTION
Adds new dependency to `update-version.sh`

Skips CI because this script is not tested in CI
