### PR TITLE
Use current system architecture in conda environment creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ UCXX is an object-oriented C++ interface for UCX, with native support for Python
 Before starting it is necessary to have the necessary dependencies installed. The simplest way to get started is to install [Miniforge](https://github.com/conda-forge/miniforge) and then to create and activate an environment with the provided development file, for CUDA 13.x:
 
 ```
-$ conda env create -n ucxx -f conda/environments/all_cuda-130_arch-$(arch).yaml
+$ conda env create -n ucxx -f conda/environments/all_cuda-130_arch-$(uname -m).yaml
 ```
 
 And then activate the newly created environment:
@@ -29,7 +29,7 @@ $ conda install -c conda-forge mamba
 After that, one can proceed as before, but simply replacing `conda` with `mamba` in the environment creation command:
 
 ```
-$ mamba env create -n ucxx -f conda/environments/all_cuda-130_arch-$(arch).yaml
+$ mamba env create -n ucxx -f conda/environments/all_cuda-130_arch-$(uname -m).yaml
 $ conda activate ucxx
 ```
 

--- a/docs/ucxx/source/install.rst
+++ b/docs/ucxx/source/install.rst
@@ -96,7 +96,7 @@ Required to build UCXX from source.
 
     # Inside the main directory of the ucxx repository
     conda env create -n ucxx \
-        -f conda/environments/all_cuda-129_arch-$(arch).yaml
+        -f conda/environments/all_cuda-129_arch-$(uname -m).yaml
 
 .. note::
     Check existing files in the same `conda/environments/` directory for other CUDA


### PR DESCRIPTION
This fixes a conda environment creation command to support both `x86_64` and `aarch64` systems.