### PR TITLE
Sanitize deserialization and allocation paths

### DIFF
--- a/cpp/include/ucxx/internal/request_am.h
+++ b/cpp/include/ucxx/internal/request_am.h
@@ -97,8 +97,9 @@ typedef std::map<std::shared_ptr<RequestAm>,
 
 typedef std::unordered_map<AmReceiverCallbackIdType, AmReceiverCallbackType>
   AmReceiverCallbackMapType;
-typedef std::unordered_map<AmReceiverCallbackOwnerType, AmReceiverCallbackMapType>
-  AmReceiverCallbackOwnerMapType;
+typedef std::
+  unordered_map<AmReceiverCallbackOwnerType, AmReceiverCallbackMapType, AmReceiverCallbackOwnerHash>
+    AmReceiverCallbackOwnerMapType;
 
 /**
  * @brief Active Message data owned by a `ucxx::Worker`.

--- a/cpp/include/ucxx/typedefs.h
+++ b/cpp/include/ucxx/typedefs.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstring>
@@ -137,13 +138,76 @@ typedef std::function<std::shared_ptr<Buffer>(size_t)> AmAllocatorType;
 typedef std::function<void(std::shared_ptr<Request>, ucp_ep_h)> AmReceiverCallbackType;
 
 /**
- * @brief Active Message receiver callback owner name.
+ * @brief Maximum number of usable characters in an Active Message receiver callback owner name.
+ */
+static constexpr size_t AmReceiverCallbackOwnerMaxLen = 63;
+
+/**
+ * @brief On-wire and in-memory storage size for an Active Message receiver callback owner name.
+ */
+static constexpr size_t AmReceiverCallbackOwnerStorageSize = AmReceiverCallbackOwnerMaxLen + 1;
+
+/**
+ * @brief Active Message receiver callback owner name (fixed-size).
  *
- * A string containing the owner's name of an Active Message receiver callback. The owner
+ * A fixed-size identifier for the owner of an Active Message receiver callback. The owner
  * should be a reasonably unique name, usually identifying the application, to allow other
  * applications to coexist and register their own receiver callbacks.
+ *
+ * Names are stored in a fixed 64-byte buffer, zero-padded. The maximum string length is
+ * 63 characters. Attempting to construct from a longer string throws @c std::invalid_argument.
+ *
+ * Implicit construction from `const char*` and `std::string` is supported so that existing
+ * call sites such as `AmReceiverCallbackInfo("MyApp", 0)` compile unchanged.
  */
-typedef std::string AmReceiverCallbackOwnerType;
+class AmReceiverCallbackOwnerType {
+ public:
+  /** @brief Construct an empty (all-zero) owner name. */
+  AmReceiverCallbackOwnerType() = default;
+
+  /** @brief Construct from a null-terminated C string. Throws if length exceeds the limit. */
+  AmReceiverCallbackOwnerType(const char* s)  // NOLINT(runtime/explicit)
+  {
+    if (s == nullptr) return;
+    const size_t len = std::strlen(s);
+    if (len > AmReceiverCallbackOwnerMaxLen)
+      throw std::invalid_argument(
+        "AmReceiverCallbackOwnerType: owner name exceeds "
+        "maximum length of " +
+        std::to_string(AmReceiverCallbackOwnerMaxLen) + " characters");
+    std::memcpy(_data.data(), s, len);
+  }
+
+  /** @brief Construct from a @c std::string. Throws if length exceeds the limit. */
+  AmReceiverCallbackOwnerType(const std::string& s)  // NOLINT(runtime/explicit)
+    : AmReceiverCallbackOwnerType(s.c_str())
+  {
+  }
+
+  /** @brief Pointer to the raw fixed-size storage. */
+  [[nodiscard]] const char* data() const noexcept { return _data.data(); }
+
+  /** @brief Mutable pointer to the raw fixed-size storage (for deserialization). */
+  [[nodiscard]] char* data() noexcept { return _data.data(); }
+
+  /** @brief The fixed storage size that is always sent on the wire. */
+  static constexpr size_t storageSize() noexcept { return AmReceiverCallbackOwnerStorageSize; }
+
+  /** @brief Equality comparison. */
+  bool operator==(const AmReceiverCallbackOwnerType& other) const noexcept
+  {
+    return _data == other._data;
+  }
+
+  /** @brief Inequality comparison. */
+  bool operator!=(const AmReceiverCallbackOwnerType& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+ private:
+  std::array<char, AmReceiverCallbackOwnerStorageSize> _data{};
+};
 
 /**
  * @brief Active Message receiver callback identifier.
@@ -238,5 +302,20 @@ struct AmSendParams {
  * and storage of remote memory access information.
  */
 typedef const std::string SerializedRemoteKey;
+
+/**
+ * @brief Hash functor for @c AmReceiverCallbackOwnerType.
+ *
+ * Hashes the full fixed-size storage so that zero-padded names compare deterministically.
+ * Used as the hasher for @c std::unordered_map keyed by @c AmReceiverCallbackOwnerType.
+ */
+struct AmReceiverCallbackOwnerHash {
+  /** @brief Compute hash of an @c AmReceiverCallbackOwnerType. */
+  size_t operator()(const AmReceiverCallbackOwnerType& o) const noexcept
+  {
+    return std::hash<std::string_view>{}(
+      std::string_view(o.data(), AmReceiverCallbackOwnerStorageSize));
+  }
+};
 
 }  // namespace ucxx

