### PR TITLE
Return immediately if AM request was already completed

### DIFF
--- a/cpp/src/request_am.cpp
+++ b/cpp/src/request_am.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -256,6 +256,11 @@ ucs_status_t RequestAm::recvCallback(void* arg,
       ucxx_trace_req_f(ownerString.c_str(), req.get(), nullptr, "amRecv", "recvPool");
     }
   }
+
+  // Return immediately if the request's status has already been set before the
+  // callback executed, e.g., the user called `amRecv()` before the request arrived and
+  // canceled it.
+  if (req->getStatus() != UCS_INPROGRESS) return req->getStatus();
 
   if (is_rndv) {
     if (amData->_allocators.find(amHeader.memoryType) == amData->_allocators.end()) {


### PR DESCRIPTION
If an Active Message receive request had its status set before the callback executed, return immediately. I believe the only case this may occur currently is if a `amRecv()` request is posted and canceled by the user before the request arrived, but cover all statuses just in case.