### PR TITLE
Surface subprocess exceptions in Python tests

### DIFF
--- a/python/ucxx/ucxx/_lib/tests/test_cancel.py
+++ b/python/ucxx/ucxx/_lib/tests/test_cancel.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import multiprocessing as mp
@@ -7,7 +7,7 @@ import pytest
 
 import ucxx._lib.libucxx as ucx_api
 from ucxx._lib.arr import Array
-from ucxx.testing import join_processes, terminate_process
+from ucxx.testing import join_processes, run_in_subprocess, terminate_process
 
 mp = mp.get_context("spawn")
 
@@ -70,16 +70,18 @@ def _client_cancel(queue):
 
 def test_message_probe():
     queue = mp.Queue()
+    server_error_q = mp.Queue()
+    client_error_q = mp.Queue()
     server = mp.Process(
-        target=_server_cancel,
-        args=(queue,),
+        target=run_in_subprocess,
+        args=(_server_cancel, server_error_q, queue),
     )
     server.start()
     client = mp.Process(
-        target=_client_cancel,
-        args=(queue,),
+        target=run_in_subprocess,
+        args=(_client_cancel, client_error_q, queue),
     )
     client.start()
     join_processes([client, server], timeout=10)
-    terminate_process(client)
-    terminate_process(server)
+    terminate_process(client, error_queue=client_error_q)
+    terminate_process(server, error_queue=server_error_q)

--- a/python/ucxx/ucxx/_lib/tests/test_endpoint.py
+++ b/python/ucxx/ucxx/_lib/tests/test_endpoint.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import multiprocessing as mp
@@ -8,7 +8,12 @@ import pytest
 
 import ucxx._lib.libucxx as ucx_api
 from ucxx._lib.arr import Array
-from ucxx.testing import join_processes, terminate_process, wait_requests
+from ucxx.testing import (
+    join_processes,
+    run_in_subprocess,
+    terminate_process,
+    wait_requests,
+)
 
 mp = mp.get_context("spawn")
 
@@ -97,17 +102,19 @@ def _client(port, server_close_callback):
 @pytest.mark.parametrize("server_close_callback", [True, False])
 def test_close_callback(server_close_callback):
     queue = mp.Queue()
+    server_error_q = mp.Queue()
+    client_error_q = mp.Queue()
     server = mp.Process(
-        target=_server,
-        args=(queue, server_close_callback),
+        target=run_in_subprocess,
+        args=(_server, server_error_q, queue, server_close_callback),
     )
     server.start()
     port = queue.get()
     client = mp.Process(
-        target=_client,
-        args=(port, server_close_callback),
+        target=run_in_subprocess,
+        args=(_client, client_error_q, port, server_close_callback),
     )
     client.start()
     join_processes([client, server], timeout=10)
-    terminate_process(client)
-    terminate_process(server)
+    terminate_process(client, error_queue=client_error_q)
+    terminate_process(server, error_queue=server_error_q)

--- a/python/ucxx/ucxx/_lib/tests/test_probe.py
+++ b/python/ucxx/ucxx/_lib/tests/test_probe.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import multiprocessing as mp
@@ -7,7 +7,12 @@ import pytest
 
 from ucxx._lib import libucxx as ucx_api
 from ucxx._lib.arr import Array
-from ucxx.testing import join_processes, terminate_process, wait_requests
+from ucxx.testing import (
+    join_processes,
+    run_in_subprocess,
+    terminate_process,
+    wait_requests,
+)
 
 mp = mp.get_context("spawn")
 
@@ -189,10 +194,18 @@ def _client_probe(queue, probe_type):
 @pytest.mark.parametrize("api_type", ["worker", "endpoint"])
 def test_message_probe(probe_type, api_type):
     queue = mp.Queue()
-    server = mp.Process(target=_server_probe, args=(queue, probe_type, api_type))
+    server_error_q = mp.Queue()
+    client_error_q = mp.Queue()
+    server = mp.Process(
+        target=run_in_subprocess,
+        args=(_server_probe, server_error_q, queue, probe_type, api_type),
+    )
     server.start()
-    client = mp.Process(target=_client_probe, args=(queue, probe_type))
+    client = mp.Process(
+        target=run_in_subprocess,
+        args=(_client_probe, client_error_q, queue, probe_type),
+    )
     client.start()
     join_processes([client, server], timeout=60)
-    terminate_process(client)
-    terminate_process(server)
+    terminate_process(client, error_queue=client_error_q)
+    terminate_process(server, error_queue=server_error_q)

