### PR TITLE
Make builder constructors ABI stable with the pImpl idiom

### DIFF
--- a/cpp/include/ucxx/experimental/builder_utils.h
+++ b/cpp/include/ucxx/experimental/builder_utils.h
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#pragma once
+
+#include <memory>
+
+/**
+ * @brief Define pImpl rule-of-five members and the implicit conversion operator for a builder.
+ *
+ * Place this in the `.cpp` file after the `Impl` struct definition. The builder class must
+ * have a `std::unique_ptr<Impl> _impl` member and a `build()` method.
+ *
+ * @param BuilderClass  the fully-qualified builder class name.
+ * @param TargetClass   the type that `build()` returns wrapped in `std::shared_ptr`.
+ */
+#define UCXX_BUILDER_PIMPL_DEFAULTS(BuilderClass, TargetClass)              \
+  BuilderClass::~BuilderClass()                                  = default; \
+  BuilderClass::BuilderClass(BuilderClass&&) noexcept            = default; \
+  BuilderClass& BuilderClass::operator=(BuilderClass&&) noexcept = default; \
+  BuilderClass::BuilderClass(const BuilderClass& other)                     \
+    : _impl(std::make_unique<Impl>(*other._impl))                           \
+  {                                                                         \
+  }                                                                         \
+  BuilderClass& BuilderClass::operator=(const BuilderClass& other)          \
+  {                                                                         \
+    if (this != &other) _impl = std::make_unique<Impl>(*other._impl);       \
+    return *this;                                                           \
+  }                                                                         \
+  BuilderClass::operator std::shared_ptr<TargetClass>() const { return build(); }

