### PR TITLE
Use static linkage for CUDA runtime

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,7 +10,6 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=3.26.4,!=3.30.0
-- cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9
 - cudf==26.2.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,7 +10,6 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=3.26.4,!=3.30.0
-- cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9
 - cudf==26.2.*,>=0.0.0a0

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -10,7 +10,6 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=3.26.4,!=3.30.0
-- cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.0
 - cudf==26.2.*,>=0.0.0a0

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -10,7 +10,6 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=3.26.4,!=3.30.0
-- cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.0
 - cudf==26.2.*,>=0.0.0a0

--- a/conda/recipes/ucxx/recipe.yaml
+++ b/conda/recipes/ucxx/recipe.yaml
@@ -76,7 +76,6 @@ cache:
       - librmm ${{ rapids_version }}
       - rapids-build-backend >=0.4.0,<0.5.0
       - ucx
-      - cuda-cudart-dev
 
 outputs:
   - package:
@@ -109,7 +108,6 @@ outputs:
         - ${{ pin_subpackage("libucxx", upper_bound="x.x") }}
       ignore_run_exports:
         by_name:
-          - cuda-cudart
           - cuda-version
           - librmm
           - ucx
@@ -170,7 +168,6 @@ outputs:
         - ${{ pin_subpackage("libucxx", exact=True) }}
       ignore_run_exports:
         by_name:
-          - cuda-cudart
           - cuda-version
           - librmm
           - libucxx
@@ -194,14 +191,12 @@ outputs:
         - ${{ stdlib("c") }}
       host:
         - cuda-version =${{ cuda_version }}
-        - cuda-cudart-dev
         - ${{ pin_subpackage("libucxx", exact=True) }}
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("libucxx", exact=True) }}
       ignore_run_exports:
         by_name:
-          - cuda-cudart
           - cuda-version
           - librmm
           - libucxx
@@ -287,7 +282,6 @@ outputs:
         - scikit-build-core >=0.10.0
         - ucx
         - ${{ pin_subpackage("libucxx", exact=True) }}
-        - cuda-cudart-dev
       run:
         - numba >=0.60.0,<0.62.0
         - numba-cuda >=0.19.1,<0.20.0
@@ -303,7 +297,6 @@ outputs:
         - cupy >=13.6.0
       ignore_run_exports:
         by_name:
-          - cuda-cudart
           - cuda-version
           - librmm
           - libucxx

--- a/conda/recipes/ucxx/recipe.yaml
+++ b/conda/recipes/ucxx/recipe.yaml
@@ -401,10 +401,8 @@ outputs:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - python =${{ python }}
         - ${{ pin_subpackage("ucxx", exact=True) }}
-        - cuda-cudart
       ignore_run_exports:
         by_name:
-          - cuda-cudart
           - cuda-version
           - librmm
           - python_abi

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -40,7 +40,7 @@ function(ConfigureBench CMAKE_BENCH_NAME)
   if(UCXX_BENCHMARKS_ENABLE_CUDA)
     target_compile_definitions(${CMAKE_BENCH_NAME} PRIVATE UCXX_BENCHMARKS_ENABLE_CUDA)
     find_package(CUDAToolkit REQUIRED)
-    target_link_libraries(${CMAKE_BENCH_NAME} PRIVATE CUDA::cudart)
+    target_link_libraries(${CMAKE_BENCH_NAME} PRIVATE CUDA::cudart_static)
   endif()
 
   add_custom_command(

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -233,7 +233,6 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - cuda-cudart-dev
           - cuda-nvcc
   dev:
     common:


### PR DESCRIPTION
## Summary
- Remove `cuda-cudart` from run requirements in `ucxx-tests` conda recipe

With static linking of the CUDA runtime, the runtime is embedded in the binaries and the `cuda-cudart` package is not needed at runtime.

Part of https://github.com/rapidsai/build-planning/issues/235