### PR TITLE
Override default progress mode for distributed-ucxx

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/ucxx.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: BSD-3-Clause
+
 """
 :ref:`UCX`_ based communications for distributed.
 
@@ -253,7 +256,10 @@ def init_once():
         # that don't override ucx_config or existing slots in the
         # environment, so the user's external environment can safely
         # override things here.
-        ucxx.init(options=ucx_config, env_takes_precedence=True)
+        progress_mode = None if "UCXPY_PROGRESS_MODE" in os.environ else "blocking"
+        ucxx.init(
+            options=ucx_config, env_takes_precedence=True, progress_mode=progress_mode
+        )
         _allocate_dask_resources_tracker()
 
     pool_size_str = dask.config.get("distributed.rmm.pool-size")

--- a/python/distributed-ucxx/distributed_ucxx/ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/ucxx.py
@@ -384,8 +384,8 @@ class UCXX(Comm):
         self._ep = ep
         self._ep_handle = int(self._ep._ep.handle)
         if local_addr:
-            assert local_addr.startswith("ucxx")
-        assert peer_addr.startswith("ucxx")
+            assert local_addr.startswith(("ucx://", "ucxx://"))
+        assert peer_addr.startswith(("ucx://", "ucxx://"))
         self._local_addr = local_addr
         self._peer_addr = peer_addr
         self.comm_flag = None


### PR DESCRIPTION
Switch the default distributed-ucxx progress mode to `"blocking"`, which is equivalent to UCX-Py's default progress mode, allowing a more transparent move of Dask to UCXX. This change may later be reverted once we have more confidence in a successful transition to UCXX.

Additionally allow both `"ucx://"` and `"ucxx://"` address prefixes, since with the change from https://github.com/rapidsai/rapids-dask-dependency/pull/116 both will be valid to enable UCXX when distributed-ucxx is installed.