### PR TITLE
Fix build warnings in C++ tests

### DIFF
--- a/cpp/tests/buffer.cpp
+++ b/cpp/tests/buffer.cpp
@@ -1,10 +1,11 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>
 #include <memory>
 #include <numeric>
+#include <tuple>
 #include <utility>
 
 #include <gtest/gtest.h>
@@ -139,7 +140,7 @@ TEST_P(BufferAllocator, TestThrowAfterRelease)
     auto releasedBuffer = buffer->release();
 
     EXPECT_THROW(buffer->data(), std::runtime_error);
-    EXPECT_THROW(buffer->release(), std::runtime_error);
+    EXPECT_THROW(std::ignore = buffer->release(), std::runtime_error);
 #else
     GTEST_SKIP() << "UCXX was not built with RMM support";
 #endif

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>
@@ -270,8 +270,8 @@ TEST_P(RequestTest, ProgressStream)
 
   // Submit and wait for transfers to complete
   if (_messageSize == 0) {
-    EXPECT_THROW(_ep->streamSend(_sendPtr[0], _messageSize, 0), std::runtime_error);
-    EXPECT_THROW(_ep->streamRecv(_recvPtr[0], _messageSize, 0), std::runtime_error);
+    EXPECT_THROW(std::ignore = _ep->streamSend(_sendPtr[0], _messageSize, 0), std::runtime_error);
+    EXPECT_THROW(std::ignore = _ep->streamRecv(_recvPtr[0], _messageSize, 0), std::runtime_error);
   } else {
     std::vector<std::shared_ptr<ucxx::Request>> requests;
     requests.push_back(_ep->streamSend(_sendPtr[0], _messageSize, 0));

--- a/cpp/tests/rma.cpp
+++ b/cpp/tests/rma.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>
@@ -160,7 +160,8 @@ TEST_P(BasicUcxxRmaTest, RemoteKeyCorruptedSerializedData)
   auto serializedRemoteKey = remoteKey->serialize();
   serializedRemoteKey[1]   = ~serializedRemoteKey[1];
 
-  EXPECT_THROW(ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey), std::runtime_error);
+  EXPECT_THROW(std::ignore = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey),
+               std::runtime_error);
 }
 
 INSTANTIATE_TEST_SUITE_P(AttributeTests,


### PR DESCRIPTION
Asserts that only check whether a C++ call marked `[[nodiscard]]` to test for exceptions need to be assigned to `std::ignore` to prevent build warnings.