### PR TITLE
Add `getStringView` & deprecate `getString`

### DIFF
--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -126,9 +126,10 @@ class Address : public Component {
    *
    * @returns The underlying `ucp_address_t` handle.
    */
+  [[nodiscard]]
   [[deprecated(
     "Removing in UCXX 0.51. Switch to `getStringView`."
-  )]] [[nodiscard]] std::string getString() const;
+  )]] std::string getString() const;
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -126,10 +126,8 @@ class Address : public Component {
    *
    * @returns The underlying `ucp_address_t` handle.
    */
-  [[nodiscard]]
-  [[deprecated(
-    "Removing in UCXX 0.51. Switch to `getStringView`."
-  )]] std::string getString() const;
+  [[deprecated("Removing in UCXX 0.51. Switch to `getStringView`.")]] [[nodiscard]] std::string
+  getString() const;
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -126,7 +126,7 @@ class Address : public Component {
    *
    * @returns The underlying `ucp_address_t` handle.
    */
-  [[deprecated("Will be removed in UCXX 0.51. Replace with `getStringView`.")]]
+  [[deprecated("Removing in UCXX 0.51. Switch to `getStringView`.")]]
   [[nodiscard]] std::string getString() const;
 };
 

--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -126,7 +126,10 @@ class Address : public Component {
    *
    * @returns The underlying `ucp_address_t` handle.
    */
-  [[deprecated("Will be removed in UCXX 0.51. Replace with `getStringView` and create `std::string` as needed.")]]
+  [[deprecated(
+    "Will be removed in UCXX 0.51. "
+    "Replace with `getStringView` and create `std::string` as needed."
+    )]]
   [[nodiscard]] std::string getString() const;
 };
 

--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <string_view>
 
 #include <ucp/api/ucp.h>
@@ -115,7 +116,18 @@ class Address : public Component {
    *
    * @returns The underlying `ucp_address_t` handle.
    */
-  [[nodiscard]] std::string_view getString() const;
+  [[nodiscard]] std::string_view getStringView() const;
+
+  /**
+   * @brief Get the address as a string.
+   *
+   * Convenience method to copy the underlying address to a `std::string` and return it as
+   * a single object.
+   *
+   * @returns The underlying `ucp_address_t` handle.
+   */
+  [[deprecated("Will be removed in UCXX 0.51. Replace with `getStringView` and create `std::string` as needed.")]]
+  [[nodiscard]] std::string getString() const;
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -126,8 +126,9 @@ class Address : public Component {
    *
    * @returns The underlying `ucp_address_t` handle.
    */
-  [[deprecated("Removing in UCXX 0.51. Switch to `getStringView`.")]]
-  [[nodiscard]] std::string getString() const;
+  [[deprecated(
+    "Removing in UCXX 0.51. Switch to `getStringView`."
+  )]] [[nodiscard]] std::string getString() const;
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -126,10 +126,7 @@ class Address : public Component {
    *
    * @returns The underlying `ucp_address_t` handle.
    */
-  [[deprecated(
-    "Will be removed in UCXX 0.51. "
-    "Replace with `getStringView` and create `std::string` as needed."
-    )]]
+  [[deprecated("Will be removed in UCXX 0.51. Replace with `getStringView`.")]]
   [[nodiscard]] std::string getString() const;
 };
 

--- a/cpp/src/address.cpp
+++ b/cpp/src/address.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
+#include <string>
 #include <string_view>
 
 #include <ucxx/address.h>
@@ -50,9 +51,14 @@ ucp_address_t* Address::getHandle() const { return _handle; }
 
 size_t Address::getLength() const { return _length; }
 
-std::string_view Address::getString() const
+std::string_view Address::getStringView() const
 {
   return std::string_view{reinterpret_cast<const char*>(_handle), _length};
+}
+
+std::string Address::getString() const
+{
+  return std::string{getStringView()};
 }
 
 }  // namespace ucxx

--- a/cpp/src/address.cpp
+++ b/cpp/src/address.cpp
@@ -56,9 +56,6 @@ std::string_view Address::getStringView() const
   return std::string_view{reinterpret_cast<const char*>(_handle), _length};
 }
 
-std::string Address::getString() const
-{
-  return std::string{getStringView()};
-}
+std::string Address::getString() const { return std::string{getStringView()}; }
 
 }  // namespace ucxx

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -507,7 +507,7 @@ cdef class UCXAddress():
             address._address = worker._worker.get().getAddress()
             address._handle = address._address.get().getHandle()
             address._length = address._address.get().getLength()
-            address._string = address._address.get().getString()
+            address._string = address._address.get().getStringView()
 
         return address
 
@@ -520,7 +520,7 @@ cdef class UCXAddress():
             address._address = createAddressFromString(address_strv)
             address._handle = address._address.get().getHandle()
             address._length = address._address.get().getLength()
-            address._string = address._address.get().getString()
+            address._string = address._address.get().getStringView()
 
         return address
 

--- a/python/ucxx/ucxx/_lib/ucxx_api.pxd
+++ b/python/ucxx/ucxx/_lib/ucxx_api.pxd
@@ -357,7 +357,8 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
     cdef cppclass Address(Component):
         ucp_address_t* getHandle()
         size_t getLength()
-        string_view getString()
+        string_view getStringView()
+        string getString()
 
     cdef cppclass Request(Component):
         cpp_bool isCompleted()


### PR DESCRIPTION
Follow up to PR: https://github.com/rapidsai/ucxx/pull/392

Restore the original signature of `getString` to avoid a breaking change. Instead deprecate it with a planned removal in UCXX 0.51. Alongside it add `getStringView` as its replacement. Update internal code to instead use `getStringView`.

This provides a deprecation cycle for external users to move to the new behavior (if they are affected).