### PR TITLE
fix(wheels): add librmm exclude to wheel builds

### DIFF
--- a/ci/build_wheel_libucxx.sh
+++ b/ci/build_wheel_libucxx.sh
@@ -33,6 +33,7 @@ export SKBUILD_CMAKE_ARGS="-DUCXX_ENABLE_RMM=ON"
 
 python -m auditwheel repair \
     --exclude "libucp.so.0" \
+    --exclude librmm.so \
     --exclude librapids_logger.so \
     -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     ${package_dir}/dist/*


### PR DESCRIPTION
Fixing the nightly builds of wheels on 0.45
