### PR TITLE
Use const reference to pass `std::string`

### DIFF
--- a/cpp/include/ucxx/delayed_submission.h
+++ b/cpp/include/ucxx/delayed_submission.h
@@ -93,7 +93,7 @@ class BaseDelayedSubmissionCollection {
    *                    class should only be used to provide a consistent interface among
    *                    implementations.
    */
-  explicit BaseDelayedSubmissionCollection(const std::string name, const bool enabled)
+  explicit BaseDelayedSubmissionCollection(const std::string& name, const bool enabled)
     : _name{name}, _enabled{enabled}
   {
   }
@@ -222,7 +222,7 @@ class RequestDelayedSubmissionCollection
    *                    debugging purposes.
    * @param[in] enabled whether delayed request submissions should be enabled.
    */
-  explicit RequestDelayedSubmissionCollection(const std::string name, const bool enabled);
+  explicit RequestDelayedSubmissionCollection(const std::string& name, const bool enabled);
 };
 
 /**
@@ -248,7 +248,7 @@ class GenericDelayedSubmissionCollection
    * @param[in] name    the human-readable name of the type of delayed submission for
    *                    debugging purposes.
    */
-  explicit GenericDelayedSubmissionCollection(const std::string name);
+  explicit GenericDelayedSubmissionCollection(const std::string& name);
 };
 
 /**

--- a/cpp/include/ucxx/header.h
+++ b/cpp/include/ucxx/header.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once

--- a/cpp/include/ucxx/request.h
+++ b/cpp/include/ucxx/request.h
@@ -78,7 +78,7 @@ class Request : public Component {
    */
   Request(std::shared_ptr<Component> endpointOrWorker,
           const data::RequestData requestData,
-          const std::string operationName,
+          const std::string& operationName,
           const bool enablePythonFuture                = false,
           RequestCallbackUserFunction callbackFunction = nullptr,
           RequestCallbackUserData callbackData         = nullptr);