--- a/python/ucxx/ucxx/_lib/tests/test_server_client.py
+++ b/python/ucxx/ucxx/_lib/tests/test_server_client.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import multiprocessing as mp
@@ -9,7 +9,7 @@ import pytest
 
 import ucxx._lib.libucxx as ucx_api
 from ucxx._lib.arr import Array
-from ucxx.testing import terminate_process, wait_requests
+from ucxx.testing import run_in_subprocess, terminate_process, wait_requests
 
 mp = mp.get_context("spawn")
 
@@ -182,18 +182,36 @@ def _echo_client(transfer_api, msg_size, progress_mode, port):
 @pytest.mark.parametrize("progress_mode", ["blocking", "thread"])
 def test_server_client(transfer_api, msg_size, progress_mode):
     put_queue, get_queue = mp.Queue(), mp.Queue()
+    server_error_q = mp.Queue()
+    client_error_q = mp.Queue()
     server = mp.Process(
-        target=_echo_server,
-        args=(put_queue, get_queue, transfer_api, msg_size, progress_mode),
+        target=run_in_subprocess,
+        args=(
+            _echo_server,
+            server_error_q,
+            put_queue,
+            get_queue,
+            transfer_api,
+            msg_size,
+            progress_mode,
+        ),
     )
     server.start()
     port = get_queue.get()
     client = mp.Process(
-        target=_echo_client, args=(transfer_api, msg_size, progress_mode, port)
+        target=run_in_subprocess,
+        args=(
+            _echo_client,
+            client_error_q,
+            transfer_api,
+            msg_size,
+            progress_mode,
+            port,
+        ),
     )
     client.start()
     client.join(timeout=60)
-    terminate_process(client)
+    terminate_process(client, error_queue=client_error_q)
     put_queue.put("Finished")
     server.join(timeout=10)
-    terminate_process(server)
+    terminate_process(server, error_queue=server_error_q)

--- a/python/ucxx/ucxx/_lib/tests/test_utils.py
+++ b/python/ucxx/ucxx/_lib/tests/test_utils.py
@@ -191,7 +191,7 @@ def test_run_in_subprocess_failure_terminate_surfaces_traceback(mp_context):
     with pytest.raises(
         RuntimeError,
         match=(
-            r"Process did not exit cleanly.*\n\nSubprocess traceback:"
+            r"(?s)Process did not exit cleanly.*Subprocess traceback:"
             r".*RuntimeError.*subprocess raised"
         ),
     ):

--- a/python/ucxx/ucxx/_lib/tests/test_utils.py
+++ b/python/ucxx/ucxx/_lib/tests/test_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import multiprocessing
@@ -8,7 +8,7 @@ from multiprocessing.queues import Empty
 
 import pytest
 
-from ucxx.testing import join_processes, terminate_process
+from ucxx.testing import join_processes, run_in_subprocess, terminate_process
 
 
 def _test_process(queue):
@@ -19,6 +19,14 @@ def _test_process(queue):
             return
         except Empty:
             pass
+
+
+def _subprocess_target_success(result_queue):
+    result_queue.put("done")
+
+
+def _subprocess_target_failure():
+    raise RuntimeError("subprocess raised")
 
 
 @pytest.mark.parametrize("mp_context", ["default", "fork", "forkserver", "spawn"])
@@ -117,3 +125,74 @@ def test_join_processes(mp_context, num_processes):
         except RuntimeError:
             # The process has to be killed and that will raise a `RuntimeError`
             pass
+
+
+@pytest.mark.parametrize("mp_context", ["default", "fork", "forkserver", "spawn"])
+def test_run_in_subprocess_success(mp_context):
+    mp = (
+        multiprocessing
+        if mp_context == "default"
+        else multiprocessing.get_context(mp_context)
+    )
+
+    result_q = mp.Queue()
+    error_q = mp.Queue()
+    proc = mp.Process(
+        target=run_in_subprocess,
+        args=(_subprocess_target_success, error_q, result_q),
+    )
+    proc.start()
+    proc.join()
+
+    assert proc.exitcode == 0
+    assert result_q.get_nowait() == "done"
+    with pytest.raises(Empty):
+        error_q.get_nowait()
+
+
+@pytest.mark.parametrize("mp_context", ["default", "fork", "forkserver", "spawn"])
+def test_run_in_subprocess_failure(mp_context):
+    mp = (
+        multiprocessing
+        if mp_context == "default"
+        else multiprocessing.get_context(mp_context)
+    )
+
+    error_q = mp.Queue()
+    proc = mp.Process(
+        target=run_in_subprocess,
+        args=(_subprocess_target_failure, error_q),
+    )
+    proc.start()
+    proc.join()
+
+    assert proc.exitcode != 0
+    tb = error_q.get_nowait()
+    assert "RuntimeError" in tb
+    assert "subprocess raised" in tb
+
+
+@pytest.mark.parametrize("mp_context", ["default", "fork", "forkserver", "spawn"])
+def test_run_in_subprocess_failure_terminate_surfaces_traceback(mp_context):
+    mp = (
+        multiprocessing
+        if mp_context == "default"
+        else multiprocessing.get_context(mp_context)
+    )
+
+    error_q = mp.Queue()
+    proc = mp.Process(
+        target=run_in_subprocess,
+        args=(_subprocess_target_failure, error_q),
+    )
+    proc.start()
+    proc.join()
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"Process did not exit cleanly.*\n\nSubprocess traceback:"
+            r".*RuntimeError.*subprocess raised"
+        ),
+    ):
+        terminate_process(proc, error_queue=error_q)

