### PR TITLE
Add devcontainer fallback for C++ test location

### DIFF
--- a/ci/run_cpp.sh
+++ b/ci/run_cpp.sh
@@ -13,11 +13,37 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 ##################################### C++ ######################################
 _SERVER_PORT=12345
 
-run_cpp_tests() {
-  RUNTIME_PATH=${CONDA_PREFIX:-./}
-  BINARY_PATH=${RUNTIME_PATH}/bin
+# First, try the installed location (CI/conda environments)
+installed_test_location="${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/gtests/libucxx/"
+# Fall back to the build directory (devcontainer environments)
+devcontainers_test_location="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../cpp/build/latest/gtests"
 
-  CMD_LINE="timeout 10m ${BINARY_PATH}/gtests/libucxx/UCXX_TEST"
+if [[ -d "${installed_test_location}" ]]; then
+    GTESTS_PATH="${installed_test_location}"
+elif [[ -d "${devcontainers_test_location}" ]]; then
+    GTESTS_PATH="${devcontainers_test_location}"
+else
+    echo "Error: Test location not found. Searched:" >&2
+    echo "  - ${installed_test_location}" >&2
+    echo "  - ${devcontainers_test_location}" >&2
+    exit 1
+fi
+
+# First, try the installed location (CI/conda environments)
+installed_examples_location="${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/examples/libucxx/"
+# Fall back to the build directory (devcontainer environments)
+devcontainers_examples_location="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../cpp/build/latest/examples"
+
+if [[ -d "${installed_examples_location}" ]]; then
+    EXAMPLES_PATH="${installed_examples_location}"
+elif [[ -d "${devcontainers_examples_location}" ]]; then
+    EXAMPLES_PATH="${devcontainers_examples_location}"
+else
+    EXAMPLES_PATH=""
+fi
+
+run_cpp_tests() {
+  CMD_LINE="timeout 10m ${GTESTS_PATH}/UCXX_TEST"
 
   log_command "${CMD_LINE}"
   UCX_TCP_CM_REUSEADDR=y ${CMD_LINE}
@@ -32,10 +58,12 @@ run_cpp_example() {
   SERVER_PORT=$1
   PROGRESS_MODE=$2
 
-  RUNTIME_PATH=${CONDA_PREFIX:-./}
-  BINARY_PATH=${RUNTIME_PATH}/bin
+  if [[ -z "${EXAMPLES_PATH}" ]]; then
+    echo "Skipping examples: examples not built (BUILD_EXAMPLES=OFF)" >&2
+    return 0
+  fi
 
-  CMD_LINE="timeout 1m ${BINARY_PATH}/examples/libucxx/ucxx_example_basic -P ${PROGRESS_MODE} -p ${SERVER_PORT}"
+  CMD_LINE="timeout 1m ${EXAMPLES_PATH}/ucxx_example_basic -P ${PROGRESS_MODE} -p ${SERVER_PORT}"
 
   log_command "${CMD_LINE}"
   UCX_TCP_CM_REUSEADDR=y ${CMD_LINE}


### PR DESCRIPTION
## Summary
- Update `run_cpp.sh` to first try the installed test location (CI/conda environments) and fall back to the build directory (devcontainer environments)
- Enables testing in devcontainers with `test-ucxx-cpp`

xref: https://github.com/rapidsai/devcontainers/pull/630
