### PR TITLE
merge release/0.48 into main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "release/*"
     tags:
       - v[0-9].[0-9][0-9].[0-9][0-9]
   workflow_dispatch:

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -euo pipefail
@@ -21,11 +21,28 @@ cd "${package_dir}"
 sccache --stop-server 2>/dev/null || true
 
 rapids-logger "Building '${package_name}' wheel"
+
+RAPIDS_PIP_WHEEL_ARGS=(
+  -w dist
+  -v
+  --no-deps
+  --disable-pip-version-check
+)
+
+# Only use --build-constraint when build isolation is enabled.
+#
+# Passing '--build-constraint' and '--no-build-isolation` together results in an error from 'pip',
+# but we want to keep environment variable PIP_CONSTRAINT set unconditionally.
+# PIP_NO_BUILD_ISOLATION=0 means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/573
+if [[ "${PIP_NO_BUILD_ISOLATION:-}" != "0" ]]; then
+    RAPIDS_PIP_WHEEL_ARGS+=(--build-constraint="${PIP_CONSTRAINT}")
+fi
+# unset that environment variable... it doesn't affect builds as of pip 25.3, and
+# results in an error from 'pip wheel' when set and --build-constraint is also passed
+unset PIP_CONSTRAINT
+
 rapids-pip-retry wheel \
-    -w dist \
-    -v \
-    --no-deps \
-    --disable-pip-version-check \
+    "${RAPIDS_PIP_WHEEL_ARGS[@]}" \
     .
 
 sccache --show-adv-stats

--- a/ci/build_wheel_ucxx.sh
+++ b/ci/build_wheel_ucxx.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -euo pipefail
@@ -14,8 +14,8 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 # Downloads libucxx wheel from this current build,
 # then ensures 'ucxx' wheel builds always use the 'libucxx' just built in the same CI run.
 #
-# Using env variable PIP_CONSTRAINT (initialized by 'rapids-init-pip') is necessary to ensure the constraints
-# are used when creating the isolated build environment.
+# env variable 'PIP_CONSTRAINT' is set up by rapids-init-pip. It constrains all subsequent
+# 'pip install', 'pip download', etc. calls (except those used in 'pip wheel', handled separately in build scripts)
 LIBUCXX_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libucxx_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
 echo "libucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBUCXX_WHEELHOUSE}"/libucxx_*.whl)" >> "${PIP_CONSTRAINT}"
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -305,12 +305,18 @@ dependencies:
         matrices:
           - matrix:
               cuda: "12.*"
+              cuda_suffixed: "true"
             packages:
               - &numba_cuda_cu12 numba-cuda[cu12]>=0.22.1
-          # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
+              cuda: "13.*"
+              cuda_suffixed: "true"
             packages:
               - &numba_cuda_cu13 numba-cuda[cu13]>=0.22.1
+          # fallback to numba-cuda with no extra CUDA packages if 'cuda_suffixed' isn't true
+          - matrix:
+            packages:
+              - *numba_cuda
   run_python_distributed_ucxx:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -325,12 +331,18 @@ dependencies:
         matrices:
           - matrix:
               cuda: "12.*"
+              cuda_suffixed: "true"
             packages:
               - *numba_cuda_cu12
-          # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
+              cuda: "13.*"
+              cuda_suffixed: "true"
             packages:
               - *numba_cuda_cu13
+          # fallback to numba-cuda with no extra CUDA packages if 'cuda_suffixed' isn't true
+          - matrix:
+            packages:
+              - *numba_cuda
   test_cpp:
     common:
       - output_types: conda

--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -20,7 +20,7 @@ license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
-    "numba-cuda[cu13]>=0.22.1",
+    "numba-cuda>=0.22.1",
     "pyyaml>=6",
     "rapids-dask-dependency==26.4.*,>=0.0.0a0",
     "ucxx==0.49.*,>=0.0.0a0",

--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -20,7 +20,7 @@ license = "BSD-3-Clause"
 requires-python = ">=3.11"
 dependencies = [
     "libucxx==0.49.*,>=0.0.0a0",
-    "numba-cuda[cu13]>=0.22.1",
+    "numba-cuda>=0.22.1",
     "numpy>=1.23,<3.0",
     "nvidia-ml-py>=12",
     "rmm==26.4.*,>=0.0.0a0",


### PR DESCRIPTION
Closes https://github.com/rapidsai/ucxx/pull/572

That forward-merger originally failed do to backend infrastructure issues a few weeks ago, and then by the time those were fixed it couldn't be auto-merged because it had picked up conflicts between #576 and #573

This fixes those conflicts.

## Notes for Reviewers

**THIS SHOULD BE NO-SQUASH MERGED WITH `/merge nosquash`**