### PR TITLE
Fix decrementing active clients upon exception in listener callback

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
@@ -265,10 +265,6 @@ async def test_ping_pong_numba(ucxx_loop):
 
 @pytest.mark.parametrize("protocol", ["ucx", "ucxx"])
 @pytest.mark.parametrize("processes", [True, False])
-@pytest.mark.flaky(
-    reruns=3,
-    only_rerun="Trying to reset UCX but not all Endpoints and/or Listeners are closed",
-)
 @gen_test()
 async def test_ucxx_localcluster(ucxx_loop, cleanup, protocol, processes):
     async with LocalCluster(
@@ -365,10 +361,6 @@ async def test_cuda_context(
                     )
 
 
-@pytest.mark.flaky(
-    reruns=3,
-    only_rerun="Trying to reset UCX but not all Endpoints and/or Listeners are closed",
-)
 @gen_test()
 async def test_transpose(
     ucxx_loop,
@@ -423,10 +415,6 @@ async def test_comm_closed_on_read_error():
     assert writer.closed()
 
 
-@pytest.mark.flaky(
-    reruns=3,
-    only_rerun="Trying to reset UCX but not all Endpoints and/or Listeners are closed",
-)
 @gen_test()
 async def test_embedded_cupy_array(
     ucxx_loop,

--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -142,9 +142,6 @@ async def _listener_handler_coroutine(
     ident,
     active_clients,
 ):
-    # def _listener_handler_coroutine(
-    #     conn_request, ctx, func, endpoint_error_handling, ident, active_clients
-    # ):
     # We create the Endpoint in five steps:
     #  1) Create endpoint from conn_request
     #  2) Generate unique IDs to use as tags
@@ -152,56 +149,59 @@ async def _listener_handler_coroutine(
     #  4) Setup control receive callback
     #  5) Execute the listener's callback function
     active_clients.inc(ident)
-    endpoint = conn_request
-
-    seed = os.urandom(16)
-    msg_tag = hash64bits("msg_tag", seed, endpoint.handle)
-
+    ep = None
     try:
-        peer_info = await exchange_peer_info(
-            endpoint=endpoint,
-            msg_tag=msg_tag,
-            listener=True,
-            connect_timeout=connect_timeout,
-        )
-    except UCXMessageTruncatedError:
-        # A truncated message occurs if the remote endpoint closed before
-        # exchanging peer info, in that case we should raise the endpoint
-        # error instead.
-        endpoint.raise_on_error()
-    tags = {
-        "msg_send": peer_info["msg_tag"],
-        "msg_recv": msg_tag,
-    }
-    ep = Endpoint(endpoint=endpoint, ctx=ctx, tags=tags)
+        endpoint = conn_request
 
-    logger.debug(
-        "_listener_handler() server: %s, error handling: %s, msg-tag-send: %s, "
-        "msg-tag-recv: %s"
-        % (
-            hex(endpoint.handle),
-            endpoint_error_handling,
-            hex(ep._tags["msg_send"]),
-            hex(ep._tags["msg_recv"]),
-        )
-    )
+        seed = os.urandom(16)
+        msg_tag = hash64bits("msg_tag", seed, endpoint.handle)
 
-    # Removing references here to avoid delayed clean up
-    del ctx
-
-    # Finally, we call `func`
-    if inspect.iscoroutinefunction(func):
         try:
-            await func(ep)
-        except Exception as e:
-            logger.error(f"Uncatched listener callback error {type(e)}: {e}")
-    else:
-        func(ep)
+            peer_info = await exchange_peer_info(
+                endpoint=endpoint,
+                msg_tag=msg_tag,
+                listener=True,
+                connect_timeout=connect_timeout,
+            )
+        except UCXMessageTruncatedError:
+            # A truncated message occurs if the remote endpoint closed before
+            # exchanging peer info, in that case we should raise the endpoint
+            # error instead.
+            endpoint.raise_on_error()
+            return
+        tags = {
+            "msg_send": peer_info["msg_tag"],
+            "msg_recv": msg_tag,
+        }
+        ep = Endpoint(endpoint=endpoint, ctx=ctx, tags=tags)
 
-    active_clients.dec(ident)
+        logger.debug(
+            "_listener_handler() server: %s, error handling: %s, msg-tag-send: %s, "
+            "msg-tag-recv: %s"
+            % (
+                hex(endpoint.handle),
+                endpoint_error_handling,
+                hex(ep._tags["msg_send"]),
+                hex(ep._tags["msg_recv"]),
+            )
+        )
 
-    # Ensure no references to `ep` remain to permit garbage collection.
-    del ep
+        # Removing references here to avoid delayed clean up
+        del ctx
+
+        # Finally, we call `func`
+        if inspect.iscoroutinefunction(func):
+            try:
+                await func(ep)
+            except Exception as e:
+                logger.error(f"Uncatched listener callback error {type(e)}: {e}")
+        else:
+            func(ep)
+    except Exception as e:
+        logger.error(f"Unexpected error in listener handler coroutine {type(e)}: {e}")
+    finally:
+        active_clients.dec(ident)
+        del ep
 
 
 def _listener_handler(

--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -193,12 +193,12 @@ async def _listener_handler_coroutine(
         if inspect.iscoroutinefunction(func):
             try:
                 await func(ep)
-            except Exception as e:
-                logger.error(f"Uncatched listener callback error {type(e)}: {e}")
+            except Exception:
+                logger.exception("Uncaught listener callback error")
         else:
             func(ep)
-    except Exception as e:
-        logger.error(f"Unexpected error in listener handler coroutine {type(e)}: {e}")
+    except Exception:
+        logger.exception("Unexpected error in listener handler coroutine")
     finally:
         active_clients.dec(ident)
         del ep


### PR DESCRIPTION
Wrapped the body of `_listener_handler_coroutine` in `try`/`finally` so that active_clients.dec(ident) and del ep always execute, even if:
* `exchange_peer_info` times out or is cancelled
* `endpoint.raise_on_error()` raises
* `func(ep)` (the callback) raises an unexpected exception
* The coroutine is externally cancelled

This ensures the coroutine frame never keeps `ctx` / `ApplicationContext` alive after the coroutine finishes (normally or abnormally).

Removed all four `@pytest.mark.flaky` decorators that were masking this bug in distributed-ucxx tests. With the listener fix in place, the retries should no longer be needed.
