### PR TITLE
Replaced every occurrence of stream_timeout and exchange_peer_info_timeout to connect_timeout, added env var support, and added connect_timeout as an argument to init in core.py

### DIFF
--- a/python/ucxx/ucxx/_lib_async/application_context.py
+++ b/python/ucxx/ucxx/_lib_async/application_context.py
@@ -46,7 +46,7 @@ class ApplicationContext:
         progress_mode=None,
         enable_delayed_submission=None,
         enable_python_future=None,
-        exchange_peer_info_timeout=10.0,
+        connect_timeout=10.0,
     ):
         self.notifier_thread_q = None
         self.notifier_thread = None
@@ -57,7 +57,12 @@ class ApplicationContext:
         self.enable_delayed_submission = enable_delayed_submission
         self.enable_python_future = enable_python_future
 
-        self.exchange_peer_info_timeout = exchange_peer_info_timeout
+        if "UCXPY_CONNECT_TIMEOUT" in os.environ:
+            self.connect_timeout = float(os.environ["UCXPY_CONNECT_TIMEOUT"])
+        elif connect_timeout is not None:
+            self.connect_timeout = connect_timeout
+        else:
+            self.connect_timeout = 10.0
 
         # For now, a application context only has one worker
         self.context = ucx_api.UCXContext(config_dict)
@@ -254,7 +259,7 @@ class ApplicationContext:
         callback_func,
         port=0,
         endpoint_error_handling=True,
-        exchange_peer_info_timeout=5.0,
+        connect_timeout=5.0,
     ):
         """Create and start a listener to accept incoming connections
 
@@ -278,7 +283,7 @@ class ApplicationContext:
             but prevents a process from terminating unexpectedly that may
             happen when disabled. If `False` endpoint endpoint error handling
             is disabled.
-        exchange_peer_info_timeout: float
+        connect_timeout: float
             Timeout in seconds for exchanging peer info. In some cases, exchanging
             peer information may hang indefinitely, a timeout prevents that. If the
             chosen value is too high it may cause the operation to be stuck for too
@@ -310,7 +315,7 @@ class ApplicationContext:
                     callback_func,
                     self,
                     endpoint_error_handling,
-                    exchange_peer_info_timeout,
+                    connect_timeout,
                     listener_id,
                     self._listener_active_clients,
                 ),
@@ -326,7 +331,7 @@ class ApplicationContext:
         ip_address,
         port,
         endpoint_error_handling=True,
-        exchange_peer_info_timeout=5.0,
+        connect_timeout=5.0,
     ):
         """Create a new endpoint to a server
 
@@ -342,7 +347,7 @@ class ApplicationContext:
             but prevents a process from terminating unexpectedly that may
             happen when disabled. If `False` endpoint endpoint error handling
             is disabled.
-        exchange_peer_info_timeout: float
+        connect_timeout: float
             Timeout in seconds for exchanging peer info. In some cases, exchanging
             peer information may hang indefinitely, a timeout prevents that. If the
             chosen value is too high it may cause the operation to be stuck for too
@@ -376,7 +381,7 @@ class ApplicationContext:
                 msg_tag=msg_tag,
                 ctrl_tag=ctrl_tag,
                 listener=False,
-                stream_timeout=exchange_peer_info_timeout,
+                connect_timeout=connect_timeout,
             )
         except UCXMessageTruncatedError as e:
             # A truncated message occurs if the remote endpoint closed before

--- a/python/ucxx/ucxx/_lib_async/exchange_peer_info.py
+++ b/python/ucxx/ucxx/_lib_async/exchange_peer_info.py
@@ -13,7 +13,7 @@ from .utils import hash64bits
 logger = logging.getLogger("ucx")
 
 
-async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, listener, stream_timeout=5.0):
+async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, listener, connect_timeout=5.0):
     """Help function that exchange endpoint information"""
 
     # Pack peer information incl. a checksum
@@ -27,14 +27,14 @@ async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, listener, stream_timeo
     # streaming calls (see <https://github.com/rapidsai/ucx-py/pull/509>)
     if listener is True:
         req = endpoint.stream_send(my_info_arr)
-        await asyncio.wait_for(req.wait(), timeout=stream_timeout)
+        await asyncio.wait_for(req.wait(), timeout=connect_timeout)
         req = endpoint.stream_recv(peer_info_arr)