--- a/cpp/include/ucxx/experimental/context_builder.h
+++ b/cpp/include/ucxx/experimental/context_builder.h
@@ -39,7 +39,7 @@ namespace experimental {
  *   std::shared_ptr<ucxx::Context> ctx = ucxx::experimental::createContext(UCP_FEATURE_RMA);
  * @endcode
  */
-class ContextBuilder {
+class ContextBuilder final {
  public:
   /**
    * @brief Constructor for `ContextBuilder` with required feature flags.

--- a/cpp/include/ucxx/experimental/context_builder.h
+++ b/cpp/include/ucxx/experimental/context_builder.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -40,10 +40,6 @@ namespace experimental {
  * @endcode
  */
 class ContextBuilder {
- private:
-  ConfigMap _configMap{};  ///< Configuration map for UCP context
-  uint64_t _featureFlags;  ///< Feature flags for UCP context (required)
-
  public:
   /**
    * @brief Constructor for `ContextBuilder` with required feature flags.
@@ -51,6 +47,30 @@ class ContextBuilder {
    * @param[in] featureFlags feature flags to be used at UCP context construction time (required).
    */
   explicit ContextBuilder(uint64_t featureFlags);
+
+  /**
+   * @brief `ContextBuilder` destructor.
+   */
+  ~ContextBuilder();
+
+  /** @brief Copy constructor (deep-copies internal state). */
+  ContextBuilder(const ContextBuilder& other);
+  /** @brief Copy assignment operator (deep-copies internal state). */
+  ContextBuilder& operator=(const ContextBuilder& other);
+  /** @brief Move constructor. */
+  ContextBuilder(ContextBuilder&&) noexcept;
+  /** @brief Move assignment operator. */
+  ContextBuilder& operator=(ContextBuilder&&) noexcept;
+
+  /**
+   * @brief Implicit conversion operator to `shared_ptr<Context>`.
+   *
+   * Enables automatic construction of the `Context` when the builder is used in a context
+   * requiring a `shared_ptr<Context>`, delegating to `build()`.
+   *
+   * @return The constructed `shared_ptr<ucxx::Context>` object.
+   */
+  operator std::shared_ptr<Context>() const;
 
   /**
    * @brief Set the configuration map for the context.
@@ -68,18 +88,11 @@ class ContextBuilder {
    *
    * @return The constructed `shared_ptr<ucxx::Context>` object.
    */
-  std::shared_ptr<Context> build() const;
+  [[nodiscard]] std::shared_ptr<Context> build() const;
 
-  /**
-   * @brief Implicit conversion operator to `shared_ptr<Context>`.
-   *
-   * This operator enables automatic construction of the `Context` when the builder
-   * is used in a context requiring a `shared_ptr<Context>`. This allows seamless
-   * use with `auto` variables.
-   *
-   * @return The constructed `shared_ptr<ucxx::Context>` object.
-   */
-  operator std::shared_ptr<Context>() const;
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> _impl;
 };
 
 /**

--- a/cpp/include/ucxx/experimental/worker_builder.h
+++ b/cpp/include/ucxx/experimental/worker_builder.h
@@ -39,7 +39,7 @@ namespace experimental {
  *   std::shared_ptr<ucxx::Worker> worker = ucxx::experimental::createWorker(context);
  * @endcode
  */
-class WorkerBuilder {
+class WorkerBuilder final {
  public:
   /**
    * @brief Constructor for `WorkerBuilder` with required context.

--- a/cpp/include/ucxx/experimental/worker_builder.h
+++ b/cpp/include/ucxx/experimental/worker_builder.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -40,11 +40,6 @@ namespace experimental {
  * @endcode
  */
 class WorkerBuilder {
- private:
-  std::shared_ptr<Context> _context;     ///< UCXX context (required)
-  bool _enableDelayedSubmission{false};  ///< Enable delayed submission to progress thread
-  bool _enableFuture{false};             ///< Enable future support
-
  public:
   /**
    * @brief Constructor for `WorkerBuilder` with required context.
@@ -52,6 +47,30 @@ class WorkerBuilder {
    * @param[in] context context from which the worker will be created (required).
    */
   explicit WorkerBuilder(std::shared_ptr<Context> context);
+
+  /**
+   * @brief `WorkerBuilder` destructor.
+   */
+  ~WorkerBuilder();
+
+  /** @brief Copy constructor (deep-copies internal state). */
+  WorkerBuilder(const WorkerBuilder& other);
+  /** @brief Copy assignment operator (deep-copies internal state). */
+  WorkerBuilder& operator=(const WorkerBuilder& other);
+  /** @brief Move constructor. */
+  WorkerBuilder(WorkerBuilder&&) noexcept;
+  /** @brief Move assignment operator. */
+  WorkerBuilder& operator=(WorkerBuilder&&) noexcept;
+
+  /**
+   * @brief Implicit conversion operator to `shared_ptr<Worker>`.
+   *
+   * Enables automatic construction of the `Worker` when the builder is used in a context
+   * requiring a `shared_ptr<Worker>`, delegating to `build()`.
+   *
+   * @return The constructed `shared_ptr<ucxx::Worker>` object.
+   */
+  operator std::shared_ptr<Worker>() const;
 
   /**
    * @brief Configure delayed submission to the progress thread.
@@ -77,18 +96,11 @@ class WorkerBuilder {
    *
    * @return The constructed `shared_ptr<ucxx::Worker>` object.
    */
-  std::shared_ptr<Worker> build() const;
+  [[nodiscard]] std::shared_ptr<Worker> build() const;
 
-  /**
-   * @brief Implicit conversion operator to `shared_ptr<Worker>`.
-   *
-   * This operator enables automatic construction of the `Worker` when the builder
-   * is used in a context requiring a `shared_ptr<Worker>`. This allows seamless
-   * use with `auto` variables.
-   *
-   * @return The constructed `shared_ptr<ucxx::Worker>` object.
-   */
-  operator std::shared_ptr<Worker>() const;
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> _impl;
 };
 
 /**

--- a/cpp/src/experimental/context_builder.cpp
+++ b/cpp/src/experimental/context_builder.cpp
@@ -1,33 +1,39 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
 #include <utility>
 
 #include <ucxx/context.h>
+#include <ucxx/experimental/builder_utils.h>
 #include <ucxx/experimental/context_builder.h>
 
 namespace ucxx {
 
 namespace experimental {
 
-ContextBuilder::ContextBuilder(uint64_t featureFlags) : _featureFlags(featureFlags) {}
+struct ContextBuilder::Impl {
+  ConfigMap configMap{};
+  uint64_t featureFlags;
+};
+
+ContextBuilder::ContextBuilder(uint64_t featureFlags) : _impl(std::make_unique<Impl>())
+{
+  _impl->featureFlags = featureFlags;
+}
+
+UCXX_BUILDER_PIMPL_DEFAULTS(ContextBuilder, Context)
 
 ContextBuilder& ContextBuilder::configMap(ConfigMap configMap)
 {
-  _configMap = std::move(configMap);
+  _impl->configMap = std::move(configMap);
   return *this;
 }
 
 std::shared_ptr<Context> ContextBuilder::build() const
 {
-  return std::shared_ptr<Context>(new Context(_configMap, _featureFlags));
-}
-
-ContextBuilder::operator std::shared_ptr<Context>() const
-{
-  return std::shared_ptr<Context>(new Context(_configMap, _featureFlags));
+  return ucxx::createContext(_impl->configMap, _impl->featureFlags);
 }
 
 }  // namespace experimental

--- a/cpp/src/experimental/context_builder.cpp
+++ b/cpp/src/experimental/context_builder.cpp
@@ -16,11 +16,12 @@ namespace experimental {
 struct ContextBuilder::Impl {
   ConfigMap configMap{};
   uint64_t featureFlags;
+
+  explicit Impl(uint64_t flags) : featureFlags(flags) {}
 };
 
-ContextBuilder::ContextBuilder(uint64_t featureFlags) : _impl(std::make_unique<Impl>())
+ContextBuilder::ContextBuilder(uint64_t featureFlags) : _impl(std::make_unique<Impl>(featureFlags))
 {
-  _impl->featureFlags = featureFlags;
 }
 
 UCXX_BUILDER_PIMPL_DEFAULTS(ContextBuilder, Context)

--- a/cpp/src/experimental/worker_builder.cpp
+++ b/cpp/src/experimental/worker_builder.cpp
@@ -1,10 +1,11 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
 #include <utility>
 
+#include <ucxx/experimental/builder_utils.h>
 #include <ucxx/experimental/worker_builder.h>
 #include <ucxx/worker.h>
 
@@ -12,28 +13,34 @@ namespace ucxx {
 
 namespace experimental {
 
-WorkerBuilder::WorkerBuilder(std::shared_ptr<Context> context) : _context(std::move(context)) {}
+struct WorkerBuilder::Impl {
+  std::shared_ptr<Context> context;
+  bool enableDelayedSubmission{false};
+  bool enableFuture{false};
+};
+
+WorkerBuilder::WorkerBuilder(std::shared_ptr<Context> context) : _impl(std::make_unique<Impl>())
+{
+  _impl->context = std::move(context);
+}
+
+UCXX_BUILDER_PIMPL_DEFAULTS(WorkerBuilder, Worker)
 
 WorkerBuilder& WorkerBuilder::delayedSubmission(bool enable)
 {
-  _enableDelayedSubmission = enable;
+  _impl->enableDelayedSubmission = enable;
   return *this;
 }
 
 WorkerBuilder& WorkerBuilder::pythonFuture(bool enable)
 {
-  _enableFuture = enable;
+  _impl->enableFuture = enable;
   return *this;
 }
 
 std::shared_ptr<Worker> WorkerBuilder::build() const
 {
-  return std::shared_ptr<Worker>(new Worker(_context, _enableDelayedSubmission, _enableFuture));
-}
-
-WorkerBuilder::operator std::shared_ptr<Worker>() const
-{
-  return std::shared_ptr<Worker>(new Worker(_context, _enableDelayedSubmission, _enableFuture));
+  return ucxx::createWorker(_impl->context, _impl->enableDelayedSubmission, _impl->enableFuture);
 }
 
 }  // namespace experimental

--- a/cpp/src/experimental/worker_builder.cpp
+++ b/cpp/src/experimental/worker_builder.cpp
@@ -17,11 +17,13 @@ struct WorkerBuilder::Impl {
   std::shared_ptr<Context> context;
   bool enableDelayedSubmission{false};
   bool enableFuture{false};
+
+  explicit Impl(std::shared_ptr<Context> ctx) : context(std::move(ctx)) {}
 };
 
-WorkerBuilder::WorkerBuilder(std::shared_ptr<Context> context) : _impl(std::make_unique<Impl>())
+WorkerBuilder::WorkerBuilder(std::shared_ptr<Context> context)
+  : _impl(std::make_unique<Impl>(std::move(context)))
 {
-  _impl->context = std::move(context);
 }
 
 UCXX_BUILDER_PIMPL_DEFAULTS(WorkerBuilder, Worker)


### PR DESCRIPTION
Use the pImpl idiom as a first step towards #3 , and also to ensure upcoming expansions of constructors to use the builder pattern already follow the same path.