--- a/cpp/src/address.cpp
+++ b/cpp/src/address.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 
@@ -41,7 +42,9 @@ std::shared_ptr<Address> createAddressFromWorker(std::shared_ptr<Worker> worker)
 
 std::shared_ptr<Address> createAddressFromString(std::string_view addressString)
 {
-  size_t length          = addressString.length();
+  size_t length = addressString.length();
+  if (length == 0) throw std::invalid_argument("UCP address must not be empty");
+
   ucp_address_t* address = reinterpret_cast<ucp_address_t*>(new char[length]);
   memcpy(address, addressString.data(), length);
   return std::shared_ptr<Address>(new Address(nullptr, address, length));

--- a/cpp/src/buffer.cpp
+++ b/cpp/src/buffer.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstring>

--- a/cpp/src/buffer.cpp
+++ b/cpp/src/buffer.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <iterator>
 #include <memory>
+#include <new>
 #include <utility>
 
 #include <ucxx/buffer.h>
@@ -28,6 +29,7 @@ size_t Buffer::getSize() const noexcept { return _size; }
 
 HostBuffer::HostBuffer(const size_t size) : Buffer(BufferType::Host, size), _buffer{malloc(size)}
 {
+  if (size > 0 && _buffer == nullptr) throw std::bad_alloc();
   ucxx_trace_data("ucxx::HostBuffer created: %p, buffer: %p, size: %lu", this, _buffer, size);
 }
 

--- a/cpp/src/header.cpp
+++ b/cpp/src/header.cpp
@@ -7,6 +7,7 @@
 #include <iterator>
 #include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -49,6 +50,10 @@ void Header::deserialize(const std::string& serializedHeader)
 
   ss.read(reinterpret_cast<char*>(&next), sizeof(next));
   ss.read(reinterpret_cast<char*>(&nframes), sizeof(nframes));
+  if (nframes > HeaderFramesSize)
+    throw std::overflow_error("Header nframes (" + std::to_string(nframes) +
+                              ") exceeds HeaderFramesSize (" + std::to_string(HeaderFramesSize) +
+                              ")");
   for (size_t i = 0; i < HeaderFramesSize; ++i)
     ss.read(reinterpret_cast<char*>(&isCUDA[i]), sizeof(isCUDA[i]));
   for (size_t i = 0; i < HeaderFramesSize; ++i)

--- a/cpp/src/header.cpp
+++ b/cpp/src/header.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>

--- a/cpp/src/remote_key.cpp
+++ b/cpp/src/remote_key.cpp
@@ -138,7 +138,8 @@ void RemoteKey::deserialize(const SerializedRemoteKey& serializedRemoteKey)
 
   const size_t fixedFieldsSize =
     sizeof(_packedRemoteKeySize) + sizeof(_memoryBaseAddress) + sizeof(_memorySize);
-  if (_packedRemoteKeySize > serializedRemoteKeyData.size() - fixedFieldsSize)
+  if (serializedRemoteKeyData.size() < fixedFieldsSize ||
+      _packedRemoteKeySize > serializedRemoteKeyData.size() - fixedFieldsSize)
     throw std::overflow_error("Packed remote key size exceeds serialized data length");
 
   _packedRemoteKeyVector = std::vector<char>(_packedRemoteKeySize);

--- a/cpp/src/remote_key.cpp
+++ b/cpp/src/remote_key.cpp
@@ -136,13 +136,13 @@ void RemoteKey::deserialize(const SerializedRemoteKey& serializedRemoteKey)
 
   ss.read(reinterpret_cast<char*>(&_packedRemoteKeySize), sizeof(_packedRemoteKeySize));
 
-  // Use a vector to store data so we don't need to bother releasing it later.
+  const size_t fixedFieldsSize =
+    sizeof(_packedRemoteKeySize) + sizeof(_memoryBaseAddress) + sizeof(_memorySize);
+  if (_packedRemoteKeySize > serializedRemoteKeyData.size() - fixedFieldsSize)
+    throw std::overflow_error("Packed remote key size exceeds serialized data length");
+
   _packedRemoteKeyVector = std::vector<char>(_packedRemoteKeySize);
   _packedRemoteKey       = _packedRemoteKeyVector.data();
-
-  if (_packedRemoteKeySize > std::numeric_limits<std::streamsize>::max())
-    // We should never have a remote key this big, but just in case.
-    throw std::overflow_error("Remote key is too large to deserialize");
 
   ss.read(reinterpret_cast<char*>(_packedRemoteKey),
           static_cast<std::streamsize>(_packedRemoteKeySize));

--- a/cpp/src/remote_key.cpp
+++ b/cpp/src/remote_key.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>

--- a/cpp/src/request_am.cpp
+++ b/cpp/src/request_am.cpp
@@ -52,11 +52,8 @@ struct AmHeader {
 
     std::optional<AmReceiverCallbackInfo> receiverCallbackInfo = std::nullopt;
     if (hasReceiverCallback) {
-      size_t ownerSize{0};
-      decode(&ownerSize, sizeof(ownerSize));
-
-      auto owner = AmReceiverCallbackOwnerType(ownerSize, 0);
-      decode(owner.data(), ownerSize);
+      AmReceiverCallbackOwnerType owner;
+      decode(owner.data(), AmReceiverCallbackOwnerType::storageSize());
 
       AmReceiverCallbackIdType id{};
       decode(&id, sizeof(id));
@@ -91,9 +88,10 @@ struct AmHeader {
   {
     size_t offset{0};
     bool hasReceiverCallback{static_cast<bool>(receiverCallbackInfo)};
-    const size_t ownerSize = (receiverCallbackInfo) ? receiverCallbackInfo->owner.size() : 0;
     const size_t amReceiverCallbackInfoSize =
-      (receiverCallbackInfo) ? sizeof(ownerSize) + ownerSize + sizeof(receiverCallbackInfo->id) : 0;
+      (receiverCallbackInfo)
+        ? AmReceiverCallbackOwnerType::storageSize() + sizeof(receiverCallbackInfo->id)
+        : 0;
     const uint8_t serializedMemoryTypePolicy = static_cast<uint8_t>(memoryTypePolicy);
     const size_t userHeaderSize              = userHeader.size();
     const size_t totalSize                   = sizeof(memoryType) + sizeof(hasReceiverCallback) +
@@ -109,8 +107,7 @@ struct AmHeader {
     encode(&memoryType, sizeof(memoryType));
     encode(&hasReceiverCallback, sizeof(hasReceiverCallback));
     if (hasReceiverCallback) {
-      encode(&ownerSize, sizeof(ownerSize));
-      encode(receiverCallbackInfo->owner.c_str(), ownerSize);
+      encode(receiverCallbackInfo->owner.data(), AmReceiverCallbackOwnerType::storageSize());
       encode(&receiverCallbackInfo->id, sizeof(receiverCallbackInfo->id));
     }
     encode(&serializedMemoryTypePolicy, sizeof(serializedMemoryTypePolicy));
@@ -259,7 +256,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
           .at(amHeader.receiverCallbackInfo->id);
       } catch (const std::out_of_range& e) {
         ucxx_error("No AM receiver callback registered for owner '%s' with id %lu",
-                   std::string(amHeader.receiverCallbackInfo->owner).data(),
+                   amHeader.receiverCallbackInfo->owner.data(),
                    amHeader.receiverCallbackInfo->id);
       }
     }

--- a/cpp/tests/endpoint.cpp
+++ b/cpp/tests/endpoint.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>

--- a/cpp/tests/endpoint.cpp
+++ b/cpp/tests/endpoint.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
+#include <stdexcept>
+#include <tuple>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -54,6 +56,11 @@ TEST_F(EndpointTest, IsAlive)
   _remoteContext = nullptr;
   _worker->progress();
   ASSERT_FALSE(ep->isAlive());
+}
+
+TEST(AddressTest, EmptyAddressRejected)
+{
+  EXPECT_THROW(std::ignore = ucxx::createAddressFromString(""), std::invalid_argument);
 }
 
 }  // namespace

--- a/cpp/tests/header.cpp
+++ b/cpp/tests/header.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>

--- a/cpp/tests/header.cpp
+++ b/cpp/tests/header.cpp
@@ -4,6 +4,7 @@
  */
 #include <algorithm>
 #include <numeric>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -128,5 +129,15 @@ TEST_P(FromPointerGenerator, PointerConstructor)
 INSTANTIATE_TEST_SUITE_P(SingleFrame,
                          FromPointerGenerator,
                          testing::Values(0, 1, 5, 10, 100, 101, 200, 201));
+
+TEST(HeaderTest, DeserializeOversizedNframes)
+{
+  std::stringstream ss;
+  bool next      = false;
+  size_t nframes = ucxx::HeaderFramesSize + 1;
+  ss.write(reinterpret_cast<const char*>(&next), sizeof(next));
+  ss.write(reinterpret_cast<const char*>(&nframes), sizeof(nframes));
+  EXPECT_THROW(ucxx::Header(ss.str()), std::overflow_error);
+}
 
 }  // namespace

--- a/cpp/tests/rma.cpp
+++ b/cpp/tests/rma.cpp
@@ -1,10 +1,11 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>
 #include <memory>
 #include <numeric>
+#include <string>
 #include <tuple>
 #include <ucp/api/ucp.h>
 #include <ucs/memory/memory_type.h>
@@ -169,6 +170,27 @@ INSTANTIATE_TEST_SUITE_P(AttributeTests,
                          Combine(Values(UCS_MEMORY_TYPE_HOST),
                                  Values(0, 1, 4, 4096, 8192, 4194304),
                                  Values(false, true)));
+
+TEST_P(BasicUcxxRmaTest, RemoteKeyTruncatedSerializedData)
+{
+  // Build a data portion shorter than the fixed fields:
+  // packedRemoteKeySize + memoryBaseAddress + memorySize = 24 bytes
+  // This ensures no underflow can occur.
+  std::stringstream ssData;
+  size_t bogusPackedSize = 9999;
+  ssData.write(reinterpret_cast<const char*>(&bogusPackedSize), sizeof(bogusPackedSize));
+  auto dataStr = ssData.str();
+
+  std::hash<std::string> hasher;
+  size_t hash = hasher(dataStr);
+
+  std::stringstream ssFull;
+  ssFull.write(reinterpret_cast<const char*>(&hash), sizeof(hash));
+  ssFull << dataStr;
+
+  EXPECT_THROW(std::ignore = ucxx::createRemoteKeyFromSerialized(_ep, ssFull.str()),
+               std::overflow_error);
+}
 
 INSTANTIATE_TEST_SUITE_P(FailureTests, BasicUcxxRmaTest, Combine(Values(0, 4194304)));
 

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -876,4 +876,38 @@ TEST(WorkerBuilderTest, BuilderBackwardCompatibility)
   ASSERT_TRUE(worker2->isFutureEnabled());
 }
 