--- a/cpp/include/ucxx/request_am.h
+++ b/cpp/include/ucxx/request_am.h
@@ -62,7 +62,7 @@ class RequestAm : public Request {
    */
   RequestAm(std::shared_ptr<Component> endpointOrWorker,
             const std::variant<data::AmSend, data::AmReceive> requestData,
-            const std::string operationName,
+            const std::string& operationName,
             const bool enablePythonFuture                = false,
             RequestCallbackUserFunction callbackFunction = nullptr,
             RequestCallbackUserData callbackData         = nullptr);

--- a/cpp/include/ucxx/request_endpoint_close.h
+++ b/cpp/include/ucxx/request_endpoint_close.h
@@ -48,7 +48,7 @@ class RequestEndpointClose : public Request {
    */
   RequestEndpointClose(std::shared_ptr<Endpoint> endpoint,
                        const data::EndpointClose requestData,
-                       const std::string operationName,
+                       const std::string& operationName,
                        const bool enablePythonFuture                = false,
                        RequestCallbackUserFunction callbackFunction = nullptr,
                        RequestCallbackUserData callbackData         = nullptr);

--- a/cpp/include/ucxx/request_flush.h
+++ b/cpp/include/ucxx/request_flush.h
@@ -54,7 +54,7 @@ class RequestFlush : public Request {
    */
   RequestFlush(std::shared_ptr<Component> endpointOrWorker,
                const data::Flush requestData,
-               const std::string operationName,
+               const std::string& operationName,
                const bool enablePythonFuture                = false,
                RequestCallbackUserFunction callbackFunction = nullptr,
                RequestCallbackUserData callbackData         = nullptr);

--- a/cpp/include/ucxx/request_mem.h
+++ b/cpp/include/ucxx/request_mem.h
@@ -62,7 +62,7 @@ class RequestMem : public Request {
    */
   RequestMem(std::shared_ptr<Endpoint> endpoint,
              const std::variant<data::MemPut, data::MemGet> requestData,
-             const std::string operationName,
+             const std::string& operationName,
              const bool enablePythonFuture                = false,
              RequestCallbackUserFunction callbackFunction = nullptr,
              RequestCallbackUserData callbackData         = nullptr);

--- a/cpp/include/ucxx/request_stream.h
+++ b/cpp/include/ucxx/request_stream.h
@@ -46,7 +46,7 @@ class RequestStream : public Request {
    */
   RequestStream(std::shared_ptr<Endpoint> endpoint,
                 const std::variant<data::StreamSend, data::StreamReceive> requestData,
-                const std::string operationName,
+                const std::string& operationName,
                 const bool enablePythonFuture = false);
 
  public:

--- a/cpp/include/ucxx/request_tag.h
+++ b/cpp/include/ucxx/request_tag.h
@@ -54,7 +54,7 @@ class RequestTag : public Request {
    */
   RequestTag(std::shared_ptr<Component> endpointOrWorker,
              const std::variant<data::TagSend, data::TagReceive> requestData,
-             const std::string operationName,
+             const std::string& operationName,
              const bool enablePythonFuture                = false,
              RequestCallbackUserFunction callbackFunction = nullptr,
              RequestCallbackUserData callbackData         = nullptr);

--- a/cpp/include/ucxx/request_tag_multi.h
+++ b/cpp/include/ucxx/request_tag_multi.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -98,7 +98,7 @@ class RequestTagMulti : public Request {
    */
   RequestTagMulti(std::shared_ptr<Endpoint> endpoint,
                   const std::variant<data::TagMultiSend, data::TagMultiReceive> requestData,
-                  const std::string operationName,
+                  const std::string& operationName,
                   const bool enablePythonFuture);
 
   /**

--- a/cpp/include/ucxx/typedefs.h
+++ b/cpp/include/ucxx/typedefs.h
@@ -171,7 +171,7 @@ typedef uint64_t AmReceiverCallbackIdType;
  * A string type representing the serialized form of an Active Message receiver callback's
  * information, used for transmission and storage.
  */
-typedef const std::string AmReceiverCallbackInfoSerialized;
+typedef const std::string& AmReceiverCallbackInfoSerialized;
 
 /**
  * @brief Information of an Active Message receiver callback.

--- a/cpp/src/delayed_submission.cpp
+++ b/cpp/src/delayed_submission.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -14,7 +14,7 @@
 
 namespace ucxx {
 
-RequestDelayedSubmissionCollection::RequestDelayedSubmissionCollection(const std::string name,
+RequestDelayedSubmissionCollection::RequestDelayedSubmissionCollection(const std::string& name,
                                                                        const bool enabled)
   : BaseDelayedSubmissionCollection<
       std::pair<std::shared_ptr<Request>, DelayedSubmissionCallbackType>>{name, enabled}
@@ -38,7 +38,7 @@ void RequestDelayedSubmissionCollection::processItem(
   if (callback) callback();
 }
 
-GenericDelayedSubmissionCollection::GenericDelayedSubmissionCollection(const std::string name)
+GenericDelayedSubmissionCollection::GenericDelayedSubmissionCollection(const std::string& name)
   : BaseDelayedSubmissionCollection<DelayedSubmissionCallbackType>{name, true}
 {
 }

--- a/cpp/src/header.cpp
+++ b/cpp/src/header.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>

--- a/cpp/src/request.cpp
+++ b/cpp/src/request.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <chrono>
@@ -18,7 +18,7 @@ namespace ucxx {
 
 Request::Request(std::shared_ptr<Component> endpointOrWorker,
                  const data::RequestData requestData,
-                 const std::string operationName,
+                 const std::string& operationName,
                  const bool enablePythonFuture,
                  RequestCallbackUserFunction callbackFunction,
                  RequestCallbackUserData callbackData)

--- a/cpp/src/request_am.cpp
+++ b/cpp/src/request_am.cpp
@@ -135,7 +135,7 @@ std::shared_ptr<RequestAm> createRequestAm(
 
 RequestAm::RequestAm(std::shared_ptr<Component> endpointOrWorker,
                      const std::variant<data::AmSend, data::AmReceive> requestData,
-                     const std::string operationName,
+                     const std::string& operationName,
                      const bool enablePythonFuture,
                      RequestCallbackUserFunction callbackFunction,
                      RequestCallbackUserData callbackData)

--- a/cpp/src/request_endpoint_close.cpp
+++ b/cpp/src/request_endpoint_close.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ucxx/request_data.h"
@@ -37,7 +37,7 @@ std::shared_ptr<RequestEndpointClose> createRequestEndpointClose(
 
 RequestEndpointClose::RequestEndpointClose(std::shared_ptr<Endpoint> endpoint,
                                            const data::EndpointClose requestData,
-                                           const std::string operationName,
+                                           const std::string& operationName,
                                            const bool enablePythonFuture,
                                            RequestCallbackUserFunction callbackFunction,
                                            RequestCallbackUserData callbackData)

--- a/cpp/src/request_flush.cpp
+++ b/cpp/src/request_flush.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -35,7 +35,7 @@ std::shared_ptr<RequestFlush> createRequestFlush(
 
 RequestFlush::RequestFlush(std::shared_ptr<Component> endpointOrWorker,
                            const data::Flush requestData,
-                           const std::string operationName,
+                           const std::string& operationName,
                            const bool enablePythonFuture,
                            RequestCallbackUserFunction callbackFunction,
                            RequestCallbackUserData callbackData)

--- a/cpp/src/request_mem.cpp
+++ b/cpp/src/request_mem.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -45,7 +45,7 @@ std::shared_ptr<RequestMem> createRequestMem(
 
 RequestMem::RequestMem(std::shared_ptr<Endpoint> endpoint,
                        const std::variant<data::MemPut, data::MemGet> requestData,
-                       const std::string operationName,
+                       const std::string& operationName,
                        const bool enablePythonFuture,
                        RequestCallbackUserFunction callbackFunction,
                        RequestCallbackUserData callbackData)

--- a/cpp/src/request_stream.cpp
+++ b/cpp/src/request_stream.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -14,7 +14,7 @@
 namespace ucxx {
 RequestStream::RequestStream(std::shared_ptr<Endpoint> endpoint,
                              const std::variant<data::StreamSend, data::StreamReceive> requestData,
-                             const std::string operationName,
+                             const std::string& operationName,
                              const bool enablePythonFuture)
   : Request(endpoint, data::getRequestData(requestData), operationName, enablePythonFuture)
 {

--- a/cpp/src/request_tag.cpp
+++ b/cpp/src/request_tag.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -55,7 +55,7 @@ std::shared_ptr<RequestTag> createRequestTag(
 
 RequestTag::RequestTag(std::shared_ptr<Component> endpointOrWorker,
                        const std::variant<data::TagSend, data::TagReceive> requestData,
-                       const std::string operationName,
+                       const std::string& operationName,
                        const bool enablePythonFuture,
                        RequestCallbackUserFunction callbackFunction,
                        RequestCallbackUserData callbackData)

--- a/cpp/src/request_tag_multi.cpp
+++ b/cpp/src/request_tag_multi.cpp
@@ -27,7 +27,7 @@ BufferRequest::~BufferRequest() { ucxx_trace_req("ucxx::BufferRequest destroyed:
 RequestTagMulti::RequestTagMulti(
   std::shared_ptr<Endpoint> endpoint,
   const std::variant<data::TagMultiSend, data::TagMultiReceive> requestData,
-  const std::string operationName,
+  const std::string& operationName,
   const bool enablePythonFuture)
   : Request(endpoint, data::getRequestData(requestData), operationName, enablePythonFuture)
 {
@@ -84,7 +84,7 @@ std::shared_ptr<RequestTagMulti> createRequestTagMulti(
 }
 
 static TagPair checkAndGetTagPair(const data::RequestData& requestData,
-                                  const std::string methodName)
+                                  const std::string& methodName)
 {
   return std::visit(
     data::dispatch{


### PR DESCRIPTION
This prevents unnecessary copies.