### PR TITLE
Use GCC 14 in conda builds.

### DIFF
--- a/conda/recipes/ucxx/conda_build_config.yaml
+++ b/conda/recipes/ucxx/conda_build_config.yaml
@@ -1,8 +1,8 @@
 c_compiler_version:
-  - 13
+  - 14
 
 cxx_compiler_version:
-  - 13
+  - 14
 
 cuda_compiler:
   - cuda-nvcc


### PR DESCRIPTION
## Description
conda-forge is migrating to gcc 14, so this PR is updating for alignment.
