### PR TITLE
Use `token.rapids.nvidia.com` when issuing S3 bucket creds in devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,8 @@ ENV HISTFILE="/home/coder/.cache/._bash_history"
 ###
 # sccache configuration
 ###
-ENV AWS_ROLE_ARN="arn:aws:iam::279114543810:role/nv-gha-token-sccache-devs"
+ENV AWS_IDP_URL="https://token.rapids.nvidia.com"
+ENV AWS_ROLE_ARN="arn:aws:iam::279114543810:role/rapids-token-sccache-devs"
 ENV SCCACHE_REGION="us-east-2"
 ENV SCCACHE_BUCKET="rapids-sccache-devs"
 ENV SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE=true


### PR DESCRIPTION
Set AWS_IDP_URL and update AWS_ROLE_ARN to use `token.rapids.nvidia.com`
