### PR TITLE
Restore distributed-ucxx flaky markers

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
@@ -265,6 +265,10 @@ async def test_ping_pong_numba(ucxx_loop):
 
 @pytest.mark.parametrize("protocol", ["ucx", "ucxx"])
 @pytest.mark.parametrize("processes", [True, False])
+@pytest.mark.flaky(
+    reruns=3,
+    only_rerun="Trying to reset UCX but not all Endpoints and/or Listeners are closed",
+)
 @gen_test()
 async def test_ucxx_localcluster(ucxx_loop, cleanup, protocol, processes):
     async with LocalCluster(
@@ -361,6 +365,10 @@ async def test_cuda_context(
                     )
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    only_rerun="Trying to reset UCX but not all Endpoints and/or Listeners are closed",
+)
 @gen_test()
 async def test_transpose(
     ucxx_loop,
@@ -415,6 +423,10 @@ async def test_comm_closed_on_read_error():
     assert writer.closed()
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    only_rerun="Trying to reset UCX but not all Endpoints and/or Listeners are closed",
+)
 @gen_test()
 async def test_embedded_cupy_array(
     ucxx_loop,


### PR DESCRIPTION
Some distributed-ucxx tests have been failing recently since their flaky markers were removed as it was believed the changes were sufficient to fix the issues, they weren't. Restore the flaky markers until the root cause can be narrowed down and the tests ultimately fixed.