### PR TITLE
Fix CI run script

### DIFF
--- a/ci/run_python_distributed.sh
+++ b/ci/run_python_distributed.sh
@@ -18,9 +18,11 @@ install_distributed_dev_mode() {
   log_message "Install Distributed in developer mode"
   MAX_ATTEMPTS=5
   for attempt in $(seq 1 $MAX_ATTEMPTS); do
+    DISTRIBUTED_VERSION=$(pip list | grep distributed | grep "distributed.*20" | awk '{print $2}')
+
     rm -rf /tmp/distributed
 
-    if git clone https://github.com/dask/distributed /tmp/distributed -b 2024.1.1; then
+    if git clone https://github.com/dask/distributed /tmp/distributed -b "${DISTRIBUTED_VERSION}"; then
       break
     else
 

--- a/ci/run_python_distributed.sh
+++ b/ci/run_python_distributed.sh
@@ -15,7 +15,7 @@ install_distributed_dev_mode() {
   # developer mode. This isn't a great solution but it's what we can currently do
   # to run non-public API tests in CI.
 
-  rapids-logger "Install Distributed in developer mode"
+  log_message "Install Distributed in developer mode"
   MAX_ATTEMPTS=5
   for attempt in $(seq 1 $MAX_ATTEMPTS); do
     rm -rf /tmp/distributed
@@ -25,7 +25,7 @@ install_distributed_dev_mode() {
     else
 
       if [ "$attempt" -eq $MAX_ATTEMPTS ]; then
-        rapids-logger "Maximum number of attempts to clone Distributed failed."
+        log_message "Maximum number of attempts to clone Distributed failed."
         exit 1
       fi
 


### PR DESCRIPTION
In https://github.com/rapidsai/ucxx/pull/451 the test run logic got moved to `ci/run_*` scripts to match other RAPIDS projects. One of the scripts mistakenly still uses `rapids-logger`, which is incorrect, this change fixes that.

Additionally pick the same `distributed` version as the currently installed one for tests required editable install.