### PR TITLE
Fix `ApplicationContext` reference cycle and unhandled write exceptions

### DIFF
--- a/cpp/include/ucxx/inflight_requests.h
+++ b/cpp/include/ucxx/inflight_requests.h
@@ -96,14 +96,22 @@ class InflightRequests {
   void remove(const std::shared_ptr<Request>& request);
 
   /**
-   * @brief Issue cancelation of all inflight requests and clear the internal container.
+   * @brief Issue cancelation of inflight requests and clear the internal container.
    *
-   * Issue cancelation of all inflight requests known to this object and clear the
-   * internal container. The total number of canceled requests is returned.
+   * Issue cancelation of inflight requests known to this object.  The total number of
+   * canceled requests is returned.
    *
+   * When `workerOnly` is `true`, only worker-scoped operations
+   * (`Request::isWorkerOperation() == true`, i.e. receive variants) are cancelled and
+   * removed; endpoint-scoped operations are left in the container untouched, on the
+   * assumption that the caller will follow up with `ucp_ep_close_nbx(FORCE)` which
+   * handles their UCT-level cleanup atomically.  When `workerOnly` is `false` (the
+   * default), all inflight requests are cancelled.
+   *
+   * @param[in] workerOnly  if `true`, cancel only worker-scoped requests.
    * @returns The total number of canceled requests.
    */
-  size_t cancelAll();
+  size_t cancelAll(bool workerOnly = false);
 
   /**
    * @brief Releases the internally-tracked containers.

--- a/cpp/include/ucxx/request.h
+++ b/cpp/include/ucxx/request.h
@@ -128,6 +128,27 @@ class Request : public Component {
   virtual void cancel();
 
   /**
+   * @brief Whether this request is worker-scoped (vs endpoint-scoped).
+   *
+   * Returns `true` for operations that are tracked by the UCP worker rather than a
+   * specific UCP endpoint, currently the receive variants (`TagReceive`,
+   * `TagReceiveWithHandle`, `AmReceive`, `StreamReceive`, `TagMultiReceive`).
+   *
+   * `Endpoint::closeBlocking()` uses this to decide which requests must be cancelled
+   * explicitly via `ucp_request_cancel`: worker-scoped requests are not cancelled by
+   * `ucp_ep_close_nbx(UCP_EP_CLOSE_FLAG_FORCE)` (which only tears down endpoint-bound
+   * state) and would otherwise hang forever. Endpoint-scoped requests are left to
+   * UCX's FORCE close, which handles their UCT-level cleanup atomically, calling
+   * `ucp_request_cancel` on them in addition to FORCE close has been observed to
+   * leave UCT-level pending queue entries referencing freed staging buffers, which
+   * the next `ucp_worker_progress()` then crashes dispatching (see
+   * test_send_recv_multi.py CUDA segfault).
+   *
+   * @returns `true` if this request is worker-scoped, `false` if endpoint-scoped.
+   */
+  [[nodiscard]] bool isWorkerOperation() const;
+
+  /**
    * @brief Return the status of the request.
    *
    * Return a `ucs_status_t` that may be used for more fine-grained error handling than

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -281,30 +281,37 @@ void Endpoint::closeBlocking(uint64_t period, uint64_t maxAttempts)
     bool submitted    = false;
     for (uint64_t i = 0; i < maxAttempts && !closeSuccess; ++i) {
       if (!submitted) {
-        // Cancel inflight requests and submit FORCE close ATOMICALLY in a
-        // single pre-callback, with no ucp_worker_progress() between them.
+        // Cancel WORKER-SCOPED inflight requests (tag_recv & friends) and submit
+        // FORCE close ATOMICALLY in a single pre-callback no
+        // ucp_worker_progress() between them, and no ucp_request_cancel() on
+        // endpoint-scoped operations.
         //
-        // Why cancel here at all (UCX FORCE close already cancels endpoint
-        // operations):
-        //   tag_recv requests are worker-scoped (ucp_tag_recv_nbx(worker, ...)),
-        //   not endpoint-scoped, so ucp_ep_close_nbx(FORCE) leaves them pending.
-        //   Without ucp_request_cancel() here, an `await ep.close()` running
-        //   alongside an outstanding `await ep.recv()` would hang forever.
-        //   See test_shutdown.py::test_{server,client}_shutdown.
+        // Why cancel anything at all (UCX FORCE close handles endpoint state):
+        //   Receive operations (`tag_recv`, `am_recv`, ...) post requests on the
+        //   UCP worker via `ucp_*_recv_nbx(worker, ...)`. ucp_ep_close_nbx(FORCE)
+        //   tears down the UCP endpoint but leaves worker-scoped requests
+        //   pending forever, an `await ep.close()` racing with an outstanding
+        //   `await ep.recv()` would hang. See
+        //   test_shutdown.py::test_{server,client}_shutdown.
+        //
+        // Why ONLY worker-scoped (not endpoint-scoped sends/RMA):
+        //   Calling ucp_request_cancel() on an endpoint-scoped tag_send and then
+        //   FORCE-closing the endpoint has been observed to leave UCT-level TCP
+        //   pending queue entries pointing at freed staging buffers; the next
+        //   ucp_worker_progress() then crashed dispatching them
+        //   (uct_tcp_pending_queue_dispatch -> uct_cuda_copy_ep_get_short ->
+        //   cuMemcpyAsync -> SIGSEGV), see test_send_recv_multi.py CUDA segfault.
+        //   FORCE close handles endpoint-scoped requests' UCT cleanup atomically
+        //   on its own, so we leave them alone.
         //
         // Why atomic with FORCE close (not as a separate pre-callback):
         //   When cancelAll and FORCE close were separate pre-callbacks (the
         //   old cancelInflightRequestsBlocking path), a full ucp_worker_progress()
-        //   ran between them.  That intermediate progress could leave UCT-level
-        //   TCP pending entries half-dispatched (mid-cuMemcpyAsync staging of
-        //   a CUDA send); the next progress after FORCE close then crashed
-        //   dispatching them on a freed staging buffer (uct_cuda_copy_ep_get_short
-        //   -> cuMemcpyAsync -> SIGSEGV).  Running them in a single pre-callback
-        //   matches the safe single-threaded ordering proven by the regression
-        //   test in cpp/tests/endpoint_close_force_tcp_cuda_race.cpp.
+        //   ran between them, see prior commit "Cancel inflight requests and
+        //   submit force-close atomically in a single pre-callback".
         if (!worker->registerGenericPre(
               [this, &status, &param]() {
-                _inflightRequests->cancelAll();
+                _inflightRequests->cancelAll(/*workerOnly=*/true);
                 status = ucp_ep_close_nbx(_handle, &param);
                 // Invalidate _handle synchronously immediately, to prevent
                 // time window where _handle` points to freed UCP memory, usually
