### PR TITLE
Refactor `InflightRequests`

### DIFF
--- a/cpp/include/ucxx/inflight_requests.h
+++ b/cpp/include/ucxx/inflight_requests.h
@@ -4,7 +4,6 @@
  */
 #pragma once
 
-#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -32,44 +31,21 @@ struct TrackedRequests {
  * Handle tracked requests, providing functionality so that its owner can modify those
  * requests, performing operations such as insertion, removal and cancelation.
  *
- * Two container backends are available, selected at construction time via the
- * `UCXX_INFLIGHT_REQUESTS_BACKEND` environment variable:
- * - `vector` (default): best latency for small request counts, cache-friendly,
- *   no per-insert heap allocation, O(n) removal.
- * - `map`: O(1) amortized insert/remove, scales to thousands of concurrent
- *   inflight requests.
+ * Uses `std::unordered_map<Request*, shared_ptr<Request>>` for O(1) amortized
+ * insert/remove that scales to thousands of concurrent inflight requests.
  */
 class InflightRequests {
  private:
-  bool _useMap{false};
-
-  std::vector<std::shared_ptr<Request>> _inflightVec{};
-  std::vector<std::shared_ptr<Request>> _cancelingVec{};
-
-  std::unordered_map<Request*, std::shared_ptr<Request>> _inflightMap{};
-  std::unordered_map<Request*, std::shared_ptr<Request>> _cancelingMap{};
+  std::unordered_map<Request*, std::shared_ptr<Request>> _inflight{};
+  std::unordered_map<Request*, std::shared_ptr<Request>> _canceling{};
 
   std::mutex _mutex{};
 
-  void _doInsert(const std::shared_ptr<Request>& request);
-  void _doRemove(const std::shared_ptr<Request>& request);
-  size_t _doInflightSize() const;
-  std::vector<std::shared_ptr<Request>> _doTakeInflight();
-  void _doPutCanceling(std::vector<std::shared_ptr<Request>>* requests);
-  size_t _doDropCanceled();
-  size_t _doCancelingSize() const;
-  void _doMergeInflight(std::vector<std::shared_ptr<Request>>* requests);
-  void _doMergeCanceling(std::vector<std::shared_ptr<Request>>* requests);
-  std::vector<std::shared_ptr<Request>> _doTakeCanceling();
-
  public:
   /**
-   * @brief Construct with backend selected from UCXX_INFLIGHT_REQUESTS_BACKEND env var.
-   *
-   * Reads the `UCXX_INFLIGHT_REQUESTS_BACKEND` environment variable to select the
-   * container backend. Valid values are `vector` (default) and `map`.
+   * @brief Default constructor.
    */
-  InflightRequests();
+  InflightRequests() = default;
 
   InflightRequests(const InflightRequests&)            = delete;
   InflightRequests& operator=(InflightRequests const&) = delete;

--- a/cpp/include/ucxx/inflight_requests.h
+++ b/cpp/include/ucxx/inflight_requests.h
@@ -4,75 +4,72 @@
  */
 #pragma once
 
-#include <map>
+#include <algorithm>
 #include <memory>
 #include <mutex>
-#include <utility>
+#include <unordered_map>
+#include <vector>
 
 namespace ucxx {
 
 class Request;
 
 /**
- * @brief An inflight request map.
+ * @brief Container for transferring tracked requests between InflightRequests instances.
  *
- * A map of inflight requests, where keys are a shared pointer to the request and
- * value is the reference-counted `ucxx::Request`, using owner-based comparison.
+ * Used by `InflightRequests::release()` and `InflightRequests::merge()` to move
+ * request ownership between instances (e.g., from an endpoint to the worker during
+ * endpoint close).
  */
-typedef std::
-  map<std::shared_ptr<Request>, std::shared_ptr<Request>, std::owner_less<std::shared_ptr<Request>>>
-    InflightRequestsMap;
-
-/**
- * @brief A container for the different types of tracked requests.
- *
- * A container encapsulating the different types of handled tracked requests, currently
- * those still valid (inflight), and those scheduled for cancelation (canceling).
- */
-typedef struct TrackedRequests {
-  InflightRequestsMap _inflight{};   ///< Valid requests awaiting completion.
-  InflightRequestsMap _canceling{};  ///< Requests scheduled for cancelation.
-  std::mutex _mutex{};               ///< Mutex to control access to inflight requests container
-  std::mutex
-    _cancelMutex{};  ///< Mutex to allow cancelation and prevent removing requests simultaneously
-} TrackedRequests;
-
-/**
- * @brief Pre-defined type for a pointer to a container of tracked requests.
- *
- * A pre-defined type for a pointer to a container of tracked requests, used as a
- * convenience type.
- */
-typedef std::unique_ptr<TrackedRequests> TrackedRequestsPtr;
+struct TrackedRequests {
+  std::vector<std::shared_ptr<Request>> inflight{};   ///< Valid requests awaiting completion.
+  std::vector<std::shared_ptr<Request>> canceling{};  ///< Requests scheduled for cancelation.
+};
 
 /**
  * @brief Handle tracked requests.
  *
  * Handle tracked requests, providing functionality so that its owner can modify those
  * requests, performing operations such as insertion, removal and cancelation.
+ *
+ * Two container backends are available, selected at construction time via the
+ * `UCXX_INFLIGHT_REQUESTS_BACKEND` environment variable:
+ * - `vector` (default): best latency for small request counts, cache-friendly,
+ *   no per-insert heap allocation, O(n) removal.
+ * - `map`: O(1) amortized insert/remove, scales to thousands of concurrent
+ *   inflight requests.
  */
 class InflightRequests {
  private:
-  TrackedRequestsPtr _trackedRequests{
-    std::make_unique<TrackedRequests>()};  ///< Container storing pointers to all inflight
-                                           ///< and in cancelation process requests known to
-                                           ///< the owner of this object
-  std::recursive_mutex _mutex{};           ///< Mutex to control access to class resources
+  bool _useMap{false};
 
-  /**
-   * @brief Drop references to requests that completed cancelation.
-   *
-   * Drops references to requests that completed cancelation and stop tracking them.
-   *
-   * @returns The number of requests that have completed cancelation since last call.
-   */
-  size_t dropCanceled();
+  std::vector<std::shared_ptr<Request>> _inflightVec{};
+  std::vector<std::shared_ptr<Request>> _cancelingVec{};
+
+  std::unordered_map<Request*, std::shared_ptr<Request>> _inflightMap{};
+  std::unordered_map<Request*, std::shared_ptr<Request>> _cancelingMap{};
+
+  std::mutex _mutex{};
+
+  void _doInsert(const std::shared_ptr<Request>& request);
+  void _doRemove(const std::shared_ptr<Request>& request);
+  size_t _doInflightSize() const;
+  std::vector<std::shared_ptr<Request>> _doTakeInflight();
+  void _doPutCanceling(std::vector<std::shared_ptr<Request>>* requests);
+  size_t _doDropCanceled();
+  size_t _doCancelingSize() const;
+  void _doMergeInflight(std::vector<std::shared_ptr<Request>>* requests);
+  void _doMergeCanceling(std::vector<std::shared_ptr<Request>>* requests);
+  std::vector<std::shared_ptr<Request>> _doTakeCanceling();
 
  public:
   /**
-   * @brief Default constructor.
+   * @brief Construct with backend selected from UCXX_INFLIGHT_REQUESTS_BACKEND env var.
+   *
+   * Reads the `UCXX_INFLIGHT_REQUESTS_BACKEND` environment variable to select the
+   * container backend. Valid values are `vector` (default) and `map`.
    */
-  InflightRequests() = default;
+  InflightRequests();
 
   InflightRequests(const InflightRequests&)            = delete;
   InflightRequests& operator=(InflightRequests const&) = delete;
@@ -94,11 +91,11 @@ class InflightRequests {
   [[nodiscard]] size_t size();
 
   /**
-   * @brief Insert an inflight requests to the container.
+   * @brief Insert an inflight request into the container.
    *
    * @param[in] request a `std::shared_ptr<Request>` with the inflight request.
    */
-  void insert(std::shared_ptr<Request> request);
+  void insert(const std::shared_ptr<Request>& request);
 
   /**
    * @brief Merge containers of inflight requests with the internal containers.
@@ -109,7 +106,7 @@ class InflightRequests {
    * @param[in] trackedRequests containers of tracked inflight requests to merge with the
    *                            internal tracked inflight requests.
    */
-  void merge(TrackedRequestsPtr trackedRequests);
+  void merge(TrackedRequests&& trackedRequests);
 
   /**
    * @brief Remove an inflight request from the internal container.
@@ -120,7 +117,7 @@ class InflightRequests {
    *
    * @param[in] request shared pointer to the request
    */
-  void remove(std::shared_ptr<Request> request);
+  void remove(const std::shared_ptr<Request>& request);
 
   /**
    * @brief Issue cancelation of all inflight requests and clear the internal container.
@@ -139,9 +136,9 @@ class InflightRequests {
    * `InflightRequests` object with `InflightRequests::merge()`. Effectively leaves the
    * internal state as a clean, new object.
    *
-   * @returns The internally-tracked containers.
+   * @returns The tracked requests as vectors for transfer.
    */
-  [[nodiscard]] TrackedRequestsPtr release();
+  [[nodiscard]] TrackedRequests release();
 
   /**
    * @brief Get count of requests in process of cancelation.

--- a/cpp/include/ucxx/inflight_requests.h
+++ b/cpp/include/ucxx/inflight_requests.h
@@ -6,7 +6,7 @@
 
 #include <memory>
 #include <mutex>
-#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace ucxx {
@@ -36,8 +36,8 @@ struct TrackedRequests {
  */
 class InflightRequests {
  private:
-  std::unordered_map<Request*, std::shared_ptr<Request>> _inflight{};
-  std::unordered_map<Request*, std::shared_ptr<Request>> _canceling{};
+  std::unordered_set<std::shared_ptr<Request>> _inflight{};
+  std::unordered_set<std::shared_ptr<Request>> _canceling{};
 
   std::mutex _mutex{};
 

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -656,7 +656,7 @@ class Worker : public Component {
    * @param[in] trackedRequests the requests tracked by a child of this class to be
    *                            scheduled for cancelation.
    */
-  void scheduleRequestCancel(TrackedRequestsPtr trackedRequests);
+  void scheduleRequestCancel(TrackedRequests trackedRequests);
 
   /**
    * @brief Remove reference to request from internal container.

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -62,7 +62,7 @@ size_t InflightRequests::cancelAll()
     std::lock_guard<std::mutex> lock(_mutex);
     for (auto& r : toCancel) {
       if (r && r->getStatus() == UCS_INPROGRESS)
-        _canceling.insert(std::move(const_cast<std::shared_ptr<Request>&>(r)));
+        _canceling.insert(r);
     }
   }
 

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -61,8 +61,7 @@ size_t InflightRequests::cancelAll()
   {
     std::lock_guard<std::mutex> lock(_mutex);
     for (auto& r : toCancel) {
-      if (r && r->getStatus() == UCS_INPROGRESS)
-        _canceling.insert(r);
+      if (r && r->getStatus() == UCS_INPROGRESS) _canceling.insert(r);
     }
   }
 

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -2,11 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include <algorithm>
-#include <cstdlib>
-#include <cstring>
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -16,152 +12,33 @@
 
 namespace ucxx {
 
-// ---- Private backend helpers ------------------------------------------------
-
-void InflightRequests::_doInsert(const std::shared_ptr<Request>& request)
-{
-  if (_useMap)
-    _inflightMap.emplace(request.get(), request);
-  else
-    _inflightVec.push_back(request);
-}
-
-void InflightRequests::_doRemove(const std::shared_ptr<Request>& request)
-{
-  if (_useMap) {
-    _inflightMap.erase(request.get());
-  } else {
-    auto it = std::find(_inflightVec.begin(), _inflightVec.end(), request);
-    if (it != _inflightVec.end()) {
-      *it = std::move(_inflightVec.back());
-      _inflightVec.pop_back();
-    }
-  }
-}
-
-size_t InflightRequests::_doInflightSize() const
-{
-  return _useMap ? _inflightMap.size() : _inflightVec.size();
-}
-
-std::vector<std::shared_ptr<Request>> InflightRequests::_doTakeInflight()
-{
-  std::vector<std::shared_ptr<Request>> result;
-  if (_useMap) {
-    result.reserve(_inflightMap.size());
-    for (auto& kv : _inflightMap)
-      result.push_back(std::move(kv.second));
-    _inflightMap.clear();
-  } else {
-    result = std::exchange(_inflightVec, {});
-  }
-  return result;
-}
-
-void InflightRequests::_doPutCanceling(std::vector<std::shared_ptr<Request>>* requests)
-{
-  if (_useMap) {
-    for (auto& r : *requests)
-      if (r) _cancelingMap.emplace(r.get(), std::move(r));
-  } else {
-    _cancelingVec.insert(_cancelingVec.end(),
-                         std::make_move_iterator(requests->begin()),
-                         std::make_move_iterator(requests->end()));
-  }
-}
-
-size_t InflightRequests::_doDropCanceled()
-{
-  size_t removed = 0;
-  if (_useMap) {
-    for (auto it = _cancelingMap.begin(); it != _cancelingMap.end();) {
-      if (it->second && it->second->getStatus() != UCS_INPROGRESS) {
-        it = _cancelingMap.erase(it);
-        ++removed;
-      } else {
-        ++it;
-      }
-    }
-  } else {
-    auto newEnd = std::remove_if(
-      _cancelingVec.begin(), _cancelingVec.end(), [](const std::shared_ptr<Request>& r) {
-        return r && r->getStatus() != UCS_INPROGRESS;
-      });
-    removed = static_cast<size_t>(std::distance(newEnd, _cancelingVec.end()));
-    _cancelingVec.erase(newEnd, _cancelingVec.end());
-  }
-  return removed;
-}
-
-size_t InflightRequests::_doCancelingSize() const
-{
-  return _useMap ? _cancelingMap.size() : _cancelingVec.size();
-}
-
-void InflightRequests::_doMergeInflight(std::vector<std::shared_ptr<Request>>* requests)
-{
-  if (_useMap) {
-    for (auto& r : *requests)
-      if (r) _inflightMap.emplace(r.get(), std::move(r));
-  } else {
-    _inflightVec.insert(_inflightVec.end(),
-                        std::make_move_iterator(requests->begin()),
-                        std::make_move_iterator(requests->end()));
-  }
-}
-
-void InflightRequests::_doMergeCanceling(std::vector<std::shared_ptr<Request>>* requests)
-{
-  _doPutCanceling(requests);
-}
-
-std::vector<std::shared_ptr<Request>> InflightRequests::_doTakeCanceling()
-{
-  std::vector<std::shared_ptr<Request>> result;
-  if (_useMap) {
-    result.reserve(_cancelingMap.size());
-    for (auto& kv : _cancelingMap)
-      result.push_back(std::move(kv.second));
-    _cancelingMap.clear();
-  } else {
-    result = std::exchange(_cancelingVec, {});
-  }
-  return result;
-}
-
-// ---- Public API -------------------------------------------------------------
-
-InflightRequests::InflightRequests()
-{
-  const char* env = std::getenv("UCXX_INFLIGHT_REQUESTS_BACKEND");
-  if (env != nullptr && std::strcmp(env, "map") == 0) _useMap = true;
-}
-
 InflightRequests::~InflightRequests() { cancelAll(); }
 
 size_t InflightRequests::size()
 {
   std::lock_guard<std::mutex> lock(_mutex);
-  return _doInflightSize();
+  return _inflight.size();
 }
 
 void InflightRequests::insert(const std::shared_ptr<Request>& request)
 {
   std::lock_guard<std::mutex> lock(_mutex);
-  _doInsert(request);
+  _inflight.emplace(request.get(), request);
 }
 
 void InflightRequests::remove(const std::shared_ptr<Request>& request)
 {
   std::lock_guard<std::mutex> lock(_mutex);
-  _doRemove(request);
+  _inflight.erase(request.get());
 }
 
 void InflightRequests::merge(TrackedRequests&& trackedRequests)
 {
   std::lock_guard<std::mutex> lock(_mutex);
-  _doMergeInflight(&trackedRequests.inflight);
-  _doMergeCanceling(&trackedRequests.canceling);
+  for (auto& r : trackedRequests.inflight)
+    if (r) _inflight.emplace(r.get(), std::move(r));
+  for (auto& r : trackedRequests.canceling)
+    if (r) _canceling.emplace(r.get(), std::move(r));
 }
 
 size_t InflightRequests::cancelAll()
@@ -169,7 +46,10 @@ size_t InflightRequests::cancelAll()
   std::vector<std::shared_ptr<Request>> toCancel;
   {
     std::lock_guard<std::mutex> lock(_mutex);
-    toCancel = _doTakeInflight();
+    toCancel.reserve(_inflight.size());
+    for (auto& kv : _inflight)
+      toCancel.push_back(std::move(kv.second));
+    _inflight.clear();
   }
 
   size_t total = toCancel.size();
@@ -183,13 +63,9 @@ size_t InflightRequests::cancelAll()
 
   {
     std::lock_guard<std::mutex> lock(_mutex);
-
-    // Keep requests that are still in progress; drop completed ones.
-    std::vector<std::shared_ptr<Request>> stillCanceling;
     for (auto& r : toCancel) {
-      if (r && r->getStatus() == UCS_INPROGRESS) stillCanceling.push_back(std::move(r));
+      if (r && r->getStatus() == UCS_INPROGRESS) _canceling.emplace(r.get(), std::move(r));
     }
-    _doPutCanceling(&stillCanceling);
   }
 
   return total;
@@ -199,16 +75,32 @@ TrackedRequests InflightRequests::release()
 {
   std::lock_guard<std::mutex> lock(_mutex);
   TrackedRequests result;
-  result.inflight  = _doTakeInflight();
-  result.canceling = _doTakeCanceling();
+
+  result.inflight.reserve(_inflight.size());
+  for (auto& kv : _inflight)
+    result.inflight.push_back(std::move(kv.second));
+  _inflight.clear();
+
+  result.canceling.reserve(_canceling.size());
+  for (auto& kv : _canceling)
+    result.canceling.push_back(std::move(kv.second));
+  _canceling.clear();
+
   return result;
 }
 
 size_t InflightRequests::getCancelingSize()
 {
   std::lock_guard<std::mutex> lock(_mutex);
-  _doDropCanceled();
-  return _doCancelingSize();
+
+  for (auto it = _canceling.begin(); it != _canceling.end();) {
+    if (it->second && it->second->getStatus() != UCS_INPROGRESS)
+      it = _canceling.erase(it);
+    else
+      ++it;
+  }
+
+  return _canceling.size();
 }
 
 }  // namespace ucxx

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -2,7 +2,13 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <ucxx/inflight_requests.h>
 #include <ucxx/log.h>
@@ -10,160 +16,199 @@
 
 namespace ucxx {
 
-InflightRequests::~InflightRequests() { cancelAll(); }
+// ---- Private backend helpers ------------------------------------------------
 
-size_t InflightRequests::size()
+void InflightRequests::_doInsert(const std::shared_ptr<Request>& request)
 {
-  std::scoped_lock localLock{_mutex};
-  std::lock_guard<std::mutex> lock(_trackedRequests->_mutex);
-  return _trackedRequests->_inflight.size();
+  if (_useMap)
+    _inflightMap.emplace(request.get(), request);
+  else
+    _inflightVec.push_back(request);
 }
 
-void InflightRequests::insert(std::shared_ptr<Request> request)
+void InflightRequests::_doRemove(const std::shared_ptr<Request>& request)
 {
-  std::scoped_lock localLock{_mutex};
-  std::lock_guard<std::mutex> lock(_trackedRequests->_mutex);
-
-  _trackedRequests->_inflight.insert({request, request});
-}
-
-void InflightRequests::merge(TrackedRequestsPtr trackedRequests)
-{
-  {
-    if (trackedRequests == nullptr) return;
-
-    std::scoped_lock localLock{_mutex};
-    std::scoped_lock lock{_trackedRequests->_cancelMutex,
-                          _trackedRequests->_mutex,
-                          trackedRequests->_cancelMutex,
-                          trackedRequests->_mutex};
-
-    _trackedRequests->_inflight.merge(trackedRequests->_inflight);
-    _trackedRequests->_canceling.merge(trackedRequests->_canceling);
+  if (_useMap) {
+    _inflightMap.erase(request.get());
+  } else {
+    auto it = std::find(_inflightVec.begin(), _inflightVec.end(), request);
+    if (it != _inflightVec.end()) {
+      *it = std::move(_inflightVec.back());
+      _inflightVec.pop_back();
+    }
   }
 }
 
-void InflightRequests::remove(std::shared_ptr<Request> request)
+size_t InflightRequests::_doInflightSize() const
 {
-  do {
-    std::scoped_lock localLock{_mutex};
-    int result = std::try_lock(_trackedRequests->_cancelMutex, _trackedRequests->_mutex);
-
-    /**
-     * `result` can be have one of three values:
-     * -1 (both arguments were locked): Remove request and return.
-     *  0 (failed to lock argument 0):  Failed acquiring `_cancelMutex`, cancel in
-     *                                  progress, nothing to do but return. The method was
-     *                                  called during execution of `cancelAll()` and the
-     *                                  `Request*` callback was invoked.
-     *  1 (failed to lock argument 1):  Only `_cancelMutex` was acquired, another
-     *                                  operation in progress, retry.
-     */
-    if (result == 0) {
-      return;
-    } else if (result == -1) {
-      auto search = _trackedRequests->_inflight.find(request);
-      decltype(search->second) tmpRequest;
-      if (search != _trackedRequests->_inflight.end()) {
-        /**
-         * If this is the last request to hold `std::shared_ptr<ucxx::Endpoint>` erasing it
-         * may cause the `ucxx::Endpoint`s destructor and subsequently the `closeBlocking()`
-         * method to be called which will in turn call `cancelAll()` and attempt to take the
-         * mutexes. For this reason we should make a temporary copy of the request being
-         * erased from `_trackedRequests->_inflight` to allow unlocking the mutexes and only then
-         * destroy the object upon this method's return.
-         */
-        tmpRequest = search->second;
-        _trackedRequests->_inflight.erase(search);
-      }
-      _trackedRequests->_cancelMutex.unlock();
-      _trackedRequests->_mutex.unlock();
-      return;
-    }
-  } while (true);
+  return _useMap ? _inflightMap.size() : _inflightVec.size();
 }
 
-size_t InflightRequests::dropCanceled()
+std::vector<std::shared_ptr<Request>> InflightRequests::_doTakeInflight()
+{
+  std::vector<std::shared_ptr<Request>> result;
+  if (_useMap) {
+    result.reserve(_inflightMap.size());
+    for (auto& kv : _inflightMap)
+      result.push_back(std::move(kv.second));
+    _inflightMap.clear();
+  } else {
+    result = std::exchange(_inflightVec, {});
+  }
+  return result;
+}
+
+void InflightRequests::_doPutCanceling(std::vector<std::shared_ptr<Request>>* requests)
+{
+  if (_useMap) {
+    for (auto& r : *requests)
+      if (r) _cancelingMap.emplace(r.get(), std::move(r));
+  } else {
+    _cancelingVec.insert(_cancelingVec.end(),
+                         std::make_move_iterator(requests->begin()),
+                         std::make_move_iterator(requests->end()));
+  }
+}
+
+size_t InflightRequests::_doDropCanceled()
 {
   size_t removed = 0;
-
-  {
-    std::scoped_lock localLock{_mutex};
-    std::scoped_lock lock{_trackedRequests->_cancelMutex};
-    for (auto it = _trackedRequests->_canceling.begin();
-         it != _trackedRequests->_canceling.end();) {
-      auto request = it->second;
-      if (request != nullptr && request->getStatus() != UCS_INPROGRESS) {
-        it = _trackedRequests->_canceling.erase(it);
+  if (_useMap) {
+    for (auto it = _cancelingMap.begin(); it != _cancelingMap.end();) {
+      if (it->second && it->second->getStatus() != UCS_INPROGRESS) {
+        it = _cancelingMap.erase(it);
         ++removed;
       } else {
         ++it;
       }
     }
+  } else {
+    auto newEnd = std::remove_if(
+      _cancelingVec.begin(), _cancelingVec.end(), [](const std::shared_ptr<Request>& r) {
+        return r && r->getStatus() != UCS_INPROGRESS;
+      });
+    removed = static_cast<size_t>(std::distance(newEnd, _cancelingVec.end()));
+    _cancelingVec.erase(newEnd, _cancelingVec.end());
   }
-
   return removed;
 }
 
-size_t InflightRequests::getCancelingSize()
+size_t InflightRequests::_doCancelingSize() const
 {
-  dropCanceled();
-  size_t cancelingSize = 0;
-  {
-    std::scoped_lock localLock{_mutex};
-    std::scoped_lock lock{_trackedRequests->_cancelMutex};
-    cancelingSize = _trackedRequests->_canceling.size();
-  }
+  return _useMap ? _cancelingMap.size() : _cancelingVec.size();
+}
 
-  return cancelingSize;
+void InflightRequests::_doMergeInflight(std::vector<std::shared_ptr<Request>>* requests)
+{
+  if (_useMap) {
+    for (auto& r : *requests)
+      if (r) _inflightMap.emplace(r.get(), std::move(r));
+  } else {
+    _inflightVec.insert(_inflightVec.end(),
+                        std::make_move_iterator(requests->begin()),
+                        std::make_move_iterator(requests->end()));
+  }
+}
+
+void InflightRequests::_doMergeCanceling(std::vector<std::shared_ptr<Request>>* requests)
+{
+  _doPutCanceling(requests);
+}
+
+std::vector<std::shared_ptr<Request>> InflightRequests::_doTakeCanceling()
+{
+  std::vector<std::shared_ptr<Request>> result;
+  if (_useMap) {
+    result.reserve(_cancelingMap.size());
+    for (auto& kv : _cancelingMap)
+      result.push_back(std::move(kv.second));
+    _cancelingMap.clear();
+  } else {
+    result = std::exchange(_cancelingVec, {});
+  }
+  return result;
+}
+
+// ---- Public API -------------------------------------------------------------
+
+InflightRequests::InflightRequests()
+{
+  const char* env = std::getenv("UCXX_INFLIGHT_REQUESTS_BACKEND");
+  if (env != nullptr && std::strcmp(env, "map") == 0) _useMap = true;
+}
+
+InflightRequests::~InflightRequests() { cancelAll(); }
+
+size_t InflightRequests::size()
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return _doInflightSize();
+}
+
+void InflightRequests::insert(const std::shared_ptr<Request>& request)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _doInsert(request);
+}
+
+void InflightRequests::remove(const std::shared_ptr<Request>& request)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _doRemove(request);
+}
+
+void InflightRequests::merge(TrackedRequests&& trackedRequests)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _doMergeInflight(&trackedRequests.inflight);
+  _doMergeCanceling(&trackedRequests.canceling);
 }
 
 size_t InflightRequests::cancelAll()
 {
-  decltype(_trackedRequests->_inflight) toCancel;
-  size_t total;
+  std::vector<std::shared_ptr<Request>> toCancel;
   {
-    std::scoped_lock localLock{_mutex};
-    std::scoped_lock lock{_trackedRequests->_cancelMutex, _trackedRequests->_mutex};
-    total = _trackedRequests->_inflight.size();
+    std::lock_guard<std::mutex> lock(_mutex);
+    toCancel = _doTakeInflight();
+  }
 
-    // Fast path when no requests have been registered or the map has been
-    // previously released.
-    if (total == 0) return 0;
+  size_t total = toCancel.size();
+  if (total == 0) return 0;
 
-    toCancel = std::exchange(_trackedRequests->_inflight, InflightRequestsMap());
+  ucxx_debug("ucxx::InflightRequests::%s, canceling %lu requests", __func__, total);
 
-    ucxx_debug("ucxx::InflightRequests::%s, canceling %lu requests", __func__, total);
+  for (auto& r : toCancel) {
+    if (r) r->cancel();
+  }
 
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    // Keep requests that are still in progress; drop completed ones.
+    std::vector<std::shared_ptr<Request>> stillCanceling;
     for (auto& r : toCancel) {
-      auto request = r.second;
-      if (request != nullptr) { request->cancel(); }
+      if (r && r->getStatus() == UCS_INPROGRESS) stillCanceling.push_back(std::move(r));
     }
-
-    _trackedRequests->_canceling.merge(toCancel);
-
-    // Drop canceled requests. Do not call `dropCanceled()` to prevent locking mutexes
-    // again.
-    for (auto it = _trackedRequests->_canceling.begin();
-         it != _trackedRequests->_canceling.end();) {
-      auto request = it->second;
-      if (request != nullptr && request->getStatus() != UCS_INPROGRESS) {
-        it = _trackedRequests->_canceling.erase(it);
-      } else {
-        ++it;
-      }
-    }
+    _doPutCanceling(&stillCanceling);
   }
 
   return total;
 }
 
-TrackedRequestsPtr InflightRequests::release()
+TrackedRequests InflightRequests::release()
 {
-  std::scoped_lock localLock{_mutex};
-  std::scoped_lock lock{_trackedRequests->_cancelMutex, _trackedRequests->_mutex};
+  std::lock_guard<std::mutex> lock(_mutex);
+  TrackedRequests result;
+  result.inflight  = _doTakeInflight();
+  result.canceling = _doTakeCanceling();
+  return result;
+}
 
-  return std::exchange(_trackedRequests, std::make_unique<TrackedRequests>());
+size_t InflightRequests::getCancelingSize()
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _doDropCanceled();
+  return _doCancelingSize();
 }
 
 }  // namespace ucxx

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -23,33 +23,30 @@ size_t InflightRequests::size()
 void InflightRequests::insert(const std::shared_ptr<Request>& request)
 {
   std::lock_guard<std::mutex> lock(_mutex);
-  _inflight.emplace(request.get(), request);
+  _inflight.insert(request);
 }
 
 void InflightRequests::remove(const std::shared_ptr<Request>& request)
 {
   std::lock_guard<std::mutex> lock(_mutex);
-  _inflight.erase(request.get());
+  _inflight.erase(request);
 }
 
 void InflightRequests::merge(TrackedRequests&& trackedRequests)
 {
   std::lock_guard<std::mutex> lock(_mutex);
   for (auto& r : trackedRequests.inflight)
-    if (r) _inflight.emplace(r.get(), std::move(r));
+    if (r) _inflight.insert(std::move(r));
   for (auto& r : trackedRequests.canceling)
-    if (r) _canceling.emplace(r.get(), std::move(r));
+    if (r) _canceling.insert(std::move(r));
 }
 
 size_t InflightRequests::cancelAll()
 {
-  std::vector<std::shared_ptr<Request>> toCancel;
+  decltype(_inflight) toCancel;
   {
     std::lock_guard<std::mutex> lock(_mutex);
-    toCancel.reserve(_inflight.size());
-    for (auto& kv : _inflight)
-      toCancel.push_back(std::move(kv.second));
-    _inflight.clear();
+    toCancel = std::exchange(_inflight, {});
   }
 
   size_t total = toCancel.size();
@@ -64,7 +61,8 @@ size_t InflightRequests::cancelAll()
   {
     std::lock_guard<std::mutex> lock(_mutex);
     for (auto& r : toCancel) {
-      if (r && r->getStatus() == UCS_INPROGRESS) _canceling.emplace(r.get(), std::move(r));
+      if (r && r->getStatus() == UCS_INPROGRESS)
+        _canceling.insert(std::move(const_cast<std::shared_ptr<Request>&>(r)));
     }
   }
 
@@ -77,13 +75,13 @@ TrackedRequests InflightRequests::release()
   TrackedRequests result;
 
   result.inflight.reserve(_inflight.size());
-  for (auto& kv : _inflight)
-    result.inflight.push_back(std::move(kv.second));
+  for (auto& r : _inflight)
+    result.inflight.push_back(r);
   _inflight.clear();
 
   result.canceling.reserve(_canceling.size());
-  for (auto& kv : _canceling)
-    result.canceling.push_back(std::move(kv.second));
+  for (auto& r : _canceling)
+    result.canceling.push_back(r);
   _canceling.clear();
 
   return result;
@@ -94,7 +92,7 @@ size_t InflightRequests::getCancelingSize()
   std::lock_guard<std::mutex> lock(_mutex);
 
   for (auto it = _canceling.begin(); it != _canceling.end();) {
-    if (it->second && it->second->getStatus() != UCS_INPROGRESS)
+    if (*it && (*it)->getStatus() != UCS_INPROGRESS)
       it = _canceling.erase(it);
     else
       ++it;

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -538,7 +538,7 @@ size_t Worker::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
 
   if (inflightRequestsToCancel->getCancelingSize() > 0) {
     std::lock_guard<std::mutex> lock(_inflightRequestsMutex);
-    _inflightRequestsToCancel->merge(std::move(inflightRequestsToCancel->release()));
+    _inflightRequestsToCancel->merge(inflightRequestsToCancel->release());
   }
 
   return canceled;

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -538,13 +538,13 @@ size_t Worker::cancelInflightRequests(uint64_t period, uint64_t maxAttempts)
 
   if (inflightRequestsToCancel->getCancelingSize() > 0) {
     std::lock_guard<std::mutex> lock(_inflightRequestsMutex);
-    _inflightRequestsToCancel->merge(inflightRequestsToCancel->release());
+    _inflightRequestsToCancel->merge(std::move(inflightRequestsToCancel->release()));
   }
 
   return canceled;
 }
 
-void Worker::scheduleRequestCancel(TrackedRequestsPtr trackedRequests)
+void Worker::scheduleRequestCancel(TrackedRequests trackedRequests)
 {
   {
     std::lock_guard<std::mutex> lock(_inflightRequestsMutex);
@@ -554,7 +554,7 @@ void Worker::scheduleRequestCancel(TrackedRequestsPtr trackedRequests)
       __func__,
       this,
       _handle,
-      trackedRequests->_inflight.size() + trackedRequests->_canceling.size());
+      trackedRequests.inflight.size() + trackedRequests.canceling.size());
     _inflightRequestsToCancel->merge(std::move(trackedRequests));
   }
 }


### PR DESCRIPTION
Refactor `InflightRequests` to replace the previous triple-mutex scheme (`std::recursive_mutex` + two `std::mutex` inside a heap-allocated `TrackedRequests` struct) and dual `std::map` containers with a single `std::mutex` and two `std::unordered_set` members. This eliminates the complex `try_lock` retry loop in `remove()` that was needed to handle the cancel-during-remove race: the new `cancelAll()` moves all requests out of the inflight set before calling `cancel()`, so any subsequent `remove()` from the completion callback is naturally a no-op. The `TrackedRequests` type is simplified from a mutex-bearing struct wrapped in `std::unique_ptr` to a plain value type holding two vectors, used solely as a transfer vehicle for `release()`/`merge()` operations. The result is significantly easier to follow: each public method acquires a single non-recursive mutex and performs one container operation, with no nested locking, no recursive mutex overhead, and no retry loops. The switch from `std::map` (red-black tree with per-node allocation and O(log n) operations) to `std::unordered_set` (O(1) amortized insert/erase) should also scalability for workloads with large numbers of concurrent inflight requests.