--- a/python/ucxx/ucxx/_lib_async/tests/test_disconnect.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_disconnect.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import asyncio
@@ -16,7 +16,7 @@ from ucxx._lib_async.utils_test import (
     compute_timeouts,
     wait_listener_client_handlers,
 )
-from ucxx.testing import terminate_process
+from ucxx.testing import run_in_subprocess, terminate_process
 
 mp = mp.get_context("spawn")
 
@@ -130,14 +130,30 @@ def test_shutdown_unexpected_closed_peer(pytestconfig, caplog, endpoint_error_ha
 
     client_queue = mp.Queue()
     server_queue = mp.Queue()
+    p1_error_q = mp.Queue()
+    p2_error_q = mp.Queue()
     p1 = mp.Process(
-        target=_test_shutdown_unexpected_closed_peer_server,
-        args=(client_queue, server_queue, endpoint_error_handling, async_timeout),
+        target=run_in_subprocess,
+        args=(
+            _test_shutdown_unexpected_closed_peer_server,
+            p1_error_q,
+            client_queue,
+            server_queue,
+            endpoint_error_handling,
+            async_timeout,
+        ),
     )
     p1.start()
     p2 = mp.Process(
-        target=_test_shutdown_unexpected_closed_peer_client,
-        args=(client_queue, server_queue, endpoint_error_handling, async_timeout),
+        target=run_in_subprocess,
+        args=(
+            _test_shutdown_unexpected_closed_peer_client,
+            p2_error_q,
+            client_queue,
+            server_queue,
+            endpoint_error_handling,
+            async_timeout,
+        ),
     )
     p2.start()
 
@@ -147,5 +163,5 @@ def test_shutdown_unexpected_closed_peer(pytestconfig, caplog, endpoint_error_ha
     server_queue.put("client is down")
     p1.join(timeout=join_timeout)
 
-    terminate_process(p2)
-    terminate_process(p1)
+    terminate_process(p2, error_queue=p2_error_q)
+    terminate_process(p1, error_queue=p1_error_q)

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address.py
@@ -12,7 +12,7 @@ import pytest
 import ucxx
 from ucxx._lib_async.utils import get_event_loop, hash64bits
 from ucxx._lib_async.utils_test import compute_timeouts
-from ucxx.testing import join_processes, terminate_process
+from ucxx.testing import join_processes, run_in_subprocess, terminate_process
 
 mp = mp.get_context("spawn")
 
@@ -90,22 +90,24 @@ def test_from_worker_address(pytestconfig):
     async_timeout, join_timeout = compute_timeouts(pytestconfig)
 
     queue = mp.Queue()
+    server_error_q = mp.Queue()
+    client_error_q = mp.Queue()
 
     server = mp.Process(
-        target=_test_from_worker_address_server,
-        args=(queue, async_timeout),
+        target=run_in_subprocess,
+        args=(_test_from_worker_address_server, server_error_q, queue, async_timeout),
     )
     server.start()
 
     client = mp.Process(
-        target=_test_from_worker_address_client,
-        args=(queue, async_timeout),
+        target=run_in_subprocess,
+        args=(_test_from_worker_address_client, client_error_q, queue, async_timeout),
     )
     client.start()
 
     join_processes([client, server], timeout=join_timeout)
-    terminate_process(client)
-    terminate_process(server)
+    terminate_process(client, error_queue=client_error_q)
+    terminate_process(server, error_queue=server_error_q)
 
 
 def _pack_address_and_tag(address, recv_tag, send_tag):
@@ -235,23 +237,38 @@ def test_from_worker_address_multinode(pytestconfig, num_nodes):
     async_timeout, join_timeout = compute_timeouts(pytestconfig)
 
     queue = mp.Queue()
+    server_error_q = mp.Queue()
 
     server = mp.Process(
-        target=_test_from_worker_address_server_fixedsize,
-        args=(num_nodes, queue, async_timeout),
+        target=run_in_subprocess,
+        args=(
+            _test_from_worker_address_server_fixedsize,
+            server_error_q,
+            num_nodes,
+            queue,
+            async_timeout,
+        ),
     )
     server.start()
 
     clients = []
+    client_error_qs = []
     for i in range(num_nodes):
+        client_error_q = mp.Queue()
         client = mp.Process(
-            target=_test_from_worker_address_client_fixedsize,
-            args=(queue, async_timeout),
+            target=run_in_subprocess,
+            args=(
+                _test_from_worker_address_client_fixedsize,
+                client_error_q,
+                queue,
+                async_timeout,
+            ),
         )
         client.start()
         clients.append(client)
+        client_error_qs.append(client_error_q)
 
     join_processes(clients + [server], timeout=join_timeout)
-    for client in clients:
-        terminate_process(client)
-    terminate_process(server)
+    for client, client_error_q in zip(clients, client_error_qs):
+        terminate_process(client, error_queue=client_error_q)
+    terminate_process(server, error_queue=server_error_q)

--- a/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address_error.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_from_worker_address_error.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import asyncio
@@ -13,7 +13,7 @@ import pytest
 import ucxx
 from ucxx._lib_async.utils import get_event_loop
 from ucxx._lib_async.utils_test import compute_timeouts
-from ucxx.testing import join_processes, terminate_process
+from ucxx.testing import join_processes, run_in_subprocess, terminate_process
 
 mp = mp.get_context("spawn")
 
@@ -172,16 +172,32 @@ def test_from_worker_address_error(pytestconfig, error_type):
 
     q1 = mp.Queue()
     q2 = mp.Queue()
+    server_error_q = mp.Queue()
+    client_error_q = mp.Queue()
 
     server = mp.Process(
-        target=_test_from_worker_address_error_server,
-        args=(q1, q2, error_type, async_timeout),
+        target=run_in_subprocess,
+        args=(
+            _test_from_worker_address_error_server,
+            server_error_q,
+            q1,
+            q2,
+            error_type,
+            async_timeout,
+        ),
     )
     server.start()
 
     client = mp.Process(
-        target=_test_from_worker_address_error_client,
-        args=(q1, q2, error_type, async_timeout),
+        target=run_in_subprocess,
+        args=(
+            _test_from_worker_address_error_client,
+            client_error_q,
+            q1,
+            q2,
+            error_type,
+            async_timeout,
+        ),
     )
     client.start()
 
@@ -190,9 +206,9 @@ def test_from_worker_address_error(pytestconfig, error_type):
         q1.put("Server closed")
 
     join_processes([client, server], timeout=join_timeout)
-    terminate_process(server)
+    terminate_process(server, error_queue=server_error_q)
     try:
-        terminate_process(client)
+        terminate_process(client, error_queue=client_error_q)
     except RuntimeError as e:
         if ucxx.get_ucx_version() < (1, 12, 0):
             if all(t in error_type for t in ["timeout", "send"]):

--- a/python/ucxx/ucxx/_lib_async/tests/test_send_recv_two_workers.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_send_recv_two_workers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import asyncio
@@ -21,7 +21,7 @@ from ucxx._lib_async.utils_test import (
     send,
     wait_listener_client_handlers,
 )
-from ucxx.testing import join_processes, terminate_process
+from ucxx.testing import join_processes, run_in_subprocess, terminate_process
 
 cupy = pytest.importorskip("cupy")
 rmm = pytest.importorskip("rmm")
@@ -229,11 +229,17 @@ def test_send_recv_cu(pytestconfig, cuda_obj_generator, comm_api):
     func = cloudpickle.dumps(cuda_obj_generator)
 
     ctx = multiprocessing.get_context("spawn")
+    server_error_q = ctx.Queue()
+    client_error_q = ctx.Queue()
     server_process = ctx.Process(
-        name="server", target=server, args=(port, func, comm_api, async_timeout)
+        name="server",
+        target=run_in_subprocess,
+        args=(server, server_error_q, port, func, comm_api, async_timeout),
     )
     client_process = ctx.Process(
-        name="client", target=client, args=(port, func, comm_api, async_timeout)
+        name="client",
+        target=run_in_subprocess,
+        args=(client, client_error_q, port, func, comm_api, async_timeout),
     )
 
     server_process.start()
@@ -246,5 +252,5 @@ def test_send_recv_cu(pytestconfig, cuda_obj_generator, comm_api):
     # Increase timeout by an additional 5s to give subprocesses a chance to
     # timeout before being forcefully terminated.
     join_processes([client_process, server_process], timeout=join_timeout)
-    terminate_process(client_process)
-    terminate_process(server_process)
+    terminate_process(client_process, error_queue=client_error_q)
+    terminate_process(server_process, error_queue=server_error_q)

--- a/python/ucxx/ucxx/testing.py
+++ b/python/ucxx/ucxx/testing.py
@@ -1,9 +1,47 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import queue as _queue_module
+import traceback as _traceback_module
 import time
 from multiprocessing.process import BaseProcess
-from typing import Type, Union
+from multiprocessing.queues import Queue as _MPQueue
+from typing import Any, Callable, Optional, Type, Union
+
+
+def run_in_subprocess(
+    target: Callable[..., Any],
+    error_queue: _MPQueue[str],
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    """Run function in a subprocess, forwarding exceptions to an error queue.
+
+    Use this as the ``target`` for ``multiprocessing.Process``, passing the
+    same ``error_queue`` to :func:`terminate_process`.  Any unhandled exception
+    raised by ``target`` will be serialized as a formatted traceback string and
+    placed in ``error_queue`` before being re-raised, so the process still
+    exits with a non-zero code.  :func:`terminate_process` then reads from
+    that queue and raises a :class:`RuntimeError` that includes the full
+    subprocess traceback rather than the generic "Process did not exit cleanly"
+    message.
+
+    Parameters
+    ----------
+    target : callable
+        The function to run in the subprocess.
+    error_queue : multiprocessing.Queue
+        Queue that receives the formatted traceback string on failure.
+    *args
+        Positional arguments forwarded to ``target``.
+    **kwargs
+        Keyword arguments forwarded to ``target``.
+    """
+    try:
+        target(*args, **kwargs)
+    except Exception:
+        error_queue.put(_traceback_module.format_exc())
+        raise
 
 
 def join_processes(
@@ -31,7 +69,9 @@ def join_processes(
 
 
 def terminate_process(
-    process: Type[BaseProcess], kill_wait: Union[float, int] = 3.0
+    process: Type[BaseProcess],
+    kill_wait: Union[float, int] = 3.0,
+    error_queue: Optional[_MPQueue[str]] = None,
 ) -> None:
     """
     Ensure a spawned process is terminated.
@@ -45,6 +85,12 @@ def terminate_process(
         The process to be terminated.
     kill_wait: float or integer
         Maximum time to wait for the kill signal to terminate the process.
+    error_queue: multiprocessing.Queue, optional
+        When the subprocess was started via :func:`run_in_subprocess`, pass
+        the same queue here.  If the process exited with a non-zero code,
+        ``terminate_process`` will pull the formatted traceback from the queue
+        and include it in the raised :class:`RuntimeError`, making the root
+        cause visible without digging into subprocess logs.
 
     Raises
     ------
@@ -65,9 +111,14 @@ def terminate_process(
     if process.is_alive():
         process.close()
     elif process.exitcode != 0:
-        raise RuntimeError(
-            f"Process did not exit cleanly (exit code: {process.exitcode})"
-        )
+        msg = f"Process did not exit cleanly (exit code: {process.exitcode})"
+        if error_queue is not None:
+            try:
+                tb = error_queue.get_nowait()
+                raise RuntimeError(f"{msg}\n\nSubprocess traceback:\n{tb}")
+            except _queue_module.Empty:
+                pass
+        raise RuntimeError(msg)
 
 
 def wait_requests(worker, progress_mode, requests):

--- a/python/ucxx/ucxx/testing.py
+++ b/python/ucxx/ucxx/testing.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import queue as _queue_module
 import traceback as _traceback_module
 import time


### PR DESCRIPTION
Add `run_in_subprocess` to `ucxx.testing`: a thin wrapper for use as a `multiprocessing.Process` target that catches any unhandled exception, serialises its traceback into a caller-supplied `multiprocessing.Queue`, and re-raises so the process still exits with a non-zero code.

Extend `terminate_process` with an optional `error_queue` parameter: when a process exits non-zero and a queue is provided, the stored traceback is included in the raised `RuntimeError` rather than the generic "Process did not exit cleanly" message.

Update all subprocess-based tests to use this pattern so that the root cause of a failure is immediately visible in CI output instead of being silently swallowed by the subprocess boundary.

Add tests for both functions to the testing-utilities test suite.