@@ -350,9 +357,9 @@ void Endpoint::closeBlocking(uint64_t period, uint64_t maxAttempts)
     }
   } else {
     // No progress thread: cancel inflight + FORCE close back-to-back, then
-    // drive progress here.  Same atomicity reasoning as the progress-thread
+    // drive progress here. Same atomicity reasoning as the progress-thread
     // path above (no ucp_worker_progress() between cancel and FORCE close).
-    _inflightRequests->cancelAll();
+    _inflightRequests->cancelAll(/*workerOnly=*/true);
     status          = ucp_ep_close_nbx(_handle, &param);
     _originalHandle = _handle;
     _handle         = nullptr;
@@ -476,7 +483,7 @@ size_t Endpoint::cancelInflightRequestsBlocking(uint64_t period, uint64_t maxAtt
         "cancel inflight requests failed",
         __func__,
         this,
-        _handle);
+        _originalHandle != nullptr ? _originalHandle : _handle);
   } else {
     canceled = _inflightRequests->cancelAll();
   }

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -269,13 +269,6 @@ void Endpoint::closeBlocking(uint64_t period, uint64_t maxAttempts)
 {
   if (_closing.exchange(true) || _handle == nullptr) return;
 
-  size_t canceled = cancelInflightRequestsBlocking(3000000000 /* 3s */, 3);
-  ucxx_debug("ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, canceled %lu requests",
-             __func__,
-             this,
-             _handle,
-             canceled);
-
   ucp_request_param_t param{};
   if (_endpointErrorHandling)
     param = {.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS, .flags = UCP_EP_CLOSE_FLAG_FORCE};

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -281,8 +281,33 @@ void Endpoint::closeBlocking(uint64_t period, uint64_t maxAttempts)
     bool submitted    = false;
     for (uint64_t i = 0; i < maxAttempts && !closeSuccess; ++i) {
       if (!submitted) {
+        // Cancel inflight requests and submit FORCE close ATOMICALLY in a
+        // single pre-callback, with no ucp_worker_progress() between them.
+        //
+        // Why cancel here at all (UCX FORCE close already cancels endpoint
+        // operations):
+        //   tag_recv requests are worker-scoped (ucp_tag_recv_nbx(worker, ...)),
+        //   not endpoint-scoped, so ucp_ep_close_nbx(FORCE) leaves them pending.
+        //   Without ucp_request_cancel() here, an `await ep.close()` running
+        //   alongside an outstanding `await ep.recv()` would hang forever.
+        //   See test_shutdown.py::test_{server,client}_shutdown.
+        //
+        // Why atomic with FORCE close (not as a separate pre-callback):
+        //   When cancelAll and FORCE close were separate pre-callbacks (the
+        //   old cancelInflightRequestsBlocking path), a full ucp_worker_progress()
+        //   ran between them.  That intermediate progress could leave UCT-level
+        //   TCP pending entries half-dispatched (mid-cuMemcpyAsync staging of
+        //   a CUDA send); the next progress after FORCE close then crashed
+        //   dispatching them on a freed staging buffer (uct_cuda_copy_ep_get_short
+        //   -> cuMemcpyAsync -> SIGSEGV).  Running them in a single pre-callback
+        //   matches the safe single-threaded ordering proven by the regression
+        //   test in cpp/tests/endpoint_close_force_tcp_cuda_race.cpp.
         if (!worker->registerGenericPre(
-              [this, &status, &param]() { status = ucp_ep_close_nbx(_handle, &param); }, period))
+              [this, &status, &param]() {
+                _inflightRequests->cancelAll();
+                status = ucp_ep_close_nbx(_handle, &param);
+              },
+              period))
           continue;
         submitted = true;
       }
