### PR TITLE
Update rapids-dependency-file-generator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
                 - --fix
                 - --rapids-version-file=RAPIDS_VERSION
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.19.0
+        rev: v1.20.0
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         rev: v1.20.0
         hooks:
             - id: rapids-dependency-file-generator
-              args: ["--clean"]
+              args: ["--clean", "--warn-all", "--strict"]
       - repo: local
         hooks:
             - id: cmake-format


### PR DESCRIPTION
This PR updates the rapids-dependency-file-generator hook to get https://github.com/rapidsai/dependency-file-generator/pull/163.
