### PR TITLE
Exclude librmm.so from auditwheel

### DIFF
--- a/ci/build_wheel_libucxx.sh
+++ b/ci/build_wheel_libucxx.sh
@@ -33,7 +33,8 @@ export SKBUILD_CMAKE_ARGS="-DUCXX_ENABLE_RMM=ON"
 
 python -m auditwheel repair \
     --exclude "libucp.so.0" \
-    --exclude librapids_logger.so \
+    --exclude "librapids_logger.so" \
+    --exclude "librmm.so" \
     -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     ${package_dir}/dist/*
 

--- a/ci/build_wheel_ucxx.sh
+++ b/ci/build_wheel_ucxx.sh
@@ -24,7 +24,8 @@ export SKBUILD_CMAKE_ARGS="-DFIND_UCXX_CPP=ON;-DCMAKE_INSTALL_LIBDIR=ucxx/lib64;
 python -m auditwheel repair \
     --exclude "libucp.so.0" \
     --exclude "libucxx.so" \
-    --exclude librapids_logger.so \
+    --exclude "librapids_logger.so" \
+    --exclude "librmm.so" \
     -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     ${package_dir}/dist/*
 


### PR DESCRIPTION
librmm will ship a shared library component in 25.06 (xref: https://github.com/rapidsai/rmm/issues/1779). This PR updates `auditwheel` calls to exclude `librmm.so`.