-        await asyncio.wait_for(req.wait(), timeout=stream_timeout)
+        await asyncio.wait_for(req.wait(), timeout=connect_timeout)
     else:
         req = endpoint.stream_recv(peer_info_arr)
-        await asyncio.wait_for(req.wait(), timeout=stream_timeout)
+        await asyncio.wait_for(req.wait(), timeout=connect_timeout)
         req = endpoint.stream_send(my_info_arr)
-        await asyncio.wait_for(req.wait(), timeout=stream_timeout)
+        await asyncio.wait_for(req.wait(), timeout=connect_timeout)
 
     # Unpacking and sanity check of the peer information
     ret = {}

--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -137,7 +137,7 @@ async def _listener_handler_coroutine(
     ctx,
     func,
     endpoint_error_handling,
-    exchange_peer_info_timeout,
+    connect_timeout,
     ident,
     active_clients,
 ):
@@ -163,7 +163,7 @@ async def _listener_handler_coroutine(
             msg_tag=msg_tag,
             ctrl_tag=ctrl_tag,
             listener=True,
-            stream_timeout=exchange_peer_info_timeout,
+            connect_timeout=connect_timeout,
         )
     except UCXMessageTruncatedError:
         # A truncated message occurs if the remote endpoint closed before
@@ -215,7 +215,7 @@ def _listener_handler(
     callback_func,
     ctx,
     endpoint_error_handling,
-    exchange_peer_info_timeout,
+    connect_timeout,
     ident,
     active_clients,
 ):
@@ -225,7 +225,7 @@ def _listener_handler(
             ctx,
             callback_func,
             endpoint_error_handling,
-            exchange_peer_info_timeout,
+            connect_timeout,
             ident,
             active_clients,
         ),

--- a/python/ucxx/ucxx/_lib_async/tests/test_multiple_nodes.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_multiple_nodes.py
@@ -33,7 +33,7 @@ async def server_node(ep):
 
 async def client_node(port):
     ep = await ucxx.create_endpoint(
-        ucxx.get_address(), port, exchange_peer_info_timeout=10.0
+        ucxx.get_address(), port, connect_timeout=10.0
     )
     await hello(ep)
     await ep.close()
@@ -50,7 +50,7 @@ async def test_many_servers_many_clients(num_servers, num_clients):
 
     for _ in range(num_servers):
         listeners.append(
-            ucxx.create_listener(server_node, exchange_peer_info_timeout=10.0)
+            ucxx.create_listener(server_node, connect_timeout=10.0)
         )
 
     # We ensure no more than `somaxconn` connections are submitted

--- a/python/ucxx/ucxx/core.py
+++ b/python/ucxx/ucxx/core.py
@@ -35,6 +35,7 @@ def init(
     progress_mode=None,
     enable_delayed_submission=None,
     enable_python_future=None,
+    connect_timeout=None,
 ):
     """Initiate UCX.
 
@@ -86,6 +87,7 @@ def init(
         progress_mode=progress_mode,
         enable_delayed_submission=enable_delayed_submission,
         enable_python_future=enable_python_future,
+        connect_timeout=connect_timeout
     )
 
 
@@ -164,24 +166,24 @@ def create_listener(
     callback_func,
     port=None,
     endpoint_error_handling=True,
-    exchange_peer_info_timeout=5.0,
+    connect_timeout=5.0,
 ):
     return _get_ctx().create_listener(
         callback_func,
         port,
         endpoint_error_handling=endpoint_error_handling,
-        exchange_peer_info_timeout=exchange_peer_info_timeout,
+        connect_timeout=connect_timeout,
     )
 
 
 async def create_endpoint(
-    ip_address, port, endpoint_error_handling=True, exchange_peer_info_timeout=5.0
+    ip_address, port, endpoint_error_handling=True, connect_timeout=5.0
 ):
     return await _get_ctx().create_endpoint(
         ip_address,
         port,
         endpoint_error_handling=endpoint_error_handling,
-        exchange_peer_info_timeout=exchange_peer_info_timeout,
+        connect_timeout=connnect_timeout,
     )
 
 


### PR DESCRIPTION
Issue #350 

Renamed stream_timeout → connect_timeout in exchange_peer_info, application_context.py

Renamed exchange_peer_info_timeout → connect_timeout in application_context.py and listener.py, core.py, test_multiple_nodes.py.

Added support for configuring connect_timeout via environment variable,

Exposed connect_timeout as an argument in init() and propagated it to ApplicationContext.