### PR TITLE
refactored update-version.sh to handle new branching strategy

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -8,16 +8,66 @@
 ########################
 
 ## Usage
-# bash update-version.sh <new_version>
+# NOTE: This script must be run from the repository root, not from the ci/release/ directory
+# Primary interface:   bash ci/release/update-version.sh <new_version> [--run-context=main|release]
+# Fallback interface:  [RAPIDS_RUN_CONTEXT=main|release] bash ci/release/update-version.sh <new_version>
+# CLI arguments take precedence over environment variables
+# Defaults to main when no run-context is specified
 
+
+# Parse command line arguments
+CLI_RUN_CONTEXT=""
+VERSION_ARG=""
+
+for arg in "$@"; do
+    case ${arg} in
+        --run-context=*)
+            CLI_RUN_CONTEXT="${arg#*=}"
+            shift
+            ;;
+        *)
+            if [[ -z "${VERSION_ARG}" ]]; then
+                VERSION_ARG="${arg}"
+            fi
+            ;;
+    esac
+done
 
 # Format is Major.Minor.Patch - no leading 'v' or trailing 'a'
 # Example: 0.30.00
-NEXT_FULL_TAG=$1
+NEXT_FULL_TAG="${VERSION_ARG}"
+
+# Determine RUN_CONTEXT with CLI precedence over environment variable, defaulting to main
+if [[ -n "${CLI_RUN_CONTEXT}" ]]; then
+    RUN_CONTEXT="${CLI_RUN_CONTEXT}"
+    echo "Using run-context from CLI: ${RUN_CONTEXT}"
+elif [[ -n "${RAPIDS_RUN_CONTEXT}" ]]; then
+    RUN_CONTEXT="${RAPIDS_RUN_CONTEXT}"
+    echo "Using run-context from environment: ${RUN_CONTEXT}"
+else
+    RUN_CONTEXT="main"
+    echo "No run-context provided, defaulting to: ${RUN_CONTEXT}"
+fi
+
+# Validate RUN_CONTEXT value
+if [[ "${RUN_CONTEXT}" != "main" && "${RUN_CONTEXT}" != "release" ]]; then
+    echo "Error: Invalid run-context value '${RUN_CONTEXT}'"
+    echo "Valid values: main, release"
+    exit 1
+fi
+
+# Validate version argument
+if [[ -z "${NEXT_FULL_TAG}" ]]; then
+    echo "Error: Version argument is required"
+    echo "Usage: ${0} <new_version> [--run-context=<context>]"
+    echo "   or: [RAPIDS_RUN_CONTEXT=<context>] ${0} <new_version>"
+    echo "Note: Defaults to main when run-context is not specified"
+    exit 1
+fi
 
 # Get <major>.<minor> for next version
-NEXT_MAJOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[1]}')
-NEXT_MINOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[2]}')
+NEXT_MAJOR=$(echo "${NEXT_FULL_TAG}" | awk '{split($0, a, "."); print a[1]}')
+NEXT_MINOR=$(echo "${NEXT_FULL_TAG}" | awk '{split($0, a, "."); print a[2]}')
 NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 
 # Get RAPIDS version associated w/ ucx-py version
@@ -28,16 +78,24 @@ NEXT_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(
 NEXT_RAPIDS_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(Version('${NEXT_RAPIDS_SHORT_TAG}'))")
 echo "Next tag is ${NEXT_RAPIDS_SHORT_TAG_PEP440}"
 
-echo "Preparing release: $NEXT_FULL_TAG"
+# Set branch references based on RUN_CONTEXT
+if [[ "${RUN_CONTEXT}" == "main" ]]; then
+    RAPIDS_BRANCH_NAME="main"
+    echo "Preparing development branch update => ${NEXT_FULL_TAG} (targeting main branch)"
+elif [[ "${RUN_CONTEXT}" == "release" ]]; then
+    RAPIDS_BRANCH_NAME="release/${NEXT_RAPIDS_SHORT_TAG}"
+    echo "Preparing release branch update => ${NEXT_FULL_TAG} (targeting release/${NEXT_RAPIDS_SHORT_TAG} branch)"
+fi
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
-    sed -i.bak ''"$1"'' "$2" && rm -f "${2}".bak
+    sed -i.bak ''"${1}"'' "${2}" && rm -f "${2}".bak
 }
 
 # Centralized version file update
 echo "${NEXT_FULL_TAG}" > VERSION
 echo "${NEXT_RAPIDS_SHORT_TAG}.00" > RAPIDS_VERSION
+echo "${RAPIDS_BRANCH_NAME}" > RAPIDS_BRANCH
 
 # Update RAPIDS version
 for FILE in conda/recipes/*/conda_build_config.yaml; do
@@ -77,9 +135,27 @@ for FILE in python/*/pyproject.toml; do
   done
 done
 
