### PR TITLE
use 'rapids-init-pip' in wheel CI, other CI changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
   docs-build:
     if: github.ref_type == 'branch'
@@ -46,7 +47,7 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       date: ${{ inputs.date }}
       node_type: "gpu-l4-latest-1"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}
   upload-conda:
     needs: [conda-cpp-build]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,6 +67,7 @@ jobs:
           - '!.devcontainer/**'
           - '!.pre-commit-config.yaml'
           - '!README.md'
+          - '!ci/release/update-version.sh'
           - '!docs/**'
           - '!python/**'
         test_python:
@@ -74,6 +75,7 @@ jobs:
           - '!.devcontainer/**'
           - '!.pre-commit-config.yaml'
           - '!README.md'
+          - '!ci/release/update-version.sh'
           - '!docs/**'
   checks:
     secrets: inherit
@@ -88,6 +90,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-25.06
     with:
       build_type: pull-request
+      script: ci/build_cpp.sh
   docs-build:
     needs: conda-cpp-build
     secrets: inherit
@@ -97,7 +100,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
@@ -106,6 +109,7 @@ jobs:
     with:
       build_type: pull-request
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      script: ci/test_cpp.sh
   conda-python-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
@@ -114,6 +118,7 @@ jobs:
     with:
       build_type: pull-request
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      script: ci/test_python.sh
   conda-python-distributed-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_cpp.sh
       sha: ${{ inputs.sha }}
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
   conda-python-tests:
@@ -33,6 +34,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_python.sh
       sha: ${{ inputs.sha }}
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
   conda-python-distributed-tests:

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -8,6 +8,7 @@ package_dir=$2
 
 source rapids-configure-sccache
 source rapids-date-string
+source rapids-init-pip
 
 rapids-generate-version > ./VERSION
 

--- a/ci/build_wheel_distributed_ucxx.sh
+++ b/ci/build_wheel_distributed_ucxx.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_dir="python/distributed-ucxx"
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"

--- a/ci/build_wheel_libucxx.sh
+++ b/ci/build_wheel_libucxx.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_name="libucxx"
 package_dir="python/libucxx"
 

--- a/ci/build_wheel_ucxx.sh
+++ b/ci/build_wheel_ucxx.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_name="ucxx"
 package_dir="python/ucxx"
 
@@ -11,11 +13,10 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 # Downloads libucxx wheel from this current build,
 # then ensures 'ucxx' wheel builds always use the 'libucxx' just built in the same CI run.
 #
-# Using env variable PIP_CONSTRAINT is necessary to ensure the constraints
+# Using env variable PIP_CONSTRAINT (initialized by 'rapids-init-pip') is necessary to ensure the constraints
 # are used when creating the isolated build environment.
 LIBUCXX_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libucxx_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
-echo "libucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBUCXX_WHEELHOUSE}"/libucxx_*.whl)" > /tmp/constraints.txt
-export PIP_CONSTRAINT="/tmp/constraints.txt"
+echo "libucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBUCXX_WHEELHOUSE}"/libucxx_*.whl)" >> "${PIP_CONSTRAINT}"
 
 export SKBUILD_CMAKE_ARGS="-DFIND_UCXX_CPP=ON;-DCMAKE_INSTALL_LIBDIR=ucxx/lib64;-DCMAKE_INSTALL_INCLUDEDIR=ucxx/include"
 

--- a/ci/test_wheel_distributed_ucxx.sh
+++ b/ci/test_wheel_distributed_ucxx.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_name="distributed_ucxx"
 
 source "$(dirname "$0")/test_common.sh"

--- a/ci/test_wheel_ucxx.sh
+++ b/ci/test_wheel_ucxx.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_name="ucxx"
 
 source "$(dirname "$0")/test_common.sh"


### PR DESCRIPTION
## Description

Proposes a batch of small, mostly-unrelated changes to building and packaging.

These are all part of RAPIDS-wide efforts to make it easier to reproduce CI locally and to use artifacts from one project's CI in another project's CI.

Contributes to https://github.com/rapidsai/build-planning/issues/178

* prevents triggering expensive CI jobs based on PRs modifying `ci/release/update-version.sh`

Contributes to https://github.com/rapidsai/shared-workflows/issues/356

* explicitly provides an input for `script` to workflows using it, instead of relying on a default value coming from the workflow file

Contributes to https://github.com/rapidsai/shared-workflows/issues/337

* switches from input `run_script` to `script` in uses of the `custom-job` workflow

Contributes to https://github.com/rapidsai/build-planning/issues/179

* adds a call to `rapids-init-pip` near the beginning of all CI scripts that use `pip`
* removed redefinitions of `PIP_CONSTRAINT` in scripts, in favor of using the one set up by `rapids-pip-init`

Contributes to https://github.com/rapidsai/gha-tools/issues/145

* confirmed that `rapids-configure-conda-channels` is not used in any builds scripts using `rattler-build`