### PR TITLE
Fix error messages in a couple `__init__` methods

### DIFF
--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -1272,7 +1272,7 @@ cdef void _endpoint_close_callback(ucs_status_t status, shared_ptr[void] args) w
 
 cdef class UCXEndpoint():
     def __init__(self) -> None:
-        raise TypeError("UCXListener cannot be instantiated directly.")
+        raise TypeError("UCXEndpoint cannot be instantiated directly.")
 
     def __dealloc__(self) -> None:
         self.remove_close_callback()

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -490,7 +490,7 @@ cdef class UCXContext():
 
 cdef class UCXAddress():
     def __init__(self) -> None:
-        raise TypeError("UCXListener cannot be instantiated directly.")
+        raise TypeError("UCXAddress cannot be instantiated directly.")
 
     def __dealloc__(self) -> None:
         with nogil:


### PR DESCRIPTION
A few classes raise in `__init__` as other methods are encouraged for their construction. However those methods all referenced `UCXListener`. IIUC they should reference the class they are creating. Guessing this just happened due to copy-paste. So have tried to fix these based on my understanding. Happy to change if needed