### PR TITLE
Export UCX dependency

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -70,18 +70,7 @@ rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
 
 # ##################################################################################################
 # * compiler options ------------------------------------------------------------------------------
-#   Due to https://github.com/openucx/ucx/issues/9614, we cannot export the ucx dependency because
-#   users would then have no control over whether ucx is found multiple times, causing potential
-#   configure errors. Therefore, we use a raw find_package call instead of rapids_find_package and
-#   skip exporting the ucx dependency. Consumers of ucxx must find ucx themselves. Once we move the
-#   minimum version to UCX 1.16 we can remove the above find_package in favor of the commented out
-#   lines below. For the same reason, we must also gate this find_package call behind a check for
-#   the target already existing so that consumers can use tools like CPM.cmake to either find or
-#   build ucxx from source if it cannot be found (i.e. both cases must allow prior finding of ucx).
-if(NOT TARGET ucx::ucp)
-  find_package(ucx REQUIRED)
-endif()
-# rapids_find_package( ucx REQUIRED BUILD_EXPORT_SET ucxx-exports INSTALL_EXPORT_SET ucxx-exports )
+rapids_find_package(ucx REQUIRED BUILD_EXPORT_SET ucxx-exports INSTALL_EXPORT_SET ucxx-exports)
 
 # ##################################################################################################
 # * dependencies ----------------------------------------------------------------------------------

--- a/cpp/python/CMakeLists.txt
+++ b/cpp/python/CMakeLists.txt
@@ -56,18 +56,7 @@ rapids_find_package(
 )
 # ##################################################################################################
 # * compiler options ------------------------------------------------------------------------------
-#   Due to https://github.com/openucx/ucx/issues/9614, we cannot export the ucx dependency because
-#   users would then have no control over whether ucx is found multiple times, causing potential
-#   configure errors. Therefore, we use a raw find_package call instead of rapids_find_package and
-#   skip exporting the ucx dependency. Consumers of ucxx must find ucx themselves. Once we move the
-#   minimum version to UCX 1.16 we can remove the above find_package in favor of the commented out
-#   lines below. For the same reason, we must also gate this find_package call behind a check for
-#   the target already existing so that consumers can use tools like CPM.cmake to either find or
-#   build ucxx from source if it cannot be found (i.e. both cases must allow prior finding of ucx).
-if(NOT TARGET ucx::ucp)
-  find_package(ucx REQUIRED)
-endif()
-# rapids_find_package( ucx REQUIRED BUILD_EXPORT_SET ucxx-exports INSTALL_EXPORT_SET ucxx-exports )
+rapids_find_package(ucx REQUIRED BUILD_EXPORT_SET ucxx-exports INSTALL_EXPORT_SET ucxx-exports)
 
 # ##################################################################################################
 # * python library --------------------------------------------------------------------------------

--- a/python/ucxx/CMakeLists.txt
+++ b/python/ucxx/CMakeLists.txt
@@ -31,7 +31,6 @@ option(UCXX_BUILD_TESTS "Configure CMake to build Cython tests" OFF)
 
 # If the user requested it we attempt to find UCXX.
 if(FIND_UCXX_PYTHON)
-  find_package(ucx REQUIRED)
   find_package(ucxx-python ${ucxx_version} REQUIRED)
 else()
   set(ucxx-python_FOUND OFF)


### PR DESCRIPTION
Previously, we have stopped exporting the UCX dependency due to a bug in the UCX CMake, see https://github.com/openucx/ucx/issues/9614. This has since been fixed in v1.16.0+, and UCXX has recently moved to depend on 1.17.0+ via https://github.com/rapidsai/ucxx/pull/485, so reverting changes from #172 #175 should be safe.

Closes #173