@@ -319,6 +344,10 @@ void Endpoint::closeBlocking(uint64_t period, uint64_t maxAttempts)
         _handle);
     }
   } else {
+    // No progress thread: cancel inflight + FORCE close back-to-back, then
+    // drive progress here.  Same atomicity reasoning as the progress-thread
+    // path above (no ucp_worker_progress() between cancel and FORCE close).
+    _inflightRequests->cancelAll();
     status = ucp_ep_close_nbx(_handle, &param);
     if (UCS_PTR_IS_PTR(status)) {
       ucs_status_t s;

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -306,6 +306,11 @@ void Endpoint::closeBlocking(uint64_t period, uint64_t maxAttempts)
               [this, &status, &param]() {
                 _inflightRequests->cancelAll();
                 status = ucp_ep_close_nbx(_handle, &param);
+                // Invalidate _handle synchronously immediately, to prevent
+                // time window where _handle` points to freed UCP memory, usually
+                // observed in `populateDelayedSubmission()`.
+                _originalHandle = _handle;
+                _handle         = nullptr;
               },
               period))
           continue;
@@ -324,7 +329,7 @@ void Endpoint::closeBlocking(uint64_t period, uint64_t maxAttempts)
                     "endpoint: %s",
                     __func__,
                     this,
-                    _handle,
+                    _originalHandle,
                     ucs_status_string(UCS_PTR_STATUS(status)));
                 }
               },
@@ -341,14 +346,16 @@ void Endpoint::closeBlocking(uint64_t period, uint64_t maxAttempts)
         "ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, all attempts to close timed out",
         __func__,
         this,
-        _handle);
+        _originalHandle != nullptr ? _originalHandle : _handle);
     }
   } else {
     // No progress thread: cancel inflight + FORCE close back-to-back, then
     // drive progress here.  Same atomicity reasoning as the progress-thread
     // path above (no ucp_worker_progress() between cancel and FORCE close).
     _inflightRequests->cancelAll();
-    status = ucp_ep_close_nbx(_handle, &param);
+    status          = ucp_ep_close_nbx(_handle, &param);
+    _originalHandle = _handle;
+    _handle         = nullptr;
     if (UCS_PTR_IS_PTR(status)) {
       ucs_status_t s;
       while ((s = ucp_request_check_status(status)) == UCS_INPROGRESS)
@@ -359,11 +366,12 @@ void Endpoint::closeBlocking(uint64_t period, uint64_t maxAttempts)
         "ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, Error while closing endpoint: %s",
         __func__,
         this,
-        _handle,
+        _originalHandle,
         ucs_status_string(UCS_PTR_STATUS(status)));
     }
   }
-  ucxx_trace("ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, closed", __func__, this, _handle);
+  ucxx_trace(
+    "ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, closed", __func__, this, _originalHandle);
 
   if (UCS_PTR_IS_PTR(status)) ucp_request_free(status);
 
@@ -373,14 +381,12 @@ void Endpoint::closeBlocking(uint64_t period, uint64_t maxAttempts)
       ucxx_debug("ucxx::Endpoint::%s, Endpoint: %p, UCP handle: %p, calling user close callback",
                  __func__,
                  this,
-                 _handle);
+                 _originalHandle);
       _closeCallback(_status, _closeCallbackArg);
       _closeCallback    = nullptr;
       _closeCallbackArg = nullptr;
     }
   }
-
-  std::swap(_handle, _originalHandle);
 }
 
 ucp_ep_h Endpoint::getHandle() { return _handle; }

--- a/cpp/src/inflight_requests.cpp
+++ b/cpp/src/inflight_requests.cpp
@@ -41,18 +41,34 @@ void InflightRequests::merge(TrackedRequests&& trackedRequests)
     if (r) _canceling.insert(std::move(r));
 }
 
