### PR TITLE
restore cudf dependency

### DIFF
--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -13,9 +13,12 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.0
+- cudf==25.10.*,>=0.0.0a0
 - cupy>=13.6.0
 - cxx-compiler
 - cython>=3.0.0
+- dask-cuda==25.10.*,>=0.0.0a0
+- dask-cudf==25.10.*,>=0.0.0a0
 - doxygen=1.9.1
 - librmm==25.10.*,>=0.0.0a0
 - libtool

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -13,9 +13,12 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.0
+- cudf==25.10.*,>=0.0.0a0
 - cupy>=13.6.0
 - cxx-compiler
 - cython>=3.0.0
+- dask-cuda==25.10.*,>=0.0.0a0
+- dask-cudf==25.10.*,>=0.0.0a0
 - doxygen=1.9.1
 - librmm==25.10.*,>=0.0.0a0
 - libtool

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -406,7 +406,7 @@ dependencies:
           - {matrix: null, packages: [*rmm_unsuffixed]}
   depends_on_cudf:
     common:
-      - ouput_type: [conda]
+      - output_types: [conda]
         packages:
           - &cudf_unsuffixed cudf==25.10.*,>=0.0.0a0
       - output_types: requirements

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -242,6 +242,8 @@ dependencies:
           # These packages are useful for development but not otherwise required to build/run
           # RAPIDS
           - pip
+          - dask-cuda==25.10.*,>=0.0.0a0
+          - dask-cudf==25.10.*,>=0.0.0a0
           # UCX Build
           - libtool
           - automake
@@ -250,18 +252,6 @@ dependencies:
           - pkg-config
           # Docs Build
           - &doxygen doxygen=1.9.1 # pre-commit hook needs a specific version.
-    specific:
-      - output_types: [conda]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-            packages:
-              - dask-cuda==25.10.*,>=0.0.0a0
-              - dask-cudf==25.10.*,>=0.0.0a0
-          # TODO: add 'dask-cuda' and 'dask-cudf' back to this 'dev' dependency list once there are CUDA 13 packages for those
-          # ref: https://github.com/rapidsai/ucxx/pull/489#issuecomment-3207723017
-          - matrix:
-            packages:
   docs:
     common:
       - output_types: [conda]
@@ -414,28 +404,17 @@ dependencies:
             packages:
               - rmm-cu13==25.10.*,>=0.0.0a0
           - {matrix: null, packages: [*rmm_unsuffixed]}
-  # TODO: re-include cudf on CUDA 13 here once cudf CUDA 13 packages exist
-  # ref: https://github.com/rapidsai/ucxx/pull/489#issuecomment-3207723017
   depends_on_cudf:
     common:
+      - ouput_type: [conda]
+        packages:
+          - &cudf_unsuffixed cudf==25.10.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
           - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
-      - output_types: [conda]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-            packages:
-              - &cudf_unsuffixed cudf==25.10.*,>=0.0.0a0
-          - matrix:
-              cuda: "13.*"
-            packages:
-          - matrix:
-            packages:
-              - *cudf_unsuffixed
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:
@@ -446,6 +425,7 @@ dependencies:
           - matrix:
               cuda: "13.*"
             packages:
+              - cudf-cu13==25.10.*,>=0.0.0a0
           - {matrix: null, packages: [*cudf_unsuffixed]}
   depends_on_distributed_ucxx:
     common:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/208

#489 temporarily removed the `cudf` test-time dependency here, because there weren't yet CUDA 13 `cudf` packages.

Those now exist (https://github.com/rapidsai/cudf/pull/19768), so this restores that dependency.