### PR TITLE
Make ucx target global

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -72,6 +72,7 @@ rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
 # * compiler options ------------------------------------------------------------------------------
 rapids_find_package(
   ucx REQUIRED
+  GLOBAL_TARGETS ucx::ucp
   BUILD_EXPORT_SET ucxx-exports
   INSTALL_EXPORT_SET ucxx-exports
 )


### PR DESCRIPTION
This change is necessary for the target to be visible when ucxx is built as part of a CPM fetch by another repository (see https://github.com/rapidsai/ucxx/issues/173#issuecomment-3252421137).