-size_t InflightRequests::cancelAll()
+size_t InflightRequests::cancelAll(bool workerOnly)
 {
   decltype(_inflight) toCancel;
+  decltype(_inflight) toKeep;
   {
     std::lock_guard<std::mutex> lock(_mutex);
-    toCancel = std::exchange(_inflight, {});
+    if (workerOnly) {
+      // Partition: receive (worker-scoped) requests get explicit ucp_request_cancel,
+      // endpoint-scoped requests stay in `_inflight` to be cleaned up by FORCE close.
+      for (auto& r : _inflight) {
+        if (r && r->isWorkerOperation())
+          toCancel.insert(r);
+        else
+          toKeep.insert(r);
+      }
+      _inflight = std::move(toKeep);
+    } else {
+      toCancel = std::exchange(_inflight, {});
+    }
   }
 
   size_t total = toCancel.size();
   if (total == 0) return 0;
 
-  ucxx_debug("ucxx::InflightRequests::%s, canceling %lu requests", __func__, total);
+  ucxx_debug("ucxx::InflightRequests::%s, canceling %lu requests (workerOnly=%d)",
+             __func__,
+             total,
+             workerOnly);
 
   for (auto& r : toCancel) {
     if (r) r->cancel();

--- a/cpp/src/request.cpp
+++ b/cpp/src/request.cpp
@@ -71,6 +71,24 @@ Request::~Request()
   ucxx_trace("ucxx::Request destroyed (%s): %p", _operationName.c_str(), this);
 }
 
+bool Request::isWorkerOperation() const
+{
+  // Receive operations go through ucp_tag_recv_nbx / ucp_am_recv_nbx and friends,
+  // which post requests against the UCP worker rather than a specific endpoint.
+  // ucp_ep_close_nbx(FORCE) does not cancel them, so closeBlocking() must do so
+  // explicitly.  Send / RMA operations are endpoint-bound and are cleaned up by
+  // FORCE close itself.
+  return std::visit(data::dispatch{
+                      [](const data::TagReceive&) { return true; },
+                      [](const data::TagReceiveWithHandle&) { return true; },
+                      [](const data::TagMultiReceive&) { return true; },
+                      [](const data::AmReceive&) { return true; },
+                      [](const data::StreamReceive&) { return true; },
+                      [](const auto&) { return false; },
+                    },
+                    _requestData);
+}
+
 void Request::cancel()
 {
   std::lock_guard<std::recursive_mutex> lock(_mutex);

--- a/python/distributed-ucxx/distributed_ucxx/ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/ucxx.py
@@ -498,9 +498,9 @@ class UCXX(Comm):
                 for each_frame in send_frames:
                     await self.ep.send(each_frame)
             return sum(sizes)
-        except ucxx.exceptions.UCXError:
+        except BaseException as e:
             self.abort()
-            raise CommClosedError("While writing, the connection was closed")
+            raise CommClosedError("While writing, the connection was closed") from e
 
     @log_errors
     async def read(self, deserializers=("cuda", "dask", "pickle", "error")):

--- a/python/distributed-ucxx/distributed_ucxx/ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/ucxx.py
@@ -707,26 +707,21 @@ class UCXXListener(Listener):
         return f"{self.prefix}{self.ip}:{self.port}"
 
     async def start(self):
-        listener_ref = weakref.ref(self)
-
         async def serve_forever(client_ep):
-            listener = listener_ref()
-            if listener is None:
-                return
-            ucx = listener.comm_class(
+            ucx = self.comm_class(
                 client_ep,
-                local_addr=listener.address,
-                peer_addr=listener.address,
-                deserialize=listener.deserialize,
+                local_addr=self.address,
+                peer_addr=self.address,
+                deserialize=self.deserialize,
             )
-            ucx.allow_offload = listener.allow_offload
+            ucx.allow_offload = self.allow_offload
             try:
-                await listener.on_connection(ucx)
+                await self.on_connection(ucx)
             except CommClosedError:
                 logger.debug("Connection closed before handshake completed")
                 return
-            if listener.comm_handler:
-                await listener.comm_handler(ucx)
+            if self.comm_handler:
+                await self.comm_handler(ucx)
 
         init_once()
         self._resource_id = _register_dask_resource()
@@ -734,6 +729,8 @@ class UCXXListener(Listener):
         self.ucxx_server = ucxx.create_listener(serve_forever, port=self._input_port)
 
     def stop(self):
+        if self.ucxx_server is not None:
+            self.ucxx_server.close()
         self.ucxx_server = None
         _deregister_dask_resource(self._resource_id)
 

--- a/python/distributed-ucxx/distributed_ucxx/ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/ucxx.py
@@ -707,21 +707,26 @@ class UCXXListener(Listener):
         return f"{self.prefix}{self.ip}:{self.port}"
 
     async def start(self):
+        listener_ref = weakref.ref(self)
+
         async def serve_forever(client_ep):
-            ucx = self.comm_class(
+            listener = listener_ref()
+            if listener is None:
+                return
+            ucx = listener.comm_class(
                 client_ep,
-                local_addr=self.address,
-                peer_addr=self.address,
-                deserialize=self.deserialize,
+                local_addr=listener.address,
+                peer_addr=listener.address,
+                deserialize=listener.deserialize,
             )
-            ucx.allow_offload = self.allow_offload
+            ucx.allow_offload = listener.allow_offload
             try:
-                await self.on_connection(ucx)
+                await listener.on_connection(ucx)
             except CommClosedError:
                 logger.debug("Connection closed before handshake completed")
                 return
-            if self.comm_handler:
-                await self.comm_handler(ucx)
+            if listener.comm_handler:
+                await listener.comm_handler(ucx)
 
         init_once()
         self._resource_id = _register_dask_resource()

--- a/python/distributed-ucxx/distributed_ucxx/utils_test.py
+++ b/python/distributed-ucxx/distributed_ucxx/utils_test.py
@@ -1,9 +1,10 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
 
 import asyncio
+import gc
 import logging
 import sys
 
@@ -84,6 +85,25 @@ def ucxx_loop(request):
 
     with check_thread_leak():
         yield loop
+
+        # Flush the event loop so that any in-flight _listener_handler_coroutine
+        # finally-blocks (which release Endpoint._ctx) have a chance to complete
+        # before we call ucxx.reset().  We also collect garbage to break the
+        # UCXXListener -> Listener -> UCXListener -> cb_args -> serve_forever closure
+        # -> UCXXListener reference cycle that CPython's reference counting alone
+        # won't free.
+        try:
+            asyncio_loop = loop.asyncio_loop
+            asyncio.run_coroutine_threadsafe(asyncio.sleep(0), asyncio_loop).result(
+                timeout=5
+            )
+            asyncio.run_coroutine_threadsafe(asyncio.sleep(0), asyncio_loop).result(
+                timeout=5
+            )
+        except Exception:
+            pass
+        gc.collect()
+
         if ignore_alive_references:
             try:
                 ucxx.reset()

--- a/python/distributed-ucxx/distributed_ucxx/utils_test.py
+++ b/python/distributed-ucxx/distributed_ucxx/utils_test.py
@@ -86,22 +86,7 @@ def ucxx_loop(request):
     with check_thread_leak():
         yield loop
 
-        # Flush the event loop so that any in-flight _listener_handler_coroutine
-        # finally-blocks (which release Endpoint._ctx) have a chance to complete
-        # before we call ucxx.reset().  We also collect garbage to break the
-        # UCXXListener -> Listener -> UCXListener -> cb_args -> serve_forever closure
-        # -> UCXXListener reference cycle that CPython's reference counting alone
-        # won't free.
-        try:
-            asyncio_loop = loop.asyncio_loop
-            asyncio.run_coroutine_threadsafe(asyncio.sleep(0), asyncio_loop).result(
-                timeout=5
-            )
-            asyncio.run_coroutine_threadsafe(asyncio.sleep(0), asyncio_loop).result(
-                timeout=5
-            )
-        except Exception:
-            pass
+        # Collect garbage to break any remaining reference cycles before reset.
         gc.collect()
 
         if ignore_alive_references:

--- a/python/ucxx/ucxx/_lib_async/application_context.py
+++ b/python/ucxx/ucxx/_lib_async/application_context.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging
@@ -311,7 +311,7 @@ class ApplicationContext:
                 cb_args=(
                     loop,
                     callback_func,
-                    self,
+                    weakref.ref(self),
                     endpoint_error_handling,
                     connect_timeout,
                     listener_id,

--- a/python/ucxx/ucxx/_lib_async/application_context.py
+++ b/python/ucxx/ucxx/_lib_async/application_context.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging
@@ -311,7 +311,7 @@ class ApplicationContext:
                 cb_args=(
                     loop,
                     callback_func,
-                    weakref.ref(self),
+                    self,
                     endpoint_error_handling,
                     connect_timeout,
                     listener_id,

--- a/python/ucxx/ucxx/_lib_async/application_context.py
+++ b/python/ucxx/ucxx/_lib_async/application_context.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging
@@ -311,7 +311,7 @@ class ApplicationContext:
                 cb_args=(
                     loop,
                     callback_func,
-                    self,
+                    weakref.ref(self),
                     endpoint_error_handling,
                     connect_timeout,
                     listener_id,
@@ -321,6 +321,7 @@ class ApplicationContext:
             ),
             listener_id,
             self._listener_active_clients,
+            ctx=self,
         )
         return ret
 

--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -150,10 +150,6 @@ async def _listener_handler_coroutine(
     #  3) Exchange endpoint info such as tags
     #  4) Setup control receive callback
     #  5) Execute the listener's callback function
-    if isinstance(ctx, weakref.ref):
-        ctx = ctx()
-        if ctx is None:
-            return
     active_clients.inc(ident)
     ep = None
     try:

--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -156,10 +156,7 @@ async def _listener_handler_coroutine(
     #  4) Setup control receive callback
     #  5) Execute the listener's callback function
 
-    # Dereference the weakref immediately so the UCXListener's cb_args tuple
-    # does not keep ApplicationContext alive through this coroutine's frame.
     ctx = ctx_weakref()
-    del ctx_weakref
     if ctx is None:
         logger.debug(
             "ApplicationContext was freed before listener handler coroutine ran"
@@ -219,8 +216,6 @@ async def _listener_handler_coroutine(
         logger.exception("Unexpected error in listener handler coroutine")
     finally:
         active_clients.dec(ident)
-        # Release ApplicationContext reference even on early exits (e.g., cancellation
-        # before the explicit ctx = None above).
         del ctx
         del ep
 

--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -34,7 +34,9 @@ class ActiveClients:
 
     def add_listener(self, ident: int) -> None:
         if ident in self._active_clients:
-            raise ValueError("Listener {ident} is already registered in ActiveClients.")
+            raise ValueError(
+                f"Listener {ident} is already registered in ActiveClients."
+            )
 
         self._locks[ident] = threading.Lock()
         self._active_clients[ident] = 0
@@ -44,7 +46,7 @@ class ActiveClients:
             active_clients = self.get_active(ident)
             if active_clients > 0:
                 raise RuntimeError(
-                    "Listener {ident} is being removed from ActiveClients, but "
+                    f"Listener {ident} is being removed from ActiveClients, but "
                     f"{active_clients} active client(s) is(are) still accounted for."
                 )
 
@@ -201,6 +203,8 @@ async def _listener_handler_coroutine(
         logger.exception("Unexpected error in listener handler coroutine")
     finally:
         active_clients.dec(ident)
+        if ep is not None:
+            ep._ctx = None
         del ep
 
 

--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -99,11 +99,15 @@ class Listener:
     Please use `create_listener()` to create an Listener.
     """
 
-    def __init__(self, listener, ident, active_clients):
+    def __init__(self, listener, ident, active_clients, ctx=None):
         if not isinstance(listener, ucx_api.UCXListener):
             raise ValueError("listener must be an instance of UCXListener")
 
         self._listener = listener
+        # Hold a strong reference to ApplicationContext so that reset() correctly
+        # detects a live Listener. Released by close() so the context can be freed
+        # even if UCXListener is still in a reference cycle.
+        self._ctx = ctx
 
         active_clients.add_listener(ident)
         self._ident = ident
@@ -132,12 +136,13 @@ class Listener:
 
     def close(self):
         """Closing the listener"""
+        self._ctx = None
         self._listener = None
 
 
 async def _listener_handler_coroutine(
     conn_request,
-    ctx,
+    ctx_weakref,
     func,
     endpoint_error_handling,
     connect_timeout,
@@ -150,6 +155,17 @@ async def _listener_handler_coroutine(
     #  3) Exchange endpoint info such as tags
     #  4) Setup control receive callback
     #  5) Execute the listener's callback function
+
+    # Dereference the weakref immediately so the UCXListener's cb_args tuple
+    # does not keep ApplicationContext alive through this coroutine's frame.
+    ctx = ctx_weakref()
+    del ctx_weakref
+    if ctx is None:
+        logger.debug(
+            "ApplicationContext was freed before listener handler coroutine ran"
+        )
+        return
+
     active_clients.inc(ident)
     ep = None
     try:
@@ -189,7 +205,7 @@ async def _listener_handler_coroutine(
         )
 
         # Removing references here to avoid delayed clean up
-        del ctx
+        ctx = None
 
         # Finally, we call `func`
         if inspect.iscoroutinefunction(func):
@@ -203,6 +219,9 @@ async def _listener_handler_coroutine(
         logger.exception("Unexpected error in listener handler coroutine")
     finally:
         active_clients.dec(ident)
+        # Release ApplicationContext reference even on early exits (e.g., cancellation
+        # before the explicit ctx = None above).
+        del ctx
         del ep
 
 
@@ -210,7 +229,7 @@ def _listener_handler(
     conn_request,
     event_loop,
     callback_func,
-    ctx,
+    ctx_weakref,
     endpoint_error_handling,
     connect_timeout,
     ident,
@@ -219,7 +238,7 @@ def _listener_handler(
     asyncio.run_coroutine_threadsafe(
         _listener_handler_coroutine(
             conn_request,
-            ctx,
+            ctx_weakref,
             callback_func,
             endpoint_error_handling,
             connect_timeout,

--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -203,8 +203,6 @@ async def _listener_handler_coroutine(
         logger.exception("Unexpected error in listener handler coroutine")
     finally:
         active_clients.dec(ident)
-        if ep is not None:
-            ep._ctx = None
         del ep
 
 

--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -150,6 +150,10 @@ async def _listener_handler_coroutine(
     #  3) Exchange endpoint info such as tags
     #  4) Setup control receive callback
     #  5) Execute the listener's callback function
+    if isinstance(ctx, weakref.ref):
+        ctx = ctx()
+        if ctx is None:
+            return
     active_clients.inc(ident)
     ep = None
     try:

--- a/python/ucxx/ucxx/_lib_async/tests/conftest.py
+++ b/python/ucxx/ucxx/_lib_async/tests/conftest.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import asyncio
+import functools
 import gc
 import inspect
 import os
@@ -110,6 +111,39 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     if timeout <= 0.0:
         raise ValueError("The `pytest.mark.asyncio_timeout` value must be positive.")
     item.config.stash[ASYNCIO_PLUGIN_TIMEOUT_STASH_KEY] = timeout
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_call(item: pytest.Item):
+    """
+    Inject the asyncio timeout BEFORE pytest-asyncio applies its MonkeyPatch.
+
+    In pytest-asyncio 1.3.0 (asyncio_mode=auto) + Python 3.14, the framework
+    replaces ``item.obj`` with a sync wrapper inside
+    ``PytestAsyncioFunction.runtest()``, which is called during
+    ``pytest_runtest_call``.  By the time ``pytest_pyfunc_call`` fires,
+    ``item.obj`` is already a sync function and
+    ``inspect.iscoroutinefunction()`` returns False.  Wrapping here instead
+    guarantees ``asyncio.wait_for`` is present in the coroutine that
+    pytest-asyncio eventually passes to its ``asyncio.Runner``.
+    """
+    if isinstance(item, pytest.Function) and inspect.iscoroutinefunction(item.obj):
+        timeout = _asyncio_plugin_timeout_seconds(item)
+        if timeout > 0.0:
+            original = item.obj
+            test_name = item.name
+
+            @functools.wraps(original)
+            async def timed_coroutine(*args, **kwargs):
+                try:
+                    return await asyncio.wait_for(
+                        original(*args, **kwargs), timeout=timeout
+                    )
+                except (asyncio.CancelledError, asyncio.TimeoutError):
+                    pytest.fail(f"{test_name} timed out after {timeout} seconds.")
+
+            item.obj = timed_coroutine
+    yield
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/python/ucxx/ucxx/_lib_async/tests/test_send_recv.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_send_recv.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools
@@ -94,6 +94,7 @@ async def test_send_recv_cupy(size, dtype):
     resp = cupy.empty_like(msg)
     await client.recv(resp)
     np.testing.assert_array_equal(cupy.asnumpy(resp), cupy.asnumpy(msg))
+    await client.close()
     await wait_listener_client_handlers(listener)
 
 
@@ -116,6 +117,7 @@ async def test_send_recv_numba(size, dtype):
     resp = cuda.device_array_like(msg)
     await client.recv(resp)
     np.testing.assert_array_equal(np.array(resp), np.array(msg))
+    await client.close()
     await wait_listener_client_handlers(listener)
 
 

--- a/python/ucxx/ucxx/_lib_async/tests/test_send_recv_multi.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_send_recv_multi.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
@@ -8,7 +8,9 @@ from ucxx._lib_async.utils_test import wait_listener_client_handlers
 
 np = pytest.importorskip("numpy")
 
-msg_sizes = [2**i for i in range(0, 25, 4)]
+msg_sizes = [2**i for i in range(0, 24, 4)] + [
+    pytest.param(2**24, marks=pytest.mark.asyncio_timeout(120))
+]
 # multi_sizes = [0, 1, 2, 3, 4, 8]
 multi_sizes = [1, 2, 3, 4, 8]
 dtypes = ["|u1", "<i8", "f8"]

--- a/python/ucxx/ucxx/_lib_async/tests/test_send_recv_multi.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_send_recv_multi.py
@@ -9,7 +9,7 @@ from ucxx._lib_async.utils_test import wait_listener_client_handlers
 np = pytest.importorskip("numpy")
 
 msg_sizes = [2**i for i in range(0, 24, 4)] + [
-    pytest.param(2**24, marks=pytest.mark.asyncio_timeout(120))
+    pytest.param(2**24, marks=pytest.mark.asyncio_timeout(240))
 ]
 # multi_sizes = [0, 1, 2, 3, 4, 8]
 multi_sizes = [1, 2, 3, 4, 8]

--- a/python/ucxx/ucxx/_lib_async/tests/test_send_recv_multi.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_send_recv_multi.py
@@ -69,6 +69,7 @@ async def test_send_recv_numpy(size, multi_size, dtype):
     recv_msg = await client.recv_multi()
     for r, s in zip(recv_msg, send_msg):
         np.testing.assert_array_equal(r.view(dtype), s)
+    await client.close()
     await wait_listener_client_handlers(listener)
 
 
@@ -88,6 +89,7 @@ async def test_send_recv_cupy(size, multi_size, dtype):
     recv_msg = await client.recv_multi()
     for r, s in zip(recv_msg, send_msg):
         cupy.testing.assert_array_equal(cupy.asarray(r).view(dtype), cupy.asarray(s))
+    await client.close()
     await wait_listener_client_handlers(listener)
 
 
@@ -109,4 +111,5 @@ async def test_send_recv_numba(size, multi_size, dtype):
         np.testing.assert_array_equal(
             r.copy_to_host().view(dtype), s.copy_to_host().view(dtype)
         )
+    await client.close()
     await wait_listener_client_handlers(listener)

--- a/python/ucxx/ucxx/_lib_async/tests/test_send_recv_multi.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_send_recv_multi.py
@@ -8,6 +8,8 @@ from ucxx._lib_async.utils_test import wait_listener_client_handlers
 
 np = pytest.importorskip("numpy")
 
+# Some CI nodes can be _very_ slow for large sized messages, generally only on
+# 4 or 8 messages, thus substantially increase the timeouts for 16MiB messages.
 msg_sizes = [2**i for i in range(0, 24, 4)] + [
     pytest.param(2**24, marks=pytest.mark.asyncio_timeout(240))
 ]

--- a/python/ucxx/ucxx/_lib_async/utils_test.py
+++ b/python/ucxx/ucxx/_lib_async/utils_test.py
@@ -196,8 +196,15 @@ async def am_recv(ep):
     return frames, msg
 
 
-async def wait_listener_client_handlers(listener):
+async def wait_listener_client_handlers(listener, timeout=None):
+    loop = asyncio.get_event_loop()
+    deadline = (loop.time() + timeout) if timeout is not None else None
     while listener.active_clients > 0:
+        if deadline is not None and loop.time() >= deadline:
+            raise asyncio.TimeoutError(
+                f"Listener still has {listener.active_clients} active client(s) "
+                f"after {timeout}s, likely due to a deadlock in the handler coroutine."
+            )
         # Minimal delay to yield to the event loop so call_soon_threadsafe callbacks
         # run. Using a very short positive sleep ensures pending callbacks are
         # processed and significantly reduces "coroutine never awaited" warnings.

--- a/python/ucxx/ucxx/_lib_async/utils_test.py
+++ b/python/ucxx/ucxx/_lib_async/utils_test.py
@@ -199,6 +199,12 @@ async def am_recv(ep):
 async def wait_listener_client_handlers(listener, timeout=None):
     loop = asyncio.get_event_loop()
     deadline = (loop.time() + timeout) if timeout is not None else None
+    # If this coroutine is cancelled (e.g., by asyncio.wait_for test timeout)
+    # while handlers are still active, we defer the CancelledError until all
+    # handlers finish.  Raising immediately would let the Listener be GC'd
+    # while a handler holds an in-flight CUDA transfer, which races with the
+    # UCX progress thread and causes a segfault.
+    cancelled = False
     while listener.active_clients > 0:
         if deadline is not None and loop.time() >= deadline:
             raise asyncio.TimeoutError(
@@ -208,6 +214,17 @@ async def wait_listener_client_handlers(listener, timeout=None):
         # Minimal delay to yield to the event loop so call_soon_threadsafe callbacks
         # run. Using a very short positive sleep ensures pending callbacks are
         # processed and significantly reduces "coroutine never awaited" warnings.
-        await asyncio.sleep(1e-9)
+        try:
+            await asyncio.sleep(1e-9)
+        except asyncio.CancelledError:
+            cancelled = True
+            # Python 3.11+ tracks cancellation depth; calling uncancel() lets
+            # this loop continue iterating rather than being re-cancelled on
+            # the very next await.
+            task = asyncio.current_task()
+            if task is not None and hasattr(task, "uncancel"):
+                task.uncancel()
         if not ucxx.core._get_ctx().progress_mode.startswith("thread"):
             ucxx.progress()
+    if cancelled:
+        raise asyncio.CancelledError()


### PR DESCRIPTION
`UCXListener._cb_data["cb_args"]` held a strong reference to `ApplicationContext` creating a reference cycle that prevented proper cleanup and caused intermittent `ucxx.reset()` failures in the `ucxx_loop` fixture. The fix passes `weakref.ref(self)` in `cb_args` so the cycle never holds `ApplicationContext` alive, while `Listener` retains a direct strong reference (released by `close()`) to preserve the detection contract in `reset()`. `_listener_handler_coroutine` now dereferences the weakref immediately and clears `ctx` in `finally` to avoid holding `ApplicationContext` in cancelled coroutine frames. `UCXXListener.stop()` now calls `ucxx_server.close()` before dropping the reference for deterministic cleanup.

Additionally, `write()` now catches `BaseException` instead of `ucxx.exceptions.UCXError` so that `CancelledError` and `ValueError` mid-write also trigger `abort()` and return `CommClosedError` (consistent with #630), two f-strings in `ActiveClients` error messages had their missing f prefix added, and `gc.collect()` is called before `ucxx.reset()` in the test fixture as a safety net.