### PR TITLE
test telemetry without env var file download

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,102 +28,11 @@ concurrency:
 jobs:
   conda-cpp-build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@msarahan-telemetry-obviate-download
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
-  docs-build:
-    if: github.ref_type == 'branch'
-    needs: conda-cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.08
-    with:
-      arch: "amd64"
-      branch: ${{ inputs.branch }}
-      build_type: ${{ inputs.build_type || 'branch' }}
-      container_image: "rapidsai/ci-conda:latest"
-      date: ${{ inputs.date }}
-      node_type: "gpu-l4-latest-1"
-      script: "ci/build_docs.sh"
-      sha: ${{ inputs.sha }}
-  upload-conda:
-    needs: [conda-cpp-build]
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.08
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
-  wheel-build-libucxx:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      script: ci/build_wheel_libucxx.sh
-      # build for every combination of arch and CUDA version, but only for the latest Python
-      matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
-      package-name: libucxx
-      package-type: cpp
-  wheel-publish-libucxx:
-    needs: wheel-build-libucxx
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      package-name: libucxx
-      package-type: cpp
-  wheel-build-ucxx:
-    needs: wheel-build-libucxx
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      script: ci/build_wheel_ucxx.sh
-      package-name: ucxx
-      package-type: python
-  wheel-publish-ucxx:
-    needs: wheel-build-ucxx
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      package-name: ucxx
-      package-type: python
-  wheel-build-distributed-ucxx:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      script: ci/build_wheel_distributed_ucxx.sh
-      package-name: distributed_ucxx
-      package-type: python
-  wheel-publish-distributed-ucxx:
-    needs: [wheel-build-ucxx, wheel-build-distributed-ucxx]
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      package-name: distributed_ucxx
-      package-type: python
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   conda-cpp-build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@msarahan-telemetry-obviate-download
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-25.08
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,6 +44,8 @@ jobs:
     needs: conda-cpp-build
     if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
     continue-on-error: true
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-summarize@main

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SHARED_ACTIONS_REPO: rapidsai/shared-actions
-  SHARED_ACTIONS_REF: main
+  SHARED_ACTIONS_REPO: msarahan/shared-actions
+  SHARED_ACTIONS_REF: debug-otel-service-name-and-traceparent
 
 jobs:
   telemetry-setup:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   SHARED_ACTIONS_REPO: rapidsai/shared-actions
-  SHARED_ACTIONS_REF: check-base-env-var-artifact
+  SHARED_ACTIONS_REF: main
 
 jobs:
   telemetry-setup:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,188 +9,32 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
-  pr-builder:
-    needs:
-      - check-nightly-ci
-      - changed-files
-      - checks
-      - conda-cpp-build
-      - devcontainer
-      - docs-build
-      - conda-cpp-tests
-      - conda-python-tests
-      - conda-python-distributed-tests
-      - wheel-build-libucxx
-      - wheel-build-ucxx
-      - wheel-tests-ucxx
-      - wheel-build-distributed-ucxx
-      - wheel-tests-distributed-ucxx
-      - telemetry-setup
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.08
-    if: always()
-    with:
-      needs: ${{ toJSON(needs) }}
-  check-nightly-ci:
-    # Switch to ubuntu-latest once it defaults to a version of Ubuntu that
-    # provides at least Python 3.11 (see
-    # https://docs.python.org/3/library/datetime.html#datetime.date.fromisoformat)
-    runs-on: ubuntu-24.04
-    env:
-      RAPIDS_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Check if nightly CI is passing
-        uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
-        with:
-          repo: ucxx
+env:
+  SHARED_ACTIONS_REPO: rapidsai/shared-actions
+  SHARED_ACTIONS_REF: msarahan-telemetry-obviate-download
 
+jobs:
   telemetry-setup:
     runs-on: ubuntu-latest
     continue-on-error: true
-    env:
-      OTEL_SERVICE_NAME: "pr-ucxx"
     steps:
       - name: Telemetry setup
         # This gate is here and not at the job level because we need the job to not be skipped,
         # since other jobs depend on it.
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
-  changed-files:
-    secrets: inherit
-    needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@branch-25.08
-    with:
-      files_yaml: |
-        test_cpp:
-          - '**'
-          - '!.devcontainer/**'
-          - '!.pre-commit-config.yaml'
-          - '!README.md'
-          - '!ci/release/update-version.sh'
-          - '!docs/**'
-          - '!python/**'
-        test_python:
-          - '**'
-          - '!.devcontainer/**'
-          - '!.pre-commit-config.yaml'
-          - '!README.md'
-          - '!ci/release/update-version.sh'
-          - '!docs/**'
-  checks:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-25.08
-    needs: telemetry-setup
-    with:
-      enable_check_generated_files: false
-      ignored_pr_jobs: telemetry-summarize
   conda-cpp-build:
