### PR TITLE
Require CUDA 12.2+

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -210,10 +210,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              cuda: "12.0"
-            packages:
-              - cuda-version=12.0
-          - matrix:
               cuda: "12.2"
             packages:
               - cuda-version=12.2


### PR DESCRIPTION
Bump minimum CUDA version from 12.0 to 12.2.

<hr>

Part of issue:
* https://github.com/rapidsai/build-planning/issues/223