### PR TITLE
Remove rapids-dask-dependency patch requirements

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/__init__.py
+++ b/python/distributed-ucxx/distributed_ucxx/__init__.py
@@ -1,13 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
-# TODO: Remove UCXXConnect and UCXXListener once rapids-dask-dependency doesn't
-# need them anymore. `UCXXBackend*` need to remain for `pyproject.toml`.
 from .ucxx import (
     UCXXBackend,
     UCXXBackendLegacyPrefix,
-    UCXXConnector,
-    UCXXListener,
 )  # noqa: F401
 
 

--- a/python/distributed-ucxx/distributed_ucxx/tests/conftest.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/conftest.py
@@ -10,14 +10,6 @@ from __future__ import annotations
 
 import pytest
 
-# Force initialization of `rapids-dask-dependency` patches before importing
-# `distributed_ucxx`. Without this, rewriting the `ucx://` prefix will
-# fail to import `distributed_ucxx` as it causes a circular import.
-#
-# TODO: Remove once `rapids-dask-dependency` pins a `distributed` release containing
-# https://github.com/dask/distributed/pull/9105
-import distributed  # noqa: F401
-
 try:
     import faulthandler
 except ImportError:

--- a/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
@@ -28,6 +28,7 @@ from distributed.utils_test import inc
 import ucxx
 
 import distributed_ucxx  # noqa: E402
+from distributed_ucxx.ucxx import UCXXListener
 from distributed_ucxx.utils_test import gen_test
 
 try:
@@ -109,7 +110,7 @@ async def test_ucxx_specific(ucxx_loop):
         await comm.close()
         assert comm.closed() is True
 
-    listener = await distributed_ucxx.UCXXListener(address, handle_comm)
+    listener = await UCXXListener(address, handle_comm)
     host, port = listener.get_host_port()
     assert host.count(".") == 3
     assert port > 0


### PR DESCRIPTION
Some changes were needed to make rapids-dask-dependency patches enable distributed-ucxx as the handler for Distributed comms protocols. Once that is completely removed from rapids-dask-dependency and a new Distributed release containing https://github.com/dask/distributed/pull/9105 is out, changes from this PR can be merged.