+# Update cmake/RAPIDS.cmake with context-aware branch references
+if [[ "${RUN_CONTEXT}" == "main" ]]; then
+    sed_runner "s|\"release/\${rapids-cmake-version}\"|\"main\"|g" cmake/RAPIDS.cmake
+elif [[ "${RUN_CONTEXT}" == "release" ]]; then
+    sed_runner "s|\"main\"|\"release/\${rapids-cmake-version}\"|g" cmake/RAPIDS.cmake
+fi
+
+# Documentation references - context-aware
+if [[ "${RUN_CONTEXT}" == "main" ]]; then
+    # In main context, use main branch for documentation links
+    sed_runner "s|/blob/branch-[^/]*/|/blob/main/|g" docs/ucxx/source/send_recv.rst
+elif [[ "${RUN_CONTEXT}" == "release" ]]; then
+    # In release context, use release branch for documentation links
+    sed_runner "s|/blob/main/|/blob/release/${NEXT_SHORT_TAG}/|g" docs/ucxx/source/send_recv.rst
+    sed_runner "s|/blob/branch-[^/]*/|/blob/release/${NEXT_SHORT_TAG}/|g" docs/ucxx/source/send_recv.rst
+fi
+
+# CI files - context-aware branch references
 for FILE in .github/workflows/*.yaml; do
-  sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_RAPIDS_SHORT_TAG}/g" "${FILE}"
-  sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_RAPIDS_SHORT_TAG}-/g" "${FILE}"
+  sed_runner "/shared-workflows/ s|@.*|@${RAPIDS_BRANCH_NAME}|g" "${FILE}"
+  sed_runner "s|:[0-9]*\\.[0-9]*-|:${NEXT_RAPIDS_SHORT_TAG}-|g" "${FILE}"
 done
 
 # .devcontainer files

--- a/cmake/RAPIDS.cmake
+++ b/cmake/RAPIDS.cmake
@@ -26,7 +26,7 @@ endif()
 # Allow users to control which branch is fetched
 if(NOT rapids-cmake-branch)
   # Define a default branch if the user doesn't set one
-  set(rapids-cmake-branch "branch-${rapids-cmake-version}")
+  set(rapids-cmake-branch "main")
 endif()
 
 # Allow users to control the exact URL passed to FetchContent

--- a/docs/ucxx/source/send_recv.rst
+++ b/docs/ucxx/source/send_recv.rst
@@ -93,6 +93,6 @@ Most users will not care about these details but developers and interested netwo
     [1757536870.872600] [dgx13:1377244] UCXPY  DEBUG [Recv #001] ep: 0x7f5a161a8080, tag: 0xdf227087928e03f6, nbytes: 12, type: <class 'bytearray'>
 
 
-We can see from the above that when the ``Endpoint`` is created, 4 tags are generated: ``msg-tag-send``, ``msg-tag-recv``, ``ctrl-tag-send``, and ``ctrl-tag-recv``. This data is transmitted to the server via a `stream <https://openucx.github.io/ucx/api/latest/html/group___u_c_p___c_o_m_m.html#gae9fe6efe6b05e4e78f58bee68c68b252>`_ communication in an `exchange peer info <https://github.com/rapidsai/ucxx/blob/branch-0.46/python/ucxx/ucxx/_lib_async/exchange_peer_info.py>`_ convenience function.
+We can see from the above that when the ``Endpoint`` is created, 4 tags are generated: ``msg-tag-send``, ``msg-tag-recv``, ``ctrl-tag-send``, and ``ctrl-tag-recv``. This data is transmitted to the server via a `stream <https://openucx.github.io/ucx/api/latest/html/group___u_c_p___c_o_m_m.html#gae9fe6efe6b05e4e78f58bee68c68b252>`_ communication in an `exchange peer info <https://github.com/rapidsai/ucxx/blob/main/python/ucxx/ucxx/_lib_async/exchange_peer_info.py>`_ convenience function.
 
 Next, the client sends data on the ``msg-tag-send`` tag. Two messages are sent, the size of the data ``8 bytes`` and data itself. The server receives the data and immediately echos the data back. The client then receives two messages the size of the data and the data itself.


### PR DESCRIPTION
## Description
This PR supports handling the new main branch strategy outlined below:

* [RSN 47 - Changes to RAPIDS branching strategy in 25.12](https://docs.rapids.ai/notices/rsn0047/)

The `update-version.sh` script should now supports two modes controlled via  `CLI` params or `ENV` vars:

CLI arguments: `--run-context=main|release`
ENV var `RAPIDS_RUN_CONTEXT=main|release`

xref: https://github.com/rapidsai/build-planning/issues/224