### PR TITLE
Run all C++ tests with protov2

### DIFF
--- a/ci/run_cpp.sh
+++ b/ci/run_cpp.sh
@@ -17,17 +17,11 @@ run_cpp_tests() {
   RUNTIME_PATH=${CONDA_PREFIX:-./}
   BINARY_PATH=${RUNTIME_PATH}/bin
 
-  # Disable memory get/put with RMM in protov1, it always segfaults.
-  CMD_LINE="timeout 10m ${BINARY_PATH}/gtests/libucxx/UCXX_TEST --gtest_filter=-*RMM*Memory*"
+  # Only test memory get/put with RMM in protov2, as protov1 segfaults.
+  CMD_LINE="timeout 10m ${BINARY_PATH}/gtests/libucxx/UCXX_TEST"
 
   log_command "${CMD_LINE}"
   UCX_TCP_CM_REUSEADDR=y ${CMD_LINE}
-
-  # Only test memory get/put with RMM in protov2, as protov1 segfaults.
-  CMD_LINE="timeout 10m ${BINARY_PATH}/gtests/libucxx/UCXX_TEST --gtest_filter=*RMM*Memory*"
-
-  log_command "${CMD_LINE}"
-  UCX_PROTO_ENABLE=y UCX_TCP_CM_REUSEADDR=y ${CMD_LINE}
 }
 
 run_cpp_benchmark() {

--- a/ci/run_cpp.sh
+++ b/ci/run_cpp.sh
@@ -17,7 +17,6 @@ run_cpp_tests() {
   RUNTIME_PATH=${CONDA_PREFIX:-./}
   BINARY_PATH=${RUNTIME_PATH}/bin
 
-  # Only test memory get/put with RMM in protov2, as protov1 segfaults.
   CMD_LINE="timeout 10m ${BINARY_PATH}/gtests/libucxx/UCXX_TEST"
 
   log_command "${CMD_LINE}"


### PR DESCRIPTION
Remove C++ tests with protov1 and enable all C++ tests with protov2.

UCX protov1 is now outdated, with multiple features required for best performance in RAPIDS that are only supported on protov2. UCXX has been using protov2 as the default for a while (see https://github.com/rapidsai/ucxx/pull/384) so it should be good to disable the last remaining protov1 testing and test only protov2.