### PR TITLE
Fix anchor naming conventions in dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -287,16 +287,16 @@ dependencies:
           - pynvml>=12.0.0,<13.0.0a0
       - output_types: [conda]
         packages:
-          - &numba-cuda-dep numba-cuda>=0.14.0,<0.15.0a0
+          - &numba_cuda numba-cuda>=0.14.0,<0.15.0a0
     specific:
       - output_types: [requirements, pyproject]
         matrices:
           - matrix: {cuda: "12.*"}
             packages:
-              - &numba-cuda-cu12-dep numba-cuda[cu12]>=0.14.0,<0.15.0a0
+              - &numba_cuda_cu12 numba-cuda[cu12]>=0.14.0,<0.15.0a0
           - matrix: # Fallback for no matrix
             packages:
-              - *numba-cuda-cu12-dep
+              - *numba_cuda_cu12
   run_python_distributed_ucxx:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -304,16 +304,16 @@ dependencies:
           - rapids-dask-dependency==25.10.*,>=0.0.0a0
       - output_types: [conda]
         packages:
-          - *numba-cuda-dep
+          - *numba_cuda
     specific:
       - output_types: [requirements, pyproject]
         matrices:
           - matrix: {cuda: "12.*"}
             packages:
-              - *numba-cuda-cu12-dep
+              - *numba_cuda_cu12
           - matrix: # Fallback for no matrix
             packages:
-              - *numba-cuda-cu12-dep
+              - *numba_cuda_cu12
   test_cpp:
     common:
       - output_types: conda


### PR DESCRIPTION
Replace hypens with underscores, and remove any `-dep` suffix.
