### PR TITLE
Update rapids_config files to support new branching strategy

### DIFF
--- a/cmake/rapids_config.cmake
+++ b/cmake/rapids_config.cmake
@@ -12,10 +12,11 @@
 # the License.
 # =============================================================================
 file(READ "${CMAKE_CURRENT_LIST_DIR}/../RAPIDS_VERSION" _rapids_version)
-if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])]])
+if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])(a?)]])
   set(RAPIDS_VERSION_MAJOR "${CMAKE_MATCH_1}")
   set(RAPIDS_VERSION_MINOR "${CMAKE_MATCH_2}")
   set(RAPIDS_VERSION_PATCH "${CMAKE_MATCH_3}")
+  set(RAPIDS_USE_MAIN "${CMAKE_MATCH_4}")
   set(RAPIDS_VERSION_MAJOR_MINOR "${RAPIDS_VERSION_MAJOR}.${RAPIDS_VERSION_MINOR}")
   set(RAPIDS_VERSION "${RAPIDS_VERSION_MAJOR}.${RAPIDS_VERSION_MINOR}.${RAPIDS_VERSION_PATCH}")
 else()
@@ -27,4 +28,7 @@ else()
 endif()
 
 set(rapids-cmake-version "${RAPIDS_VERSION_MAJOR_MINOR}")
+if(RAPIDS_USE_MAIN)
+  set(rapids-cmake-branch main)
+endif()
 include("${CMAKE_CURRENT_LIST_DIR}/RAPIDS.cmake")


### PR DESCRIPTION
rapids_config will detect trailing a version suffix to mean use main branch