### PR TITLE
Worker builder

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(
   src/delayed_submission.cpp
   src/endpoint.cpp
   src/experimental/context_builder.cpp
+  src/experimental/worker_builder.cpp
   src/header.cpp
   src/inflight_requests.cpp
   src/internal/request_am.cpp

--- a/cpp/include/ucxx/experimental/worker_builder.h
+++ b/cpp/include/ucxx/experimental/worker_builder.h
@@ -1,0 +1,129 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#pragma once
+
+#include <memory>
+#include <utility>
+
+namespace ucxx {
+
+// Forward declarations
+class Context;
+class Worker;
+
+namespace experimental {
+
+/**
+ * @brief Builder class for constructing `std::shared_ptr<ucxx::Worker>` objects.
+ *
+ * This class implements the builder pattern for `std::shared_ptr<ucxx::Worker>`, allowing
+ * optional parameters to be specified via method chaining. Construction happens when the
+ * builder expression completes (via implicit conversion) or when `build()` is called.
+ *
+ * The `context` is required and must be provided to `createWorker()`.
+ * The `enableDelayedSubmission()` and `enableFuture()` methods are optional.
+ *
+ * @code{.cpp}
+ *   // Minimal usage (no options enabled)
+ *   auto worker = ucxx::experimental::createWorker(context).build();
+ *
+ *   // With optional parameters
+ *   auto worker = ucxx::experimental::createWorker(context)
+ *                   .enableDelayedSubmission(true)
+ *                   .enableFuture(true)
+ *                   .build();
+ *
+ *   // Using implicit conversion
+ *   std::shared_ptr<ucxx::Worker> worker = ucxx::experimental::createWorker(context);
+ * @endcode
+ */
+class WorkerBuilder {
+ private:
+  std::shared_ptr<Context> _context;     ///< UCXX context (required)
+  bool _enableDelayedSubmission{false};  ///< Enable delayed submission to progress thread
+  bool _enableFuture{false};             ///< Enable future support
+
+ public:
+  /**
+   * @brief Constructor for `WorkerBuilder` with required context.
+   *
+   * @param[in] context context from which the worker will be created (required).
+   */
+  explicit WorkerBuilder(std::shared_ptr<Context> context);
+
+  /**
+   * @brief Configure delayed submission to the progress thread.
+   *
+   * @param[in] enable whether delayed submission is enabled (default: true).
+   * @return Reference to this builder for method chaining.
+   */
+  WorkerBuilder& delayedSubmission(bool enable = true);
+
+  /**
+   * @brief Configure Python future support.
+   *
+   * @param[in] enable whether Python futures are enabled (default: true).
+   * @return Reference to this builder for method chaining.
+   */
+  WorkerBuilder& pythonFuture(bool enable = true);
+
+  /**
+   * @brief Build and return the `Worker`.
+   *
+   * This method constructs the `Worker` with the specified parameters and returns it.
+   * Each call to build() creates a new `Worker` instance with the current parameters.
+   *
+   * @return The constructed `shared_ptr<ucxx::Worker>` object.
+   */
+  std::shared_ptr<Worker> build() const;
+
+  /**
+   * @brief Implicit conversion operator to `shared_ptr<Worker>`.
+   *
+   * This operator enables automatic construction of the `Worker` when the builder
+   * is used in a context requiring a `shared_ptr<Worker>`. This allows seamless
+   * use with `auto` variables.
+   *
+   * @return The constructed `shared_ptr<ucxx::Worker>` object.
+   */
+  operator std::shared_ptr<Worker>() const;
+};
+
+/**
+ * @brief Create a WorkerBuilder for constructing a `shared_ptr<ucxx::Worker>`.
+ *
+ * This function returns a builder object that allows setting optional context parameters
+ * via method chaining. The context is required and must be provided as an argument. The
+ * actual worker is constructed when the builder is converted to a `shared_ptr<Worker>`
+ * or when `build()` is called.
+ *
+ * @code{.cpp}
+ *   auto worker = ucxx::experimental::createWorker(context)
+ *                   .enableDelayedSubmission()
+ *                   .build();
+ * // Minimal usage (only context required)
+ * auto worker = ucxx::experimental::createWorker().build();
+ *
+ * // With optional enableDelayedSubmission
+ * auto worker = ucxx::experimental::createContext(UCP_FEATURE_TAG)
+ *                 .enableDelayedSubmission()
+ *                 .build();
+ *
+ * // Using implicit conversion
+ * std::shared_ptr<ucxx::Worker> worker = ucxx::experimental::createWorker();
+ *
+ * @endcode
+ *
+ * @param[in] context context from which the worker will be created (required).
+ * @return A WorkerBuilder object that can be used to set optional parameters.
+ */
+inline WorkerBuilder createWorker(std::shared_ptr<Context> context)
+{
+  return WorkerBuilder(std::move(context));
+}
+
+}  // namespace experimental
+
+}  // namespace ucxx

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -27,6 +27,10 @@
 
 namespace ucxx {
 
+namespace experimental {
+class WorkerBuilder;
+}  // namespace experimental
+
 class Address;
 class Buffer;
 class Endpoint;
@@ -166,32 +170,19 @@ class Worker : public Component {
   Worker& operator=(Worker&& o)    = delete;
 
   /**
-   * @brief Constructor of `shared_ptr<ucxx::Worker>`.
+   * @brief Friend declaration for `ucxx::createWorker` with parameters.
    *
-   * The constructor for a `shared_ptr<ucxx::Worker>` object. The default constructor is
-   * made private to ensure all UCXX objects are shared pointers for correct
-   * lifetime management.
-   *
-   * @code{.cpp}
-   * // context is `std::shared_ptr<ucxx::Context>`
-   * auto worker = context->createWorker(false);
-   *
-   * // Equivalent to line above
-   * // auto worker = ucxx::createWorker(context, false);
-   * @endcode
-   *
-   * @param[in] context the context from which to create the worker.
-   * @param[in] enableDelayedSubmission if `true`, each `ucxx::Request` will not be
-   *                                    submitted immediately, but instead delayed to
-   *                                    the progress thread. Requires use of the
-   *                                    progress thread.
-   * @param[in] enableFuture if `true`, notifies the future associated with each
-   *                         `ucxx::Request`, currently used only by `ucxx::python::Worker`.
-   * @returns The `shared_ptr<ucxx::Worker>` object
+   * This friend declaration allows the standalone `ucxx::createWorker` function to access
+   * the protected constructor. See the public declaration for full documentation.
    */
   friend std::shared_ptr<Worker> createWorker(std::shared_ptr<Context> context,
                                               const bool enableDelayedSubmission,
                                               const bool enableFuture);
+
+  /**
+   * @brief Allow experimental::WorkerBuilder to access protected/private constructor.
+   */
+  friend class experimental::WorkerBuilder;
 
   /**
    * @brief `ucxx::Worker` destructor.
@@ -1008,4 +999,32 @@ class Worker : public Component {
     RequestCallbackUserData callbackData         = nullptr);
 };
 
+/**
+ * @brief Constructor of `shared_ptr<ucxx::Worker>` with parameters.
+ *
+ * The constructor for a `shared_ptr<ucxx::Worker>` object. The default constructor is
+ * made private to ensure all UCXX objects are shared pointers for correct lifetime
+ * management.
+ *
+ * @code{.cpp}
+ *   // context is `std::shared_ptr<ucxx::Context>`
+ *   auto worker = ucxx::createWorker(context, false, false);
+ * @endcode
+ *
+ * @param[in] context the context from which to create the worker.
+ * @param[in] enableDelayedSubmission if `true`, each `ucxx::Request` will not be
+ *                                    submitted immediately, but instead delayed to
+ *                                    the progress thread. Requires use of the
+ *                                    progress thread.
+ * @param[in] enableFuture if `true`, notifies the future associated with each
+ *                         `ucxx::Request`, currently used only by `ucxx::python::Worker`.
+ * @returns The `shared_ptr<ucxx::Worker>` object
+ */
+std::shared_ptr<Worker> createWorker(std::shared_ptr<Context> context,
+                                     const bool enableDelayedSubmission,
+                                     const bool enableFuture);
+
 }  // namespace ucxx
+
+// Include experimental features
+#include <ucxx/experimental/worker_builder.h>

--- a/cpp/src/experimental/worker_builder.cpp
+++ b/cpp/src/experimental/worker_builder.cpp
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <memory>
+#include <utility>
+
+#include <ucxx/experimental/worker_builder.h>
+#include <ucxx/worker.h>
+
+namespace ucxx {
+
+namespace experimental {
+
+WorkerBuilder::WorkerBuilder(std::shared_ptr<Context> context) : _context(std::move(context)) {}
+
+WorkerBuilder& WorkerBuilder::delayedSubmission(bool enable)
+{
+  _enableDelayedSubmission = enable;
+  return *this;
+}
+
+WorkerBuilder& WorkerBuilder::pythonFuture(bool enable)
+{
+  _enableFuture = enable;
+  return *this;
+}
+
+std::shared_ptr<Worker> WorkerBuilder::build() const
+{
+  return std::shared_ptr<Worker>(new Worker(_context, _enableDelayedSubmission, _enableFuture));
+}
+
+WorkerBuilder::operator std::shared_ptr<Worker>() const
+{
+  return std::shared_ptr<Worker>(new Worker(_context, _enableDelayedSubmission, _enableFuture));
+}
+
+}  // namespace experimental
+
+}  // namespace ucxx


### PR DESCRIPTION
Continuation of #435 and follow-up to #535, adds a new `ucxx::WorkerBuilder` to be used for `ucxx::Worker` construction allowing to specify only the options desired.

For now, this change is backwards-compatible but we may want to remove the constructors at some point and break the API once to do that (to be discussed).

The Python implementation is not adapted to the new constructor because it uses `ucxx::python::Worker` specialization of `ucxx::Worker` that will be covered in a follow-up PR.