### PR TITLE
Fix `ucxx::Endpoint::close()` callback function use

### DIFF
--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -229,7 +229,7 @@ std::shared_ptr<Request> Endpoint::close(const bool enablePythonFuture,
   auto endpoint = std::dynamic_pointer_cast<Endpoint>(shared_from_this());
   bool force    = _endpointErrorHandling;
 
-  auto combineCallbacksFunction = [this, &callbackFunction, &callbackData](
+  auto combineCallbacksFunction = [this, callbackFunction, callbackData](
                                     ucs_status_t status,
                                     EndpointCloseCallbackUserData /* callbackData */) {
     _status = status;


### PR DESCRIPTION
The `callbackFunction`/`callbackData` arguments that can be passed to `ucxx::Endpoint::close()` are turned into a lambda that is itself made into a callback to be executed asynchronously when the close request completes. The objects were being captured as references which is an invalid use due to the local scope of those variables and need to be captured by value since they're `std::function`/`std::shared_ptr`, respectively.

This resolves a bug we previously observed in listener tests that was worked around in a way that for some reason wouldn't hit the issue but was unclear why. That workaround can now be removed.