### PR TITLE
Make send/put buffer pointers const

### DIFF
--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -371,7 +371,7 @@ class Endpoint : public Component {
    * @returns Request to be subsequently checked for the completion and its state.
    */
   [[nodiscard]] std::shared_ptr<Request> amSend(
-    void* buffer,
+    const void* buffer,
     const size_t length,
     const ucs_memory_type_t memoryType,
     const std::optional<AmReceiverCallbackInfo> receiverCallbackInfo = std::nullopt,
@@ -595,7 +595,7 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  [[nodiscard]] std::shared_ptr<Request> streamSend(void* buffer,
+  [[nodiscard]] std::shared_ptr<Request> streamSend(const void* buffer,
                                                     size_t length,
                                                     const bool enablePythonFuture);
 
@@ -653,7 +653,7 @@ class Endpoint : public Component {
    * @returns Request to be subsequently checked for the completion and its state.
    */
   [[nodiscard]] std::shared_ptr<Request> tagSend(
-    void* buffer,
+    const void* buffer,
     size_t length,
     Tag tag,
     const bool enablePythonFuture                = false,

--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -444,7 +444,7 @@ class Endpoint : public Component {
    * @returns Request to be subsequently checked for the completion and its state.
    */
   [[nodiscard]] std::shared_ptr<Request> memPut(
-    void* buffer,
+    const void* buffer,
     size_t length,
     uint64_t remoteAddr,
     ucp_rkey_h rkey,
@@ -486,7 +486,7 @@ class Endpoint : public Component {
    * @returns Request to be subsequently checked for the completion and its state.
    */
   [[nodiscard]] std::shared_ptr<Request> memPut(
-    void* buffer,
+    const void* buffer,
     size_t length,
     std::shared_ptr<ucxx::RemoteKey> remoteKey,
     uint64_t remoteAddrOffset                    = 0,
@@ -733,7 +733,7 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  [[nodiscard]] std::shared_ptr<Request> tagMultiSend(const std::vector<void*>& buffer,
+  [[nodiscard]] std::shared_ptr<Request> tagMultiSend(const std::vector<const void*>& buffer,
                                                       const std::vector<size_t>& size,
                                                       const std::vector<int>& isCUDA,
                                                       const Tag tag,

--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -371,7 +371,7 @@ class Endpoint : public Component {
    * @returns Request to be subsequently checked for the completion and its state.
    */
   [[nodiscard]] std::shared_ptr<Request> amSend(
-    const void* buffer,
+    const void* const buffer,
     const size_t length,
     const ucs_memory_type_t memoryType,
     const std::optional<AmReceiverCallbackInfo> receiverCallbackInfo = std::nullopt,
@@ -444,7 +444,7 @@ class Endpoint : public Component {
    * @returns Request to be subsequently checked for the completion and its state.
    */
   [[nodiscard]] std::shared_ptr<Request> memPut(
-    const void* buffer,
+    const void* const buffer,
     size_t length,
     uint64_t remoteAddr,
     ucp_rkey_h rkey,
@@ -486,7 +486,7 @@ class Endpoint : public Component {
    * @returns Request to be subsequently checked for the completion and its state.
    */
   [[nodiscard]] std::shared_ptr<Request> memPut(
-    const void* buffer,
+    const void* const buffer,
     size_t length,
     std::shared_ptr<ucxx::RemoteKey> remoteKey,
     uint64_t remoteAddrOffset                    = 0,
@@ -595,7 +595,7 @@ class Endpoint : public Component {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  [[nodiscard]] std::shared_ptr<Request> streamSend(const void* buffer,
+  [[nodiscard]] std::shared_ptr<Request> streamSend(const void* const buffer,
                                                     size_t length,
                                                     const bool enablePythonFuture);
 
@@ -653,7 +653,7 @@ class Endpoint : public Component {
    * @returns Request to be subsequently checked for the completion and its state.
    */
   [[nodiscard]] std::shared_ptr<Request> tagSend(
-    const void* buffer,
+    const void* const buffer,
     size_t length,
     Tag tag,
     const bool enablePythonFuture                = false,

--- a/cpp/include/ucxx/request_data.h
+++ b/cpp/include/ucxx/request_data.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -284,10 +284,10 @@ class TagReceive {
  */
 class TagMultiSend {
  public:
-  const std::vector<void*> _buffer{};   ///< Raw pointers where data to be sent is stored.
-  const std::vector<size_t> _length{};  ///< Lengths of messages.
-  const std::vector<int> _isCUDA{};     ///< Flags indicating whether the buffer is CUDA or not.
-  const ::ucxx::Tag _tag{0};            ///< Tag to match
+  const std::vector<const void*> _buffer{};  ///< Raw pointers where data to be sent is stored.
+  const std::vector<size_t> _length{};       ///< Lengths of messages.
+  const std::vector<int> _isCUDA{};  ///< Flags indicating whether the buffer is CUDA or not.
+  const ::ucxx::Tag _tag{0};         ///< Tag to match
 
   /**
    * @brief Constructor for send multi-buffer tag-specific data.

--- a/cpp/include/ucxx/request_data.h
+++ b/cpp/include/ucxx/request_data.h
@@ -27,8 +27,8 @@ namespace data {
  */
 class AmSend {
  public:
-  const void* _buffer{nullptr};  ///< The raw pointer where data to be sent is stored.
-  const size_t _length{0};       ///< The length of the message.
+  const void* const _buffer{nullptr};  ///< The raw pointer where data to be sent is stored.
+  const size_t _length{0};             ///< The length of the message.
   const ucs_memory_type_t _memoryType{UCS_MEMORY_TYPE_HOST};  ///< Memory type used on the operation
   const std::optional<AmReceiverCallbackInfo> _receiverCallbackInfo{
     std::nullopt};  ///< Owner name and unique identifier of the receiver callback.
@@ -115,10 +115,10 @@ class Flush {
  */
 class MemPut {
  public:
-  const void* _buffer{nullptr};   ///< The raw pointer where data to be sent is stored.
-  const size_t _length{0};        ///< The length of the message.
-  const uint64_t _remoteAddr{0};  ///< Remote memory address to write to.
-  const ucp_rkey_h _rkey{};       ///< UCX remote key associated with the remote memory address.
+  const void* const _buffer{nullptr};  ///< The raw pointer where data to be sent is stored.
+  const size_t _length{0};             ///< The length of the message.
+  const uint64_t _remoteAddr{0};       ///< Remote memory address to write to.
+  const ucp_rkey_h _rkey{};  ///< UCX remote key associated with the remote memory address.
 
   /**
    * @brief Constructor for memory-specific data.
@@ -177,8 +177,8 @@ class MemGet {
  */
 class StreamSend {
  public:
-  const void* _buffer{nullptr};  ///< The raw pointer where data to be sent is stored.
-  const size_t _length{0};       ///< The length of the message.
+  const void* const _buffer{nullptr};  ///< The raw pointer where data to be sent is stored.
+  const size_t _length{0};             ///< The length of the message.
 
   /**
    * @brief Constructor for stream-specific data.
@@ -225,9 +225,9 @@ class StreamReceive {
  */
 class TagSend {
  public:
-  const void* _buffer{nullptr};  ///< The raw pointer where data to be sent is stored.
-  const size_t _length{0};       ///< The length of the message.
-  const ::ucxx::Tag _tag{0};     ///< Tag to match
+  const void* const _buffer{nullptr};  ///< The raw pointer where data to be sent is stored.
+  const size_t _length{0};             ///< The length of the message.
+  const ::ucxx::Tag _tag{0};           ///< Tag to match
 
   /**
    * @brief Constructor for tag-specific data.

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -442,7 +442,7 @@ size_t Endpoint::cancelInflightRequestsBlocking(uint64_t period, uint64_t maxAtt
 size_t Endpoint::getCancelingSize() const { return _inflightRequests->getCancelingSize(); }
 
 std::shared_ptr<Request> Endpoint::amSend(
-  const void* buffer,
+  const void* const buffer,
   const size_t length,
   const ucs_memory_type_t memoryType,
   const std::optional<AmReceiverCallbackInfo> receiverCallbackInfo,
@@ -502,7 +502,7 @@ std::shared_ptr<Request> Endpoint::memGet(void* buffer,
     callbackData));
 }
 
-std::shared_ptr<Request> Endpoint::memPut(const void* buffer,
+std::shared_ptr<Request> Endpoint::memPut(const void* const buffer,
                                           size_t length,
                                           uint64_t remoteAddr,
                                           ucp_rkey_h rkey,
@@ -518,7 +518,7 @@ std::shared_ptr<Request> Endpoint::memPut(const void* buffer,
                                                   callbackData));
 }
 
-std::shared_ptr<Request> Endpoint::memPut(const void* buffer,
+std::shared_ptr<Request> Endpoint::memPut(const void* const buffer,
                                           size_t length,
                                           std::shared_ptr<RemoteKey> remoteKey,
                                           uint64_t remoteAddressOffset,
@@ -536,7 +536,7 @@ std::shared_ptr<Request> Endpoint::memPut(const void* buffer,
     callbackData));
 }
 
-std::shared_ptr<Request> Endpoint::streamSend(const void* buffer,
+std::shared_ptr<Request> Endpoint::streamSend(const void* const buffer,
                                               size_t length,
                                               const bool enablePythonFuture)
 {
@@ -554,7 +554,7 @@ std::shared_ptr<Request> Endpoint::streamRecv(void* buffer,
     createRequestStream(endpoint, data::StreamReceive(buffer, length), enablePythonFuture));
 }
 
-std::shared_ptr<Request> Endpoint::tagSend(const void* buffer,
+std::shared_ptr<Request> Endpoint::tagSend(const void* const buffer,
                                            size_t length,
                                            Tag tag,
                                            const bool enablePythonFuture,

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -502,7 +502,7 @@ std::shared_ptr<Request> Endpoint::memGet(void* buffer,
     callbackData));
 }
 
-std::shared_ptr<Request> Endpoint::memPut(void* buffer,
+std::shared_ptr<Request> Endpoint::memPut(const void* buffer,
                                           size_t length,
                                           uint64_t remoteAddr,
                                           ucp_rkey_h rkey,
@@ -518,7 +518,7 @@ std::shared_ptr<Request> Endpoint::memPut(void* buffer,
                                                   callbackData));
 }
 
-std::shared_ptr<Request> Endpoint::memPut(void* buffer,
+std::shared_ptr<Request> Endpoint::memPut(const void* buffer,
                                           size_t length,
                                           std::shared_ptr<RemoteKey> remoteKey,
                                           uint64_t remoteAddressOffset,
@@ -585,7 +585,7 @@ std::shared_ptr<Request> Endpoint::tagRecv(void* buffer,
                                                   callbackData));
 }
 
-std::shared_ptr<Request> Endpoint::tagMultiSend(const std::vector<void*>& buffer,
+std::shared_ptr<Request> Endpoint::tagMultiSend(const std::vector<const void*>& buffer,
                                                 const std::vector<size_t>& size,
                                                 const std::vector<int>& isCUDA,
                                                 const Tag tag,

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -442,7 +442,7 @@ size_t Endpoint::cancelInflightRequestsBlocking(uint64_t period, uint64_t maxAtt
 size_t Endpoint::getCancelingSize() const { return _inflightRequests->getCancelingSize(); }
 
 std::shared_ptr<Request> Endpoint::amSend(
-  void* buffer,
+  const void* buffer,
   const size_t length,
   const ucs_memory_type_t memoryType,
   const std::optional<AmReceiverCallbackInfo> receiverCallbackInfo,
@@ -536,7 +536,7 @@ std::shared_ptr<Request> Endpoint::memPut(void* buffer,
     callbackData));
 }
 
-std::shared_ptr<Request> Endpoint::streamSend(void* buffer,
+std::shared_ptr<Request> Endpoint::streamSend(const void* buffer,
                                               size_t length,
                                               const bool enablePythonFuture)
 {
@@ -554,7 +554,7 @@ std::shared_ptr<Request> Endpoint::streamRecv(void* buffer,
     createRequestStream(endpoint, data::StreamReceive(buffer, length), enablePythonFuture));
 }
 
-std::shared_ptr<Request> Endpoint::tagSend(void* buffer,
+std::shared_ptr<Request> Endpoint::tagSend(const void* buffer,
                                            size_t length,
                                            Tag tag,
                                            const bool enablePythonFuture,

--- a/cpp/src/request_data.cpp
+++ b/cpp/src/request_data.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <stdexcept>
@@ -78,7 +78,7 @@ TagReceive::TagReceive(void* buffer,
 {
 }
 
-TagMultiSend::TagMultiSend(const std::vector<void*>& buffer,
+TagMultiSend::TagMultiSend(const std::vector<const void*>& buffer,
                            const std::vector<size_t>& length,
                            const std::vector<int>& isCUDA,
                            const ::ucxx::Tag tag)

--- a/cpp/src/request_data.cpp
+++ b/cpp/src/request_data.cpp
@@ -15,7 +15,7 @@ namespace ucxx {
 
 namespace data {
 
-AmSend::AmSend(const void* buffer,
+AmSend::AmSend(const void* const buffer,
                const size_t length,
                const ucs_memory_type memoryType,
                const std::optional<AmReceiverCallbackInfo> receiverCallbackInfo)
@@ -32,7 +32,7 @@ EndpointClose::EndpointClose(const bool force) : _force(force) {}
 
 Flush::Flush() {}
 
-MemPut::MemPut(const void* buffer,
+MemPut::MemPut(const void* const buffer,
                const size_t length,
                const uint64_t remoteAddr,
                const ucp_rkey_h rkey)
@@ -45,7 +45,8 @@ MemGet::MemGet(void* buffer, const size_t length, const uint64_t remoteAddr, con
 {
 }
 
-StreamSend::StreamSend(const void* buffer, const size_t length) : _buffer(buffer), _length(length)
+StreamSend::StreamSend(const void* const buffer, const size_t length)
+  : _buffer(buffer), _length(length)
 {
   /**
    * Stream API does not support zero-sized messages. See
@@ -65,7 +66,7 @@ StreamReceive::StreamReceive(void* buffer, const size_t length) : _buffer(buffer
   if (length == 0) throw std::runtime_error("Length has to be a positive value.");
 }
 
-TagSend::TagSend(const void* buffer, const size_t length, const ::ucxx::Tag tag)
+TagSend::TagSend(const void* const buffer, const size_t length, const ::ucxx::Tag tag)
   : _buffer(buffer), _length(length), _tag(tag)
 {
 }

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -54,7 +54,7 @@ class RequestTest : public ::testing::TestWithParam<
   std::vector<DataContainerType> _recv;
   std::vector<std::unique_ptr<ucxx::Buffer>> _sendBuffer;
   std::vector<std::unique_ptr<ucxx::Buffer>> _recvBuffer;
-  std::vector<void*> _sendPtr{nullptr};
+  std::vector<const void*> _sendPtr{nullptr};
   std::vector<void*> _recvPtr{nullptr};
 
   void SetUp()
@@ -576,7 +576,7 @@ TEST_P(RequestTest, MemoryPutWithOffset)
   auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->memPut(reinterpret_cast<char*>(_sendPtr[0]) + offsetBytes,
+  requests.push_back(_ep->memPut(reinterpret_cast<const char*>(_sendPtr[0]) + offsetBytes,
                                  _messageSize - offsetBytes,
                                  remoteKey,
                                  offsetBytes));

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -454,7 +454,9 @@ TEST_P(RequestTest, MemoryGetPreallocated)
 {
   allocate();
 
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, _sendPtr[0], _memoryType);
+  // Memory handles are always non-const
+  auto memoryHandle =
+    _context->createMemoryHandle(_messageSize, const_cast<void*>(_sendPtr[0]), _memoryType);
   // If message size is 0, there's no allocation and memory type is then "host" by default.
   if (_messageSize > 0) ASSERT_EQ(memoryHandle->getMemoryType(), _memoryType);
 

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -320,7 +320,7 @@ TEST_P(WorkerProgressTest, ProgressTagMulti)
 
   const size_t numMulti = 8;
 
-  std::vector<void*> multiBuffer(numMulti, send.data());
+  std::vector<const void*> multiBuffer(numMulti, send.data());
   std::vector<size_t> multiSize(numMulti, send.size() * sizeof(int));
   std::vector<int> multiIsCUDA(numMulti, false);
 

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -1456,7 +1456,7 @@ cdef class UCXEndpoint():
         return UCXRequest(<uintptr_t><void*>&req, self._enable_python_future)
 
     def tag_send_multi(self, tuple arrays, UCXXTag tag) -> UCXBufferRequests:
-        cdef vector[void*] v_buffer
+        cdef vector[const void*] v_buffer
         cdef vector[size_t] v_size
         cdef vector[int] v_is_cuda
         cdef shared_ptr[Request] ucxx_buffer_requests
@@ -1476,7 +1476,7 @@ cdef class UCXEndpoint():
                 )
 
         for arr in arrays:
-            v_buffer.push_back(<void*><uintptr_t>arr.ptr)
+            v_buffer.push_back(<const void*><uintptr_t>arr.ptr)
             v_size.push_back(arr.nbytes)
             v_is_cuda.push_back(arr.cuda)
 

--- a/python/ucxx/ucxx/_lib/ucxx_api.pxd
+++ b/python/ucxx/ucxx/_lib/ucxx_api.pxd
@@ -308,7 +308,7 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
             bint enable_python_future
         ) except +raise_py_error
         shared_ptr[Request] tagMultiSend(
-            const vector[void*]& buffer,
+            const vector[const void*]& buffer,
             const vector[size_t]& length,
             const vector[int]& isCUDA,
             Tag tag,

--- a/python/ucxx/ucxx/_lib/ucxx_api.pxd
+++ b/python/ucxx/ucxx/_lib/ucxx_api.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -279,7 +279,7 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
         ) except +raise_py_error
         void closeBlocking(uint64_t period, uint64_t maxAttempts)
         shared_ptr[Request] amSend(
-            void* buffer,
+            const void* buffer,
             size_t length,
             ucs_memory_type_t memory_type,
             # Using `nullopt_t` is a workaround for Cython error
@@ -292,13 +292,13 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
             bint enable_python_future
         ) except +raise_py_error
         shared_ptr[Request] streamSend(
-            void* buffer, size_t length, bint enable_python_future
+            const void* buffer, size_t length, bint enable_python_future
         ) except +raise_py_error
         shared_ptr[Request] streamRecv(
             void* buffer, size_t length, bint enable_python_future
         ) except +raise_py_error
         shared_ptr[Request] tagSend(
-            void* buffer, size_t length, Tag tag, bint enable_python_future
+            const void* buffer, size_t length, Tag tag, bint enable_python_future
         ) except +raise_py_error
         shared_ptr[Request] tagRecv(
             void* buffer,

--- a/python/ucxx/ucxx/_lib/ucxx_api.pxd
+++ b/python/ucxx/ucxx/_lib/ucxx_api.pxd
@@ -279,7 +279,7 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
         ) except +raise_py_error
         void closeBlocking(uint64_t period, uint64_t maxAttempts)
         shared_ptr[Request] amSend(
-            const void* buffer,
+            const void* const buffer,
             size_t length,
             ucs_memory_type_t memory_type,
             # Using `nullopt_t` is a workaround for Cython error
@@ -292,13 +292,13 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
             bint enable_python_future
         ) except +raise_py_error
         shared_ptr[Request] streamSend(
-            const void* buffer, size_t length, bint enable_python_future
+            const void* const buffer, size_t length, bint enable_python_future
         ) except +raise_py_error
         shared_ptr[Request] streamRecv(
             void* buffer, size_t length, bint enable_python_future
         ) except +raise_py_error
         shared_ptr[Request] tagSend(
-            const void* buffer, size_t length, Tag tag, bint enable_python_future
+            const void* const buffer, size_t length, Tag tag, bint enable_python_future
         ) except +raise_py_error
         shared_ptr[Request] tagRecv(
             void* buffer,


### PR DESCRIPTION
To prevent unintentional modification of send/put buffers and also to make it clear for users that those methods are not supposed modify data/pointers, mark them `const`.

In `tagMultiSend` only the data can be `const`, the pointers themselves need to be modifiable by `std::vector`. Perhaps it would make sense to have a specialized container for `tagMultiSend` in the future.