+TEST(AmReceiverCallbackOwnerTypeTest, DefaultConstructsEmpty)
+{
+  ucxx::AmReceiverCallbackOwnerType owner;
+  EXPECT_EQ(std::string(owner.data()), "");
+}
+
+TEST(AmReceiverCallbackOwnerTypeTest, ConstructsFromString)
+{
+  ucxx::AmReceiverCallbackOwnerType owner("MyApp");
+  EXPECT_EQ(std::string(owner.data()), "MyApp");
+}
+
+TEST(AmReceiverCallbackOwnerTypeTest, MaxLengthAccepted)
+{
+  std::string maxLen(ucxx::AmReceiverCallbackOwnerMaxLen, 'x');
+  EXPECT_NO_THROW(ucxx::AmReceiverCallbackOwnerType(maxLen));
+}
+
+TEST(AmReceiverCallbackOwnerTypeTest, OversizedStringRejected)
+{
+  std::string tooLong(ucxx::AmReceiverCallbackOwnerMaxLen + 1, 'x');
+  EXPECT_THROW(
+    { [[maybe_unused]] ucxx::AmReceiverCallbackOwnerType owner(tooLong); }, std::invalid_argument);
+}
+
+TEST(AmReceiverCallbackOwnerTypeTest, EqualityComparison)
+{
+  ucxx::AmReceiverCallbackOwnerType a("Test");
+  ucxx::AmReceiverCallbackOwnerType b("Test");
+  ucxx::AmReceiverCallbackOwnerType c("Other");
+  EXPECT_EQ(a, b);
+  EXPECT_NE(a, c);
+}
+
 }  // namespace


### PR DESCRIPTION
Add input validation and bounds checking across several deserialization and allocation code paths.

* Replace `AmReceiverCallbackOwnerType` with a fixed-size type.
* Validate `_packedRemoteKeySize` against the actual serialized data length before allocating in `RemoteKey::deserialize`.
* Validate `nframes` against `HeaderFramesSize` in `Header::deserialize` to prevent consumers from iterating past the fixed-size arrays.
* Check `malloc` return value in the `HostBuffer` constructor to avoid undefined behavior on allocation failure.
* Reject empty addresses in `createAddressFromString`.