### PR TITLE
Use strict priority in CI conda tests

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -10,6 +10,9 @@ CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
+rapids-logger "Configuring conda strict channel priority"
+conda config --set channel_priority strict
+
 UCXX_VERSION="$(head -1 ./VERSION)"
 export UCXX_VERSION
 UCXX_VERSION_MAJOR_MINOR="$(sed -E -e 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1.\2/' VERSION)"

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 rapids-logger "Create checks conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
+rapids-logger "Configuring conda strict channel priority"
+conda config --set channel_priority strict
+
 rapids-dependency-file-generator \
   --output conda \
   --file-key checks \


### PR DESCRIPTION
## Description
This PR sets conda to use `strict` priority in CI tests.

Mixing channel priority is frequently a cause of unexpected errors. Our CI jobs should always use strict priority in order to enforce that conda packages come from local channels with the artifacts built in CI, not mixing with older nightly artifacts from the `rapidsai-nightly` channel or other sources.

xref: https://github.com/rapidsai/build-planning/issues/14
