### PR TITLE
Set a timeout for event loop in async tests

### DIFF
--- a/python/ucxx/ucxx/_lib_async/tests/test_disconnect.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_disconnect.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import asyncio
@@ -28,7 +28,7 @@ async def mp_queue_get_nowait(queue):
 
 
 def _test_shutdown_unexpected_closed_peer_server(
-    client_queue, server_queue, endpoint_error_handling
+    client_queue, server_queue, endpoint_error_handling, timeout
 ):
     global ep_alive
     ep_alive = None
@@ -61,20 +61,25 @@ def _test_shutdown_unexpected_closed_peer_server(
 
     log_stream = StringIO()
     logging.basicConfig(stream=log_stream, level=logging.DEBUG)
-    get_event_loop().run_until_complete(run())
-    log = log_stream.getvalue()
 
-    if endpoint_error_handling is True:
-        assert ep_alive is False
-    else:
-        assert ep_alive
-        assert log.find("""UCXError('<[Send shutdown]""") != -1
+    loop = get_event_loop()
+    try:
+        loop.run_until_complete(asyncio.wait_for(run(), timeout=timeout))
+        log = log_stream.getvalue()
 
-    ucxx.stop_notifier_thread()
+        if endpoint_error_handling is True:
+            assert ep_alive is False
+        else:
+            assert ep_alive
+            assert log.find("""UCXError('<[Send shutdown]""") != -1
+    finally:
+        ucxx.stop_notifier_thread()
+
+        loop.close()
 
 
 def _test_shutdown_unexpected_closed_peer_client(
-    client_queue, server_queue, endpoint_error_handling
+    client_queue, server_queue, endpoint_error_handling, timeout
 ):
     async def run():
         server_port = client_queue.get()
@@ -86,9 +91,13 @@ def _test_shutdown_unexpected_closed_peer_client(
         msg = np.empty(100, dtype=np.int64)
         await ep.recv(msg)
 
-    get_event_loop().run_until_complete(run())
+    loop = get_event_loop()
+    try:
+        loop.run_until_complete(asyncio.wait_for(run(), timeout=timeout))
+    finally:
+        ucxx.stop_notifier_thread()
 
-    ucxx.stop_notifier_thread()
+        loop.close()
 
 
 @pytest.mark.parametrize("endpoint_error_handling", [True, False])
@@ -100,6 +109,7 @@ def test_shutdown_unexpected_closed_peer(caplog, endpoint_error_handling):
     The main goal is to assert that the processes exit without errors
     despite a somewhat messy initial state.
     """
+    timeout = 30
     if endpoint_error_handling is False:
         pytest.xfail(
             "Temporarily xfailing, due to https://github.com/rapidsai/ucxx/issues/21"
@@ -120,17 +130,20 @@ def test_shutdown_unexpected_closed_peer(caplog, endpoint_error_handling):
     server_queue = mp.Queue()
     p1 = mp.Process(
         target=_test_shutdown_unexpected_closed_peer_server,
-        args=(client_queue, server_queue, endpoint_error_handling),
+        args=(client_queue, server_queue, endpoint_error_handling, timeout),
     )
     p1.start()
     p2 = mp.Process(
         target=_test_shutdown_unexpected_closed_peer_client,
-        args=(client_queue, server_queue, endpoint_error_handling),
+        args=(client_queue, server_queue, endpoint_error_handling, timeout),
     )
     p2.start()
-    p2.join(timeout=30)
+
+    # Increase timeout by an additional 5s to give subprocesses a chance to
+    # timeout before being forcefully terminated.
+    p2.join(timeout=timeout + 5)
     server_queue.put("client is down")
-    p1.join(timeout=30)
+    p1.join(timeout=timeout + 5)
 
     terminate_process(p2)
     terminate_process(p1)

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import asyncio
@@ -16,7 +16,7 @@ from ucxx.testing import join_processes, terminate_process
 mp = mp.get_context("spawn")
 
 
-def _test_from_worker_address_server(queue):
+def _test_from_worker_address_server(queue, timeout):
     async def run():
         # Send worker address to client process via multiprocessing.Queue
         address = ucxx.get_worker_address()
@@ -40,14 +40,15 @@ def _test_from_worker_address_server(queue):
         await ep.close()
 
     loop = get_event_loop()
-    loop.run_until_complete(run())
+    try:
+        loop.run_until_complete(asyncio.wait_for(run(), timeout=timeout))
+    finally:
+        ucxx.stop_notifier_thread()
 
-    ucxx.stop_notifier_thread()
-
-    loop.close()
+        loop.close()
 
 
-def _test_from_worker_address_client(queue):
+def _test_from_worker_address_client(queue, timeout):
     async def run():
         # Read local worker address
         address = ucxx.get_worker_address()
@@ -69,29 +70,33 @@ def _test_from_worker_address_client(queue):
         np.testing.assert_array_equal(recv_msg, np.arange(10, dtype=np.int64))
 
     loop = get_event_loop()
-    loop.run_until_complete(run())
+    try:
+        loop.run_until_complete(asyncio.wait_for(run(), timeout=timeout))
+    finally:
+        ucxx.stop_notifier_thread()
 
-    ucxx.stop_notifier_thread()
-
-    loop.close()
+        loop.close()
 
 
 def test_from_worker_address():
+    timeout = 30
     queue = mp.Queue()
 
     server = mp.Process(
         target=_test_from_worker_address_server,
-        args=(queue,),
+        args=(queue, timeout),
     )
     server.start()
 
     client = mp.Process(
         target=_test_from_worker_address_client,
-        args=(queue,),
+        args=(queue, timeout),
     )
     client.start()
 
-    join_processes([client, server], timeout=30)
+    # Increase timeout by an additional 5s to give subprocesses a chance to
+    # timeout before being forcefully terminated.
+    join_processes([client, server], timeout=timeout + 5)
     terminate_process(client)
     terminate_process(server)
 
@@ -157,7 +162,7 @@ def _unpack_address_and_tag(address_packed):
     }
 
 
-def _test_from_worker_address_server_fixedsize(num_nodes, queue):
+def _test_from_worker_address_server_fixedsize(num_nodes, queue, timeout):
     async def run():
         async def _handle_client(packed_remote_address):
             # Unpack the fixed-size address+tag buffer
@@ -198,14 +203,15 @@ def _test_from_worker_address_server_fixedsize(num_nodes, queue):
         await asyncio.gather(*server_tasks)
 
     loop = get_event_loop()
-    loop.run_until_complete(run())
+    try:
+        loop.run_until_complete(asyncio.wait_for(run(), timeout=timeout))
+    finally:
+        ucxx.stop_notifier_thread()
 
-    ucxx.stop_notifier_thread()
-
-    loop.close()
+        loop.close()
 
 
-def _test_from_worker_address_client_fixedsize(queue):
+def _test_from_worker_address_client_fixedsize(queue, timeout):
     async def run():
         # Read local worker address
         address = ucxx.get_worker_address()
@@ -232,33 +238,36 @@ def _test_from_worker_address_client_fixedsize(queue):
         await ep.send(send_msg, tag=send_tag, force_tag=True)
 
     loop = get_event_loop()
-    loop.run_until_complete(run())
+    try:
+        loop.run_until_complete(asyncio.wait_for(run(), timeout=timeout))
+    finally:
+        ucxx.stop_notifier_thread()
 
-    ucxx.stop_notifier_thread()
-
-    loop.close()
+        loop.close()
 
 
 @pytest.mark.parametrize("num_nodes", [1, 2, 4, 8])
 def test_from_worker_address_multinode(num_nodes):
+    timeout = 30
     queue = mp.Queue()
 
     server = mp.Process(
         target=_test_from_worker_address_server_fixedsize,
-        args=(num_nodes, queue),
+        args=(num_nodes, queue, timeout),
     )
     server.start()
 
     clients = []
     for i in range(num_nodes):
         client = mp.Process(
-            target=_test_from_worker_address_client_fixedsize,
-            args=(queue,),
+            target=_test_from_worker_address_client_fixedsize, args=(queue, timeout)
         )
         client.start()
         clients.append(client)
 
-    join_processes(clients + [server], timeout=30)
+    # Increase timeout by an additional 5s to give subprocesses a chance to
+    # timeout before being forcefully terminated.
+    join_processes(clients + [server], timeout=timeout + 5)
     for client in clients:
         terminate_process(client)
     terminate_process(server)

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -11,7 +11,7 @@ import pytest
 
 import ucxx
 from ucxx._lib_async.utils import get_event_loop, hash64bits
-from ucxx._lib_async.utils_tests import compute_timeouts
+from ucxx._lib_async.utils_test import compute_timeouts
 from ucxx.testing import join_processes, terminate_process
 
 mp = mp.get_context("spawn")

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address_error.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address_error.py
@@ -12,7 +12,7 @@ import pytest
 
 import ucxx
 from ucxx._lib_async.utils import get_event_loop
-from ucxx._lib_async.utils_tests import compute_timeouts
+from ucxx._lib_async.utils_test import compute_timeouts
 from ucxx.testing import join_processes, terminate_process
 
 mp = mp.get_context("spawn")

--- a/python/ucxx/ucxx/_lib_async/utils_test.py
+++ b/python/ucxx/ucxx/_lib_async/utils_test.py
@@ -41,7 +41,7 @@ def get_cuda_devices():
         return list(range(ngpus))
 
 
-def compute_timeouts(pytestconfig: pytest.pytestconfig) -> tuple(float, float):
+def compute_timeouts(pytestconfig: pytest.Config) -> tuple[float, float]:
     """
     Calculate low and high timeouts.
 


### PR DESCRIPTION
The current way subprocesses using `run_until_complete()` timeout only allows the process to be immediately killed 
which doesn't provide any information about the stack, by using an async task with a timeout we allow the event loop to timeout first and print the stack and only then kill the process, which should help debugging issues especially in CI.

This change adds a new test utility function `compute_timeouts()` that uses the timeout from the `asyncio_timeout` fixture to compute both async and process timeouts, ensuring better traceability of errors when any part of the test fails.

Additionally the hardcoded timeouts that were defined for some tests relying on subprocesses are now replaced with `compute_timeouts()` and thus indirectly increasing those timeouts as a factor of the timeout defined in `asyncio_timeout`. This seems to resolve recent failures in `test_from_worker_address` that are seemingly facing timeout issues on A100 runner that use NVKS, the runtime for such tests on non-NVKS runners is usually smaller than 10s, but on NVKS nodes can slightly exceed 30s, causing the previous hardcoded timeout to hit before the test completes. It is not clear why only NVKS runners are affected.