### PR TITLE
Remove numba-cuda upper bound

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - libtool
 - make
 - ninja
-- numba-cuda>=0.24.0
+- numba-cuda>=0.22.1
 - numpy>=1.23,<3.0
 - nvidia-ml-py>=12
 - pip

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - libtool
 - make
 - ninja
-- numba-cuda>=0.24.0
+- numba-cuda>=0.22.1
 - numpy>=1.23,<3.0
 - nvidia-ml-py>=12
 - pip

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - libtool
 - make
 - ninja
-- numba-cuda>=0.24.0
+- numba-cuda>=0.22.1
 - numpy>=1.23,<3.0
 - nvidia-ml-py>=12
 - pip

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - libtool
 - make
 - ninja
-- numba-cuda>=0.24.0
+- numba-cuda>=0.22.1
 - numpy>=1.23,<3.0
 - nvidia-ml-py>=12
 - pip

--- a/conda/recipes/ucxx/recipe.yaml
+++ b/conda/recipes/ucxx/recipe.yaml
@@ -290,7 +290,7 @@ outputs:
         - cuda-cudart-dev
       run:
         - numba >=0.60.0,<0.62.0
-        - numba-cuda >=0.24.0
+        - numba-cuda >=0.22.1
         - numpy >=1.23,<3.0
         # 'nvidia-ml-py' provides the 'pynvml' module
         - nvidia-ml-py>=12
@@ -431,7 +431,7 @@ outputs:
         - wheel
       run:
         - numba >=0.60.0,<0.62.0
-        - numba-cuda >=0.24.0
+        - numba-cuda >=0.22.1
         - python
         - pyyaml >=6
         - rapids-dask-dependency ${{ rapids_version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -303,18 +303,18 @@ dependencies:
           - nvidia-ml-py>=12
       - output_types: [conda]
         packages:
-          - &numba_cuda numba-cuda>=0.24.0
+          - &numba_cuda numba-cuda>=0.22.1
     specific:
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:
               cuda: "12.*"
             packages:
-              - &numba_cuda_cu12 numba-cuda[cu12]>=0.24.0
+              - &numba_cuda_cu12 numba-cuda[cu12]>=0.22.1
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - &numba_cuda_cu13 numba-cuda[cu13]>=0.24.0
+              - &numba_cuda_cu13 numba-cuda[cu13]>=0.22.1
   run_python_distributed_ucxx:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -20,7 +20,7 @@ license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "numba-cuda[cu13]>=0.24.0",
+    "numba-cuda[cu13]>=0.22.1",
     "pyyaml>=6",
     "rapids-dask-dependency==26.4.*,>=0.0.0a0",
     "ucxx==0.49.*,>=0.0.0a0",

--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -20,7 +20,7 @@ license = "BSD-3-Clause"
 requires-python = ">=3.10"
 dependencies = [
     "libucxx==0.49.*,>=0.0.0a0",
-    "numba-cuda[cu13]>=0.24.0",
+    "numba-cuda[cu13]>=0.22.1",
     "numpy>=1.23,<3.0",
     "nvidia-ml-py>=12",
     "rmm==26.4.*,>=0.0.0a0",


### PR DESCRIPTION
This PR removes the upper bound from the numba-cuda dependency.

Ref: https://github.com/rapidsai/build-planning/issues/245