### PR TITLE
Add `UCXAddress.tobytes` method

### DIFF
--- a/python/ucxx/ucxx/_lib/libucxx.pxd
+++ b/python/ucxx/ucxx/_lib/libucxx.pxd
@@ -43,8 +43,11 @@ cdef class UCXAddress:
         size_t _length
         ucp_address_t *_handle
         string_view _string
+        bytes _bytes
 
     cdef shared_ptr[Address] get_ucxx_shared_ptr(self) nogil
+
+    cpdef bytes tobytes()
 
 
 cdef class UCXWorker:

--- a/python/ucxx/ucxx/_lib/libucxx.pxd
+++ b/python/ucxx/ucxx/_lib/libucxx.pxd
@@ -47,7 +47,7 @@ cdef class UCXAddress:
 
     cdef shared_ptr[Address] get_ucxx_shared_ptr(self) nogil
 
-    cpdef bytes tobytes()
+    cpdef bytes tobytes(self)
 
 
 cdef class UCXWorker:

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -579,7 +579,7 @@ cdef class UCXAddress():
             return (UCXAddress.create_from_buffer, (bytes(self),))
 
     def __hash__(self) -> Py_hash_t:
-        return hash(bytes(self))
+        return hash(self.tobytes())
 
 
 cdef void _generic_callback(void *args) with gil:

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -554,7 +554,7 @@ cdef class UCXAddress():
     cdef shared_ptr[Address] get_ucxx_shared_ptr(self) nogil:
         return self._address
 
-    cpdef bytes tobytes():
+    cpdef bytes tobytes(self):
         if self._bytes is None:
             self._bytes = bytes(self._string)
         return self._bytes

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -576,7 +576,7 @@ cdef class UCXAddress():
         if protocol >= 5:
             return (UCXAddress.create_from_buffer, (PickleBuffer(self),))
         else:
-            return (UCXAddress.create_from_buffer, (bytes(self),))
+            return (UCXAddress.create_from_buffer, (self.tobytes(),))
 
     def __hash__(self) -> Py_hash_t:
         return hash(self.tobytes())

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -503,6 +503,7 @@ cdef class UCXAddress():
     def create_from_worker(cls, UCXWorker worker) -> UCXAddress:
         cdef UCXAddress address = UCXAddress.__new__(UCXAddress)
 
+        address._bytes = None
         with nogil:
             address._address = worker._worker.get().getAddress()
             address._handle = address._address.get().getHandle()
@@ -516,6 +517,7 @@ cdef class UCXAddress():
         cdef UCXAddress address = UCXAddress.__new__(UCXAddress)
         cdef string_view address_strv = string_view(<const char*>&buf[0], len(buf))
 
+        address._bytes = None
         with nogil:
             address._address = createAddressFromString(address_strv)
             address._handle = address._address.get().getHandle()
@@ -551,6 +553,11 @@ cdef class UCXAddress():
 
     cdef shared_ptr[Address] get_ucxx_shared_ptr(self) nogil:
         return self._address
+
+    cpdef bytes tobytes():
+        if self._bytes is None:
+            self._bytes = bytes(self._string)
+        return self._bytes
 
     @property
     def length(self) -> int:

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -571,7 +571,7 @@ cdef class UCXAddress():
         else:
             return (UCXAddress.create_from_buffer, (bytes(self),))
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> Py_hash_t:
         return hash(bytes(self))
 
 

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -564,7 +564,7 @@ cdef class UCXAddress():
         return int(self._length)
 
     def __bytes__(self) -> bytes:
-        return bytes(self._string)
+        return self.tobytes()
 
     def __getbuffer__(self, Py_buffer *buffer, int flags) -> None:
         PyBuffer_FillInfo(buffer, self, self._handle, self._length, True, flags)


### PR DESCRIPTION
Add a `cpdef` method `tobytes` to `UCXAddress` for efficient Python & Cython/C++ construction of `bytes` representations of `UCXAddress`. This allows for efficient C++ function calls whenever `tobytes` is used as is the case in several `UCXAddress` methods.

Also `tobytes` caches the resulting `bytes` object in `UCXAddress._bytes` for fast retrieval. That way a single `tobytes` call constructs the `bytes` representation and subsequent calls retrieves it for free. Ensure `__bytes__` makes use of `tobytes` along with all other `UCXAddress` methods needing the `bytes` representation.

Plus [`bytes` implementation of `__hash__`]( https://github.com/python/cpython/blob/9a89f1bf1e7bb819fe7240be779c99a84f47ea46/Objects/bytesobject.c#L1570-L1581 ) maintains a cache of the hashed value. Meaning that when `UCXAddress.__hash__` calls `hash` on the cached `bytes` object, the cached hash value for `bytes` can be used as well. So `hash`ing of `UCXAddress` benefits not only from caching the `bytes` object, but also the hash value. Meaning subsequent `hash` calls can retrieve the cached hash value.

In summary this should cutdown on the cost of repeated calls to things like `bytes`, `hash`, etc. on `UCXAddress` objects.