### PR TITLE
Remove deprecated `Address::getString()`

### DIFF
--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <memory>
-#include <string>
 #include <string_view>
 
 #include <ucp/api/ucp.h>
@@ -117,17 +116,6 @@ class Address : public Component {
    * @returns The underlying `ucp_address_t` handle.
    */
   [[nodiscard]] std::string_view getStringView() const;
-
-  /**
-   * @brief Get the address as a string.
-   *
-   * Convenience method to copy the underlying address to a `std::string` and return it as
-   * a single object.
-   *
-   * @returns The underlying `ucp_address_t` handle.
-   */
-  [[deprecated("Removing in UCXX 0.51. Switch to `getStringView`.")]] [[nodiscard]] std::string
-  getString() const;
 };
 
 }  // namespace ucxx

--- a/cpp/src/address.cpp
+++ b/cpp/src/address.cpp
@@ -2,9 +2,9 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <cstring>
 #include <memory>
 #include <stdexcept>
-#include <string>
 #include <string_view>
 
 #include <ucxx/address.h>
@@ -58,7 +58,5 @@ std::string_view Address::getStringView() const
 {
   return std::string_view{reinterpret_cast<const char*>(_handle), _length};
 }
-
-std::string Address::getString() const { return std::string{getStringView()}; }
 
 }  // namespace ucxx

--- a/python/ucxx/ucxx/_lib/ucxx_api.pxd
+++ b/python/ucxx/ucxx/_lib/ucxx_api.pxd
@@ -367,7 +367,6 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
         ucp_address_t* getHandle()
         size_t getLength()
         string_view getStringView()
-        string getString()
 
     cdef cppclass Request(Component):
         cpp_bool isCompleted()


### PR DESCRIPTION
`Address::getString()` was deprecated in favor of the new `Address::getStringView()`. Removes that for UCXX v0.51/RAPIDS 26.08.