### PR TITLE
Add missing numba-cuda dependency to the conda recipe

### DIFF
--- a/conda/recipes/ucxx/recipe.yaml
+++ b/conda/recipes/ucxx/recipe.yaml
@@ -270,6 +270,7 @@ outputs:
       run_constraints:
         - cupy >=9.5.0
         - numba >=0.59.1,<0.62.0a0
+        - numba-cuda >=0.14.0,<0.15.0a00
       ignore_run_exports:
         by_name:
           - cuda-cudart


### PR DESCRIPTION
The `numba-cuda` package was made a dependency in https://github.com/rapidsai/ucxx/pull/462, but the conda recipe was missed.