### PR TITLE
Remove `UCXAddress.string` in favor of `__bytes__`

### DIFF
--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -463,6 +463,9 @@ cdef class UCXAddress():
     def __bytes__(self) -> bytes:
         return bytes(self._string)
 
+    def __str__(self) -> str:
+        return self._string.decode('utf-8')
+
     def __getbuffer__(self, Py_buffer *buffer, int flags) -> None:
         if bool(flags & PyBUF_WRITABLE):
             raise BufferError("Requested writable view on readonly data")

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -460,8 +460,7 @@ cdef class UCXAddress():
     def length(self) -> int:
         return int(self._length)
 
-    @property
-    def string(self) -> bytes:
+    def __bytes__(self) -> bytes:
         return bytes(self._string)
 
     def __getbuffer__(self, Py_buffer *buffer, int flags) -> None:
@@ -489,10 +488,10 @@ cdef class UCXAddress():
         pass
 
     def __reduce__(self) -> tuple:
-        return (UCXAddress.create_from_buffer, (self.string,))
+        return (UCXAddress.create_from_buffer, (bytes(self),))
 
     def __hash__(self) -> int:
-        return hash(bytes(self.string))
+        return hash(bytes(self))
 
 
 cdef void _generic_callback(void *args) with gil:

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -405,14 +405,9 @@ cdef class UCXAddress():
         return address
 
     @classmethod
-    def create_from_buffer(cls, bytes buffer) -> UCXAddress:
+    def create_from_buffer(cls, bytes buf) -> UCXAddress:
         cdef UCXAddress address = UCXAddress.__new__(UCXAddress)
-        cdef string address_str
-
-        buf = Array(buffer)
-        assert buf.c_contiguous
-
-        address_str = string(<char*>buf.ptr, <size_t>buf.nbytes)
+        cdef string address_str = string(<const char*>buf, len(buf))
 
         with nogil:
             address._address = createAddressFromString(address_str)

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -405,20 +405,8 @@ cdef class UCXAddress():
         return address
 
     @classmethod
-    def create_from_string(cls, string address_str) -> UCXAddress:
-        cdef UCXAddress address = UCXAddress.__new__(UCXAddress)
-        cdef string cpp_address_str = address_str
-
-        with nogil:
-            address._address = createAddressFromString(cpp_address_str)
-            address._handle = address._address.get().getHandle()
-            address._length = address._address.get().getLength()
-            address._string = address._address.get().getString()
-
-        return address
-
-    @classmethod
     def create_from_buffer(cls, bytes buffer) -> UCXAddress:
+        cdef UCXAddress address = UCXAddress.__new__(UCXAddress)
         cdef string address_str
 
         buf = Array(buffer)
@@ -426,7 +414,13 @@ cdef class UCXAddress():
 
         address_str = string(<char*>buf.ptr, <size_t>buf.nbytes)
 
-        return UCXAddress.create_from_string(address_str)
+        with nogil:
+            address._address = createAddressFromString(address_str)
+            address._handle = address._address.get().getHandle()
+            address._length = address._address.get().getLength()
+            address._string = address._address.get().getString()
+
+        return address
 
     # For old UCX-Py API compatibility
     @classmethod
@@ -462,9 +456,6 @@ cdef class UCXAddress():
 
     def __bytes__(self) -> bytes:
         return bytes(self._string)
-
-    def __str__(self) -> str:
-        return self._string.decode('utf-8')
 
     def __getbuffer__(self, Py_buffer *buffer, int flags) -> None:
         if bool(flags & PyBUF_WRITABLE):

--- a/python/ucxx/ucxx/_lib/tests/test_address_object.py
+++ b/python/ucxx/ucxx/_lib/tests/test_address_object.py
@@ -9,17 +9,6 @@ import ucxx._lib.libucxx as ucx_api
 mp = mp.get_context("spawn")
 
 
-def test_ucx_address_string():
-    ctx = ucx_api.UCXContext()
-    worker = ucx_api.UCXWorker(ctx)
-    org_address = worker.address
-    org_address_str = str(org_address)
-    new_address = ucx_api.UCXAddress.create_from_string(org_address_str)
-    new_address_str = str(new_address)
-    assert hash(org_address) == hash(new_address)
-    assert org_address_str == new_address_str
-
-
 def test_ucx_address_bytes():
     ctx = ucx_api.UCXContext()
     worker = ucx_api.UCXWorker(ctx)

--- a/python/ucxx/ucxx/_lib/tests/test_address_object.py
+++ b/python/ucxx/ucxx/_lib/tests/test_address_object.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import multiprocessing as mp
@@ -13,24 +13,22 @@ def test_ucx_address_string():
     ctx = ucx_api.UCXContext()
     worker = ucx_api.UCXWorker(ctx)
     org_address = worker.address
-    org_address_str = org_address.string
-    new_address = ucx_api.UCXAddress.create_from_string(org_address_str)
-    new_address_str = new_address.string
+    org_address_bytes = bytes(org_address)
+    new_address = ucx_api.UCXAddress.create_from_string(org_address_bytes)
+    new_address_bytes = bytes(new_address)
     assert hash(org_address) == hash(new_address)
-    assert bytes(org_address_str) == bytes(new_address_str)
+    assert org_address_bytes == new_address_bytes
 
 
 def test_pickle_ucx_address():
     ctx = ucx_api.UCXContext()
     worker = ucx_api.UCXWorker(ctx)
     org_address = worker.address
-    org_address_str = org_address.string
+    org_address_bytes = bytes(org_address)
     org_address_hash = hash(org_address)
     dumped_address = pickle.dumps(org_address)
-    org_address = bytes(org_address)
     new_address = pickle.loads(dumped_address)
-    new_address_str = new_address.string
+    new_address_bytes = bytes(new_address)
 
     assert org_address_hash == hash(new_address)
-    assert bytes(org_address_str) == bytes(new_address_str)
-    assert bytes(org_address) == bytes(new_address)
+    assert org_address_bytes == new_address_bytes

--- a/python/ucxx/ucxx/_lib/tests/test_address_object.py
+++ b/python/ucxx/ucxx/_lib/tests/test_address_object.py
@@ -13,8 +13,19 @@ def test_ucx_address_string():
     ctx = ucx_api.UCXContext()
     worker = ucx_api.UCXWorker(ctx)
     org_address = worker.address
+    org_address_str = str(org_address)
+    new_address = ucx_api.UCXAddress.create_from_string(org_address_str)
+    new_address_str = str(new_address)
+    assert hash(org_address) == hash(new_address)
+    assert org_address_str == new_address_str
+
+
+def test_ucx_address_bytes():
+    ctx = ucx_api.UCXContext()
+    worker = ucx_api.UCXWorker(ctx)
+    org_address = worker.address
     org_address_bytes = bytes(org_address)
-    new_address = ucx_api.UCXAddress.create_from_string(org_address_bytes)
+    new_address = ucx_api.UCXAddress.create_from_buffer(org_address_bytes)
     new_address_bytes = bytes(new_address)
     assert hash(org_address) == hash(new_address)
     assert org_address_bytes == new_address_bytes


### PR DESCRIPTION
Currently the Python core API has a `UCXAddress.string` property that returns `bytes`. This is a confusing match, so instead of having that property this now switches to supporting `__bytes__` that can use proper Python API to return the serializable `bytes` object by calling `bytes(ucx_address_object)`.

Also removes the `create_from_string` method, as there were two methods that are essentially redundant and might cause more confusion than good.