### PR TITLE
Clarify information about C++ user callbacks

### DIFF
--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -350,6 +350,13 @@ class Endpoint : public Component {
    * Python future is requested, the Python application must then await on this future to
    * ensure the transfer has completed. Requires UCXX Python support.
    *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
+   *
    * @param[in] buffer                  a raw pointer to the data to be sent.
    * @param[in] length                  the size in bytes of the tag message to be sent.
    * @param[in] memoryType              the memory type of the buffer.
@@ -386,6 +393,13 @@ class Endpoint : public Component {
    * Python future is requested, the Python application must then await on this future to
    * ensure the transfer has completed. Requires UCXX Python support.
    *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
+   *
    * @param[in] enablePythonFuture  whether a python future should be created and
    *                                subsequently notified.
    * @param[in] callbackFunction    user-defined callback function to call upon completion.
@@ -409,6 +423,13 @@ class Endpoint : public Component {
    * Using a Python future may be requested by specifying `enablePythonFuture`. If a
    * Python future is requested, the Python application must then await on this future to
    * ensure the transfer has completed. Requires UCXX Python support.
+   *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
    *
    * @param[in] buffer              a raw pointer to the data to be sent.
    * @param[in] length              the size in bytes of the tag message to be sent.
@@ -442,6 +463,13 @@ class Endpoint : public Component {
    * Using a Python future may be requested by specifying `enablePythonFuture`. If a
    * Python future is requested, the Python application must then await on this future to
    * ensure the transfer has completed. Requires UCXX Python support.
+   *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
    *
    * @param[in] buffer              a raw pointer to the data to be sent.
    * @param[in] length              the size in bytes of the tag message to be sent.
@@ -478,6 +506,13 @@ class Endpoint : public Component {
    * Python future is requested, the Python application must then await on this future to
    * ensure the transfer has completed. Requires UCXX Python support.
    *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
+   *
    * @param[in] buffer              a raw pointer to the data to be sent.
    * @param[in] length              the size in bytes of the tag message to be sent.
    * @param[in] remoteAddr          the source remote memory address to read from.
@@ -510,6 +545,13 @@ class Endpoint : public Component {
    * Using a Python future may be requested by specifying `enablePythonFuture`. If a
    * Python future is requested, the Python application must then await on this future to
    * ensure the transfer has completed. Requires UCXX Python support.
+   *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
    *
    * @param[in] buffer              a raw pointer to the data to be sent.
    * @param[in] length              the size in bytes of the tag message to be sent.
@@ -593,6 +635,13 @@ class Endpoint : public Component {
    * Python future is requested, the Python application must then await on this future to
    * ensure the transfer has completed. Requires UCXX Python support.
    *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
+   *
    * @param[in] buffer              a raw pointer to the data to be sent.
    * @param[in] length              the size in bytes of the tag message to be sent.
    * @param[in] tag                 the tag to match.
@@ -622,6 +671,13 @@ class Endpoint : public Component {
    * Using a Python future may be requested by specifying `enablePythonFuture`. If a
    * Python future is requested, the Python application must then await on this future to
    * ensure the transfer has completed. Requires UCXX Python support.
+   *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
    *
    * @param[in] buffer              a raw pointer to pre-allocated memory where resulting
    *                                data will be stored.
@@ -722,6 +778,13 @@ class Endpoint : public Component {
    * Python future is requested, the Python application must then await on this future to
    * ensure the transfer has completed. Requires UCXX Python support.
    *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
+   *
    * @param[in] enablePythonFuture  whether a python future should be created and
    *                                subsequently notified.
    * @param[in] callbackFunction    user-defined callback function to call upon completion.
@@ -771,6 +834,13 @@ class Endpoint : public Component {
    * Using a Python future may be requested by specifying `enablePythonFuture`. If a
    * Python future is requested, the Python application must then await on this future to
    * ensure the close operation has completed. Requires UCXX Python support.
+   *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
    *
    * @warning Unlike its `closeBlocking()` counterpart, this method does not cancel any
    * inflight requests prior to submitting the UCP close request. Before scheduling the

--- a/cpp/include/ucxx/notifier.h
+++ b/cpp/include/ucxx/notifier.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -73,7 +73,7 @@ class Notifier {
    * timeout in nanoseconds to unblock after a that period if no event has occurred. A
    * period of zero means this call will never unblock until an event occurs.
    *
-   * WARNING: Be cautious using a period of zero, if no event ever occurs it will be
+   * @warning Be cautious using a period of zero, if no event ever occurs it will be
    * impossible to continue the thread.
    *
    * @param[in] period the time in nanoseconds to wait for an event before unblocking.

--- a/cpp/include/ucxx/request.h
+++ b/cpp/include/ucxx/request.h
@@ -178,7 +178,7 @@ class Request : public Component {
    * Generic callback executed by UCX when a request is completed, used to set the status
    * of the request and free any resources associated with it.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *

--- a/cpp/include/ucxx/request_am.h
+++ b/cpp/include/ucxx/request_am.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -78,6 +78,13 @@ class RequestAm : public Request {
    * this is a send operation, or consumed if this is a receive operation. Received data is
    * available via the `getRecvBuffer()` method if the receive transfer request completed
    * successfully.
+   *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
    *
    * @throws ucxx::Error  if `endpoint` is not a valid
    *                      `std::shared_ptr<ucxx::Endpoint>`.

--- a/cpp/include/ucxx/request_endpoint_close.h
+++ b/cpp/include/ucxx/request_endpoint_close.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -100,7 +100,7 @@ class RequestEndpointClose : public Request {
    * Callback executed by UCX when an endpoint close request is completed, that will
    * dispatch `ucxx::Request::callback()`.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *

--- a/cpp/include/ucxx/request_endpoint_close.h
+++ b/cpp/include/ucxx/request_endpoint_close.h
@@ -63,6 +63,13 @@ class RequestEndpointClose : public Request {
    * must be verified from the resulting request object to confirm the close operation has
    * completed successfully.
    *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
+   *
    * @throws ucxx::Error  `endpoint` is not a valid `std::shared_ptr<ucxx::Endpoint>`.
    *
    * @param[in] endpoint            the `std::shared_ptr<Endpoint>` parent component.

--- a/cpp/include/ucxx/request_flush.h
+++ b/cpp/include/ucxx/request_flush.h
@@ -70,6 +70,13 @@ class RequestFlush : public Request {
    * status must be verified from the resulting request object to confirm the flush
    * operation has completed successfully.
    *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
+   *
    * @throws ucxx::Error  `endpointOrWorker` is not a valid
    *                      `std::shared_ptr<ucxx::Endpoint>` or
    *                      `std::shared_ptr<ucxx::Worker>`.

--- a/cpp/include/ucxx/request_flush.h
+++ b/cpp/include/ucxx/request_flush.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -111,7 +111,7 @@ class RequestFlush : public Request {
    * Callback executed by UCX when a flush request is completed, that will dispatch
    * `ucxx::Request::callback()`.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *

--- a/cpp/include/ucxx/request_mem.h
+++ b/cpp/include/ucxx/request_mem.h
@@ -107,7 +107,7 @@ class RequestMem : public Request {
    * Callback executed by UCX when a memory put request is completed, that will dispatch
    * `ucxx::Request::callback()`.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *
@@ -124,7 +124,7 @@ class RequestMem : public Request {
    * Callback executed by UCX when a memory get request is completed, that will dispatch
    * `ucxx::Request::callback()`.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *

--- a/cpp/include/ucxx/request_mem.h
+++ b/cpp/include/ucxx/request_mem.h
@@ -78,6 +78,13 @@ class RequestMem : public Request {
    * be released and the local data (on get operations) or remote data (on put operations)
    * can be consumed.
    *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
+   *
    * @throws ucxx::Error  if `endpointOrWorker` is not a valid
    *                      `std::shared_ptr<ucxx::Endpoint>` or
    *                      `std::shared_ptr<ucxx::Worker>`.

--- a/cpp/include/ucxx/request_stream.h
+++ b/cpp/include/ucxx/request_stream.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -91,7 +91,7 @@ class RequestStream : public Request {
    * truncated and set that state if necessary, and finally dispatch
    * `ucxx::Request::callback()`.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *
@@ -107,7 +107,7 @@ class RequestStream : public Request {
    * Callback executed by UCX when a stream send request is completed, that will dispatch
    * `ucxx::Request::callback()`.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *
@@ -124,7 +124,7 @@ class RequestStream : public Request {
    * Callback executed by UCX when a stream receive request is completed, that will
    * dispatch `ucxx::RequestStream::callback()`.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *

--- a/cpp/include/ucxx/request_tag.h
+++ b/cpp/include/ucxx/request_tag.h
@@ -69,6 +69,13 @@ class RequestTag : public Request {
    * transfer must be verified from the resulting request object before the data can be
    * released (for a send operation) or consumed (for a receive operation).
    *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
+   *
    * @throws ucxx::Error  if send is `true` and `endpointOrWorker` is not a
    *                      `std::shared_ptr<ucxx::Endpoint>`.
    *

--- a/cpp/include/ucxx/request_tag.h
+++ b/cpp/include/ucxx/request_tag.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -108,7 +108,7 @@ class RequestTag : public Request {
    * Callback executed by UCX when a tag send request is completed, that will dispatch
    * `ucxx::Request::callback()`.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *
@@ -125,7 +125,7 @@ class RequestTag : public Request {
    * Callback executed by UCX when a tag receive request is completed, that will dispatch
    * `ucxx::RequestTag::callback()`.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *
@@ -148,7 +148,7 @@ class RequestTag : public Request {
    * truncated and set that state if necessary, and finally dispatch
    * `ucxx::Request::callback()`.
    *
-   * WARNING: This is not intended to be called by the user, but it currently needs to be
+   * @warning This is not intended to be called by the user, but it currently needs to be
    * a public method so that UCX may access it. In future changes this will be moved to
    * an internal object and remove this method from the public API.
    *

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -725,6 +725,13 @@ class Worker : public Component {
    * implementation has support for it. If a future is requested, the application must then
    * await on this future to ensure the transfer has completed.
    *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
+   *
    * @param[in] buffer            a raw pointer to pre-allocated memory where resulting
    *                              data will be stored.
    * @param[in] length            the size in bytes of the tag message to be received.
@@ -936,6 +943,13 @@ class Worker : public Component {
    * Using a Python future may be requested by specifying `enablePythonFuture`. If a
    * Python future is requested, the Python application must then await on this future to
    * ensure the transfer has completed. Requires UCXX Python support.
+   *
+   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
+   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
+   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
+   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
+   * in which case the callback will also execute immediately within the calling thread and
+   * before the method returns.
    *
    * @param[in] enablePythonFuture  whether a python future should be created and
    *                                subsequently notified.

--- a/cpp/python/include/ucxx/python/notifier.h
+++ b/cpp/python/include/ucxx/python/notifier.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -48,7 +48,7 @@ class Notifier : public ::ucxx::Notifier {
    * Block while waiting for an event (new future to be notified or stop signal)
    * indefinitely.
    *
-   * WARNING: Use with caution, if no event ever occurs it will be impossible to continue
+   * @warning Use with caution, if no event ever occurs it will be impossible to continue
    * the thread.
    */
   [[nodiscard]] RequestNotifierWaitState waitRequestNotifierWithoutTimeout();
@@ -115,7 +115,7 @@ class Notifier : public ::ucxx::Notifier {
    * timeout in nanoseconds to unblock after a that period if no event has occurred. A
    * period of zero means this call will never unblock until an event occurs.
    *
-   * WARNING: Be cautious using a period of zero, if no event ever occurs it will be
+   * @warning Be cautious using a period of zero, if no event ever occurs it will be
    * impossible to continue the thread.
    *
    * @param[in] period the time in nanoseconds to wait for an event before unblocking.

--- a/cpp/python/include/ucxx/python/python_future_task_collector.h
+++ b/cpp/python/include/ucxx/python/python_future_task_collector.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -49,7 +49,7 @@ class PythonFutureTaskCollector {
    * Decrement each reference (i.e., garbage collect) that was previously pushed via the
    * `push()` method exactly once, cleaning internal references at the end.
    *
-   * WARNING: Calling this method will attempt to take the GIL, so make sure no other thread
+   * @warning Calling this method will attempt to take the GIL, so make sure no other thread
    * currently owns it while this thread also competes for other resources that the Python
    * thread holding the GIL may require as it may cause a deadlock.
    */


### PR DESCRIPTION
It is currently unclear that users need to maintain the lifetime of the `callbackFunction` and its associated data, as well as where (in what thread) callbacks are executed from.