### PR TITLE
Ensure distributed-ucxx `read()` aborts endpoint on frame errors

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/ucxx.py
@@ -524,9 +524,7 @@ class UCXX(Comm):
                 # "low-level" exception. The only safe thing to do is to abort.
                 # (See also https://github.com/dask/distributed/pull/6574).
                 self.abort()
-                raise CommClosedError(
-                    f"Connection closed by writer.\nInner exception: {e!r}"
-                )
+                raise CommClosedError("Connection closed by writer") from e
         else:
             try:
                 # Recv meta data
@@ -551,9 +549,7 @@ class UCXX(Comm):
                 # "low-level" exception. The only safe thing to do is to abort.
                 # (See also https://github.com/dask/distributed/pull/6574).
                 self.abort()
-                raise CommClosedError(
-                    f"Connection closed by writer.\nInner exception: {e!r}"
-                )
+                raise CommClosedError("Connection closed by writer") from e
             else:
                 try:
                     # Recv frames
@@ -582,9 +578,7 @@ class UCXX(Comm):
                     # "low-level" exception. The only safe thing to do is to abort.
                     # (See also https://github.com/dask/distributed/pull/6574).
                     self.abort()
-                    raise CommClosedError(
-                        f"Connection closed by writer.\nInner exception: {e!r}"
-                    )
+                    raise CommClosedError("Connection closed by writer") from e
 
         try:
             return await from_frames(

--- a/python/distributed-ucxx/distributed_ucxx/ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/ucxx.py
@@ -555,26 +555,26 @@ class UCXX(Comm):
                     f"Connection closed by writer.\nInner exception: {e!r}"
                 )
             else:
-                # Recv frames
-                frames = [
-                    device_array(each_size) if is_cuda else host_array(each_size)
-                    for is_cuda, each_size in zip(cuda_frames, sizes)
-                ]
-                cuda_recv_frames, recv_frames = zip(
-                    *(
-                        (is_cuda, each_frame)
-                        for is_cuda, each_frame in zip(cuda_frames, frames)
-                        if nbytes(each_frame) > 0
-                    )
-                )
-
-                # It is necessary to first populate `frames` with CUDA arrays and
-                # synchronize the default stream before starting receiving to ensure
-                # buffers have been allocated
-                if any(cuda_recv_frames):
-                    synchronize_stream(CudaStream.Default)
-
                 try:
+                    # Recv frames
+                    frames = [
+                        device_array(each_size) if is_cuda else host_array(each_size)
+                        for is_cuda, each_size in zip(cuda_frames, sizes)
+                    ]
+                    cuda_recv_frames, recv_frames = zip(
+                        *(
+                            (is_cuda, each_frame)
+                            for is_cuda, each_frame in zip(cuda_frames, frames)
+                            if nbytes(each_frame) > 0
+                        )
+                    )
+
+                    # It is necessary to first populate `frames` with CUDA arrays
+                    # and synchronize the default stream before starting receiving
+                    # to ensure buffers have been allocated
+                    if any(cuda_recv_frames):
+                        synchronize_stream(CudaStream.Default)
+
                     for each_frame in recv_frames:
                         await self.ep.recv(each_frame)
                 except BaseException as e:


### PR DESCRIPTION
The else block of `read()` had a `try`/`except` `BaseException` that only wrapped the frame recv loop, leaving frame allocation and the `zip()` unpacking unprotected, so when corrupted metadata during shutdown caused a `ValueError` there, the endpoint was never aborted, leaking it and blocking `ucxx.reset()` at teardown. The fix widens that existing `try`/`except` `BaseException` to cover the entire `else` block, ensuring any error during frame processing properly aborts the endpoint and raises `CommClosedError`.