### PR TITLE
Add Python to distributed-ucxx Conda build string

### DIFF
--- a/conda/recipes/ucxx/recipe.yaml
+++ b/conda/recipes/ucxx/recipe.yaml
@@ -401,7 +401,7 @@ outputs:
       version: ${{ version }}
     build:
       noarch: python
-      string: ${{ date_string }}_${{ head_rev }}
+      string: py${{ python | version_to_buildstring }}_${{ date_string }}_${{ head_rev }}
       script: ./build.sh distributed_ucxx
     requirements:
       host:

--- a/conda/recipes/ucxx/recipe.yaml
+++ b/conda/recipes/ucxx/recipe.yaml
@@ -401,7 +401,7 @@ outputs:
       version: ${{ version }}
     build:
       noarch: python
-      string: py${{ python | version_to_buildstring }}_${{ date_string }}_${{ head_rev }}
+      string: py_${{ date_string }}_${{ head_rev }}
       script: ./build.sh distributed_ucxx
     requirements:
       host:


### PR DESCRIPTION
The Python version was dropped from the `distributed-ucxx` build string when migrating to `rattler-build`. Manually add this back.