### PR TITLE
Simplify header generation in UCXX worker test

### DIFF
--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -17,6 +17,14 @@ from ucxx.testing import join_processes, terminate_process
 mp = mp.get_context("spawn")
 
 
+# Fixed frame size
+FRAME_SIZE = 10000
+
+
+# Header format: Recv Tag (Q) + Send Tag (Q) + UCXAddress.length (Q)
+HEADER_STRUCT = struct.Struct("QQQ")
+
+
 def _test_from_worker_address_server(queue, timeout):
     async def run():
         # Send worker address to client process via multiprocessing.Queue
@@ -101,32 +109,19 @@ def test_from_worker_address(pytestconfig):
     terminate_process(server)
 
 
-def _get_address_header_info():
-    # Fixed frame size
-    frame_size = 10000
-
-    # Header format: Recv Tag (Q) + Send Tag (Q) + UCXAddress.length (Q)
-    header_fmt = "QQQ"
-    header_fmt_size = struct.calcsize(header_fmt)
-
-    return {
-        "frame_size": frame_size,
-        "header_fmt": header_fmt,
-        "header_fmt_size": header_fmt_size,
-    }
-
-
 def _pack_address_and_tag(address, recv_tag, send_tag):
-    header_info = _get_address_header_info()
-
-    fixed_size_address_packed = np.empty(header_info["frame_size"], dtype=np.uint8)
-    struct.pack_into(
-        f"""{header_info["header_fmt"]}{address.length}s""",
+    fixed_size_address_packed = np.empty(FRAME_SIZE, dtype=np.uint8)
+    HEADER_STRUCT.pack_into(
         fixed_size_address_packed,  # Buffer to fill
         0,  # Starting Offset
         recv_tag,  # Recv Tag
         send_tag,  # Send Tag
         address.length,  # Address buffer length
+    )
+    struct.pack_into(
+        f"{address.length}s",
+        fixed_size_address_packed,  # Buffer to fill & Starting Offset
+        HEADER_STRUCT.size,  # Offset by header
         bytes(address),  # Address buffer
     )
 
@@ -134,16 +129,13 @@ def _pack_address_and_tag(address, recv_tag, send_tag):
 
 
 def _unpack_address_and_tag(address_packed):
-    header_info = _get_address_header_info()
-
-    recv_tag, send_tag, address_length = struct.unpack_from(
-        header_info["header_fmt"],
+    recv_tag, send_tag, address_length = HEADER_STRUCT.unpack_from(
         address_packed,
     )
     (address,) = struct.unpack_from(
         f"{address_length}s",
         address_packed,
-        header_info["header_fmt_size"],
+        HEADER_STRUCT.size,
     )
 
     # Swap send and recv tags, as they are used by the remote process in the
@@ -181,12 +173,10 @@ def _test_from_worker_address_server_fixedsize(num_nodes, queue, timeout):
         for i in range(num_nodes):
             queue.put(address)
 
-        header_info = _get_address_header_info()
-
         server_tasks = []
         for i in range(num_nodes):
             # Receive fixed-size address+tag buffer on tag 0
-            packed_remote_address = np.empty(header_info["frame_size"], dtype=np.uint8)
+            packed_remote_address = np.empty(FRAME_SIZE, dtype=np.uint8)
             await ucxx.recv(packed_remote_address, tag=0)
 
             # Create an async task for client

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -110,9 +110,9 @@ def test_from_worker_address(pytestconfig):
 
 
 def _pack_address_and_tag(address, recv_tag, send_tag):
-    fixed_size_address_packed = np.empty(FRAME_SIZE, dtype=np.uint8)
+    address_packed = np.empty(FRAME_SIZE, dtype=np.uint8)
     HEADER_STRUCT.pack_into(
-        fixed_size_address_packed,  # Buffer to fill
+        address_packed,  # Buffer to fill
         0,  # Starting Offset
         recv_tag,  # Recv Tag
         send_tag,  # Send Tag
@@ -121,9 +121,9 @@ def _pack_address_and_tag(address, recv_tag, send_tag):
 
     address_start = HEADER_STRUCT.size
     address_stop = address_start + address.length
-    fixed_size_address_packed[address_start:address_stop] = memoryview(address)
+    address_packed[address_start:address_stop] = memoryview(address)
 
-    return fixed_size_address_packed
+    return address_packed
 
 
 def _unpack_address_and_tag(address_packed):

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -146,15 +146,20 @@ def _pack_address_and_tag(address, recv_tag, send_tag):
 def _unpack_address_and_tag(address_packed):
     address_info = _get_address_info()
 
-    recv_tag, send_tag, address_length, address_padded = struct.unpack(
-        address_info["fixed_size_address_buffer_fmt"],
+    recv_tag, send_tag, address_length = struct.unpack_from(
+        address_info["header_fmt"],
         address_packed,
+    )
+    (address,) = struct.unpack_from(
+        f"{address_length}s",
+        address_packed,
+        address_info["header_fmt_size"],
     )
 
     # Swap send and recv tags, as they are used by the remote process in the
     # opposite direction.
     return {
-        "address": address_padded[:address_length],
+        "address": address,
         "recv_tag": send_tag,
         "send_tag": recv_tag,
     }

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -127,7 +127,7 @@ def _pack_address_and_tag(address, recv_tag, send_tag):
 
 
 def _unpack_address_and_tag(address_packed):
-    address_packed = memoryview(address_packed)
+    address_packed = memoryview(address_packed).toreadonly()
 
     recv_tag, send_tag, address_length = HEADER_STRUCT.unpack_from(
         address_packed,

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -111,6 +111,7 @@ def test_from_worker_address(pytestconfig):
 
 def _pack_address_and_tag(address, recv_tag, send_tag):
     address_packed = np.empty(FRAME_SIZE, dtype=np.uint8)
+
     HEADER_STRUCT.pack_into(
         address_packed,  # Buffer to fill
         0,  # Starting Offset

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -107,9 +107,10 @@ def _get_address_info(address=None):
 
     # Header format: Recv Tag (Q) + Send Tag (Q) + UCXAddress.length (Q)
     header_fmt = "QQQ"
+    header_fmt_size = struct.calcsize(header_fmt)
 
     # Data length
-    data_length = frame_size - struct.calcsize(header_fmt)
+    data_length = frame_size - header_fmt_size
 
     # Header + UCXAddress string + padding
     fixed_size_address_buffer_fmt = f"{header_fmt}{data_length}s"
@@ -118,6 +119,8 @@ def _get_address_info(address=None):
 
     return {
         "frame_size": frame_size,
+        "header_fmt": header_fmt,
+        "header_fmt_size": header_fmt_size,
         "data_length": data_length,
         "fixed_size_address_buffer_fmt": fixed_size_address_buffer_fmt,
     }

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -109,20 +109,10 @@ def _get_address_info(address=None):
     header_fmt = "QQQ"
     header_fmt_size = struct.calcsize(header_fmt)
 
-    # Data length
-    data_length = frame_size - header_fmt_size
-
-    # Header + UCXAddress string + padding
-    fixed_size_address_buffer_fmt = f"{header_fmt}{data_length}s"
-
-    assert struct.calcsize(fixed_size_address_buffer_fmt) == frame_size
-
     return {
         "frame_size": frame_size,
         "header_fmt": header_fmt,
         "header_fmt_size": header_fmt_size,
-        "data_length": data_length,
-        "fixed_size_address_buffer_fmt": fixed_size_address_buffer_fmt,
     }
 
 

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -20,7 +20,6 @@ mp = mp.get_context("spawn")
 # Fixed frame size
 FRAME_SIZE = 10000
 
-
 # Header format: Recv Tag (Q) + Send Tag (Q) + UCXAddress.length (Q)
 HEADER_STRUCT = struct.Struct("QQQ")
 

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -101,7 +101,7 @@ def test_from_worker_address(pytestconfig):
     terminate_process(server)
 
 
-def _get_address_info(address=None):
+def _get_address_header_info():
     # Fixed frame size
     frame_size = 10000
 
@@ -117,11 +117,11 @@ def _get_address_info(address=None):
 
 
 def _pack_address_and_tag(address, recv_tag, send_tag):
-    address_info = _get_address_info(address)
+    header_info = _get_address_header_info()
 
-    fixed_size_address_packed = np.empty(address_info["frame_size"], dtype=np.uint8)
+    fixed_size_address_packed = np.empty(header_info["frame_size"], dtype=np.uint8)
     struct.pack_into(
-        f"""{address_info["header_fmt"]}{address.length}s""",
+        f"""{header_info["header_fmt"]}{address.length}s""",
         fixed_size_address_packed,  # Buffer to fill
         0,  # Starting Offset
         recv_tag,  # Recv Tag
@@ -134,16 +134,16 @@ def _pack_address_and_tag(address, recv_tag, send_tag):
 
 
 def _unpack_address_and_tag(address_packed):
-    address_info = _get_address_info()
+    header_info = _get_address_header_info()
 
     recv_tag, send_tag, address_length = struct.unpack_from(
-        address_info["header_fmt"],
+        header_info["header_fmt"],
         address_packed,
     )
     (address,) = struct.unpack_from(
         f"{address_length}s",
         address_packed,
-        address_info["header_fmt_size"],
+        header_info["header_fmt_size"],
     )
 
     # Swap send and recv tags, as they are used by the remote process in the
@@ -181,12 +181,12 @@ def _test_from_worker_address_server_fixedsize(num_nodes, queue, timeout):
         for i in range(num_nodes):
             queue.put(address)
 
-        address_info = _get_address_info()
+        header_info = _get_address_header_info()
 
         server_tasks = []
         for i in range(num_nodes):
             # Receive fixed-size address+tag buffer on tag 0
-            packed_remote_address = np.empty(address_info["frame_size"], dtype=np.uint8)
+            packed_remote_address = np.empty(header_info["frame_size"], dtype=np.uint8)
             await ucxx.recv(packed_remote_address, tag=0)
 
             # Create an async task for client

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -128,6 +128,8 @@ def _pack_address_and_tag(address, recv_tag, send_tag):
 
 
 def _unpack_address_and_tag(address_packed):
+    address_packed = memoryview(address_packed)
+
     recv_tag, send_tag, address_length = HEADER_STRUCT.unpack_from(
         address_packed,
     )

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -118,12 +118,10 @@ def _pack_address_and_tag(address, recv_tag, send_tag):
         send_tag,  # Send Tag
         address.length,  # Address buffer length
     )
-    struct.pack_into(
-        f"{address.length}s",
-        fixed_size_address_packed,  # Buffer to fill & Starting Offset
-        HEADER_STRUCT.size,  # Offset by header
-        bytes(address),  # Address buffer
-    )
+
+    address_start = HEADER_STRUCT.size
+    address_stop = address_start + address.length
+    fixed_size_address_packed[address_start:address_stop] = memoryview(address)
 
     return fixed_size_address_packed
 

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -130,11 +130,10 @@ def _unpack_address_and_tag(address_packed):
     recv_tag, send_tag, address_length = HEADER_STRUCT.unpack_from(
         address_packed,
     )
-    (address,) = struct.unpack_from(
-        f"{address_length}s",
-        address_packed,
-        HEADER_STRUCT.size,
-    )
+
+    address_start = HEADER_STRUCT.size
+    address_stop = address_start + address_length
+    address = address_packed[address_start:address_stop]
 
     # Swap send and recv tags, as they are used by the remote process in the
     # opposite direction.

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -131,7 +131,7 @@ def _pack_address_and_tag(address, recv_tag, send_tag):
 
     fixed_size_address_packed = np.empty(address_info["frame_size"], dtype=np.uint8)
     struct.pack_into(
-        address_info["fixed_size_address_buffer_fmt"],
+        f"""{address_info["header_fmt"]}{address.length}s""",
         fixed_size_address_packed,  # Buffer to fill
         0,  # Starting Offset
         recv_tag,  # Recv Tag

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -137,8 +137,6 @@ def _pack_address_and_tag(address, recv_tag, send_tag):
         bytes(address),  # Address buffer
     )
 
-    assert len(fixed_size_address_packed) == address_info["frame_size"]
-
     return fixed_size_address_packed
 
 


### PR DESCRIPTION
Follow up to PR: https://github.com/rapidsai/ucxx/pull/625

Move from a function generating constants used in message headers to a couple global constants used in message packing/unpacking functions. This reduces the lines of code. Also it benefits from building things like a `struct.Struct` object once and reusing it for serializing message header metadata.

Additionally this ensures zero-copy packing of `UCXXAddress` when packing/unpacking it. Thus eliminating some intermediate `bytes` objects that are otherwise created.

Lastly this avoids explicit writes that `struct.pack` did to fill in the padded bytes with `\0`. Similarly `struct.unpack` included both the address and the pad values, which it copied to a large `bytes` object containing both. Given the padding is only there to ensure the frame is of a specific size, there is no need to fill out the pad values or copy them around. As a result this change now ensures no extra effort is put into the pad values.