-    needs: checks
+    needs: telemetry-setup
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
     with:
       build_type: pull-request
       script: ci/build_cpp.sh
-  docs-build:
-    needs: conda-cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.08
-    with:
-      build_type: pull-request
-      node_type: "gpu-l4-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
-      script: "ci/build_docs.sh"
-  conda-cpp-tests:
-    needs: [conda-cpp-build, changed-files]
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-25.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
-    with:
-      build_type: pull-request
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-      script: ci/test_cpp.sh
-  conda-python-tests:
-    needs: [conda-cpp-build, changed-files]
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
-    with:
-      build_type: pull-request
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-      script: ci/test_python.sh
-  conda-python-distributed-tests:
-    needs: [conda-cpp-build, changed-files]
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
-    with:
-      build_type: pull-request
-      script: "ci/test_python_distributed.sh"
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-  wheel-build-libucxx:
-    needs: checks
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
-    with:
-      build_type: pull-request
-      script: ci/build_wheel_libucxx.sh
-      # build for every combination of arch and CUDA version, but only for the latest Python
-      matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
-      package-name: libucxx
-      package-type: cpp
-  wheel-build-ucxx:
-    needs: wheel-build-libucxx
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
-    with:
-      build_type: pull-request
-      script: ci/build_wheel_ucxx.sh
-      package-name: ucxx
-      package-type: python
-  wheel-tests-ucxx:
-    needs: [wheel-build-ucxx, changed-files]
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
-    with:
-      build_type: pull-request
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-      script: ci/test_wheel_ucxx.sh
-  wheel-build-distributed-ucxx:
-    needs: checks
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
-    with:
-      build_type: pull-request
-      script: ci/build_wheel_distributed_ucxx.sh
-      package-name: distributed_ucxx
-      package-type: python
-  wheel-tests-distributed-ucxx:
-    needs: [wheel-build-ucxx, wheel-build-distributed-ucxx, changed-files]
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.08
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
-    with:
-      build_type: pull-request
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-      script: ci/test_wheel_distributed_ucxx.sh
-  devcontainer:
-    secrets: inherit
-    needs: [checks, telemetry-setup]
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-25.08
-    with:
-      arch: '["amd64"]'
-      cuda: '["12.9"]'
-      build_command: |
-        sccache -z;
-        build-all --verbose;
-        sccache -s;
 
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4
-    needs: pr-builder
+    needs: conda-cpp-build
     if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
     continue-on-error: true
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ jobs:
   conda-cpp-build:
     needs: [telemetry-setup]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@msarahan-telemetry-obviate-download
     with:
       build_type: pull-request
       script: ci/build_cpp.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   SHARED_ACTIONS_REPO: rapidsai/shared-actions
-  SHARED_ACTIONS_REF: msarahan-telemetry-obviate-download
+  SHARED_ACTIONS_REF: check-base-env-var-artifact
 
 jobs:
   telemetry-setup:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,13 +23,20 @@ jobs:
         # since other jobs depend on it.
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
+
   conda-cpp-build:
-    needs: telemetry-setup
+    needs: [telemetry-setup]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-25.08
     with:
       build_type: pull-request
       script: ci/build_cpp.sh
+
+  intentionally-failing-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Intentionally failing job
+        run: exit 1
 
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
   conda-cpp-build:
     needs: telemetry-setup
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-25.08
     with:
       build_type: pull-request
       script: ci/build_cpp.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ jobs:
   conda-cpp-build:
     needs: [telemetry-setup]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@msarahan-telemetry-obviate-download
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-25.08
     with:
       build_type: pull-request
       script: ci/build_cpp.sh


### PR DESCRIPTION
Please ignore. This is part of an effort across shared-actions, shared-workflows and our various project repos to fix the annoying issue with CI noise like

```
Unable to download artifact(s): Artifact not found for name: telemetry-tools-env-vars Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact. For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md
```