### PR TITLE
C++ tests: remove 'UCX_' prefix in configmap keys

### DIFF
--- a/cpp/tests/config.cpp
+++ b/cpp/tests/config.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <gtest/gtest.h>
@@ -30,7 +30,7 @@ TEST(ConfigTest, HandleIsValid)
 
 TEST(ConfigTest, ConfigMapTLS)
 {
-  ucxx::ConfigMap configMap{{"UCX_TLS", "tcp"}};
+  ucxx::ConfigMap configMap{{"TLS", "tcp"}};
   ucxx::Config config{configMap};
 
   auto configMapOut = config.get();

--- a/cpp/tests/context.cpp
+++ b/cpp/tests/context.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdlib>
@@ -63,7 +63,7 @@ TEST(ContextTest, CustomFlags)
 
 TEST(ContextTest, Info)
 {
-  auto context = ucxx::createContext({{"UCX_TLS", "tcp"}}, ucxx::Context::defaultFeatureFlags);
+  auto context = ucxx::createContext({{"TLS", "tcp"}}, ucxx::Context::defaultFeatureFlags);
 
   ASSERT_GT(context->getInfo().size(), 0u);
 }


### PR DESCRIPTION
In an environment with UCX 1.20, I saw some UCXX C++ test failures like this:

```console
$ UCX_LOG_LEVEL=debug ./UCXX_TEST --gtest_filter=ConfigTest.ConfigMapTLS
...
[1776123216.178312] [db6afae42fe4:1034 :0]            init.c:120  UCX  DEBUG /usr/local/ucx/lib/libucs.so.0 loaded at 0x79cbc049c000
[1776123216.178323] [db6afae42fe4:1034 :0]            init.c:122  UCX  DEBUG cmd line: ./UCXX_TEST --gtest_filter=ConfigTest.ConfigMapTLS 
[1776123216.178328] [db6afae42fe4:1034 :0]          module.c:72   UCX  DEBUG ucs library path: /usr/local/ucx/lib/libucs.so.0
...
Running main() from gmock_main.cc
Note: Google Test filter = ConfigTest.ConfigMapTLS
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ConfigTest
[ RUN      ] ConfigTest.ConfigMapTLS
[1776123216.180430] [db6afae42fe4:1034 :0]            time.c:22   UCX  DEBUG arch clock frequency: 3184736383.44 Hz
[1776123216.180445] [db6afae42fe4:1034 :0]          module.c:304  UCX  DEBUG loading modules for uct
[1776123216.180446] [db6afae42fe4:1034 :0]          module.c:257  UCX  DEBUG loading module 'cuda' with mode 0x1
...
[1776123216.318534] [db6afae42fe4:1034 :0]     ucp_context.c:909  UCX  DEBUG 'UCX_TLS' configuration is invalid
unknown file: Failure
C++ exception with description "Invalid parameter" thrown in the test body.

[  FAILED  ] ConfigTest.ConfigMapTLS (138 ms)
[----------] 1 test from ConfigTest (138 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (138 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ConfigTest.ConfigMapTLS

 1 FAILED TEST
```

Looks like that and another related error come from this change in UCX: https://github.com/openucx/ucx/pull/11003

Looks like configMap keys like this:

https://github.com/rapidsai/ucxx/blob/13c4b0d836c3fa4c6be25c8d10c369d725cc14af/cpp/tests/config.cpp#L33

are expected to exclude the `UCX_` prefix that's used in environment variables.

## Notes for Reviewers

### Why didn't CI catch this?

I *think* that maybe https://github.com/openucx/ucx/pull/11003 didn't make it out into UCX 1.20.0?

We are definitely getting UCX 1.20 in C++ test jobs, e.g.:

```text
...
  + ucx                         1.20.0  hf72d326_1              conda-forge               8MB
...
```

([recent conda-cpp-tests link](https://github.com/rapidsai/ucxx/actions/runs/24408350170/job/71308017772#step:12:166))

Maybe it depends on how UCX was built?

I see "Fixed ucp_config_modify not reporting an error when no matching modifiable configuration exists." listed under https://github.com/openucx/ucx/releases/tag/v1.20.1-rc1.

Best guess, the version of UCX I have in my environment was custom-built from some later commit than the `v1.20.0` tag, and that's how it picked up this change.

What I have locally:

```console
$ ucx_info -v
# Library version: 1.20.0
# Library path: /usr/local/ucx/lib/libucs.so.0
# API headers version: 1.20.0
# Git branch '', revision d9a4f35
# Configured with: --disable-logging --disable-debug --disable-assertions --disable-params-check --enable-mt --without-knem --with-xpmem=/hpc/local/oss/xpmem/v2.7.1 --without-java --enable-devel-headers --with-fuse3-static --with-cuda=/hpc/local/oss/cuda13.2_latestRC --with-gdrcopy --prefix=/build-result/hpcx-v2.26-gcc-inbox-ubuntu24.04-cuda13-x86_64/ucx/mt
```

What conda-forge currently ships:

```console
$ conda create --yes --name ucxx-dev -c rapidsai-nightly -c conda-forge ucxx=0.50 ucx=1.20
$ source activate ucxx-dev
$ $CONDA_PREFIX/bin/ucx_info -v
# Library version: 1.20.0
# Library path: /home/jlamb/miniforge3/envs/ucxx-dev/bin/../lib/libucs.so.0
# API headers version: 1.20.0
# Git branch '', revision 4b7a6ca
# Configured with: --disable-logging --disable-debug --disable-assertions --disable-params-check --build=x86_64-conda-linux-gnu --host=x86_64-conda-linux-gnu --prefix=/home/jlamb/miniforge3/envs/ucxx-dev --with-sysroot --disable-static --enable-openmp --enable-cma --enable-mt --with-gnu-ld --with-rdmacm=/home/jlamb/miniforge3/envs/ucxx-dev --with-verbs=/home/jlamb/miniforge3/envs/ucxx-dev --with-cuda=/home/jlamb/miniforge3/envs/ucxx-dev
```