### PR TITLE
Synchronize Python futures pool access

### DIFF
--- a/cpp/python/src/worker.cpp
+++ b/cpp/python/src/worker.cpp
@@ -22,6 +22,23 @@ namespace ucxx {
 
 namespace python {
 
+namespace {
+
+class GilState {
+ public:
+  GilState() : _state(PyGILState_Ensure()) {}
+
+  GilState(const GilState&)            = delete;
+  GilState& operator=(const GilState&) = delete;
+
+  ~GilState() { PyGILState_Release(_state); }
+
+ private:
+  PyGILState_STATE _state;
+};
+
+}  // namespace
+
 Worker::Worker(std::shared_ptr<Context> context,
                const bool enableDelayedSubmission,
                const bool enableFuture)
@@ -73,10 +90,11 @@ void Worker::populateFuturesPool()
   }
 
   decltype(_futuresPool) newFuturesPool;
-  PyGILState_STATE state = PyGILState_Ensure();
-  for (size_t i = 0; i < futuresNeeded; ++i)
-    newFuturesPool.emplace(createFuture(_notifier));
-  PyGILState_Release(state);
+  {
+    GilState gil;
+    for (size_t i = 0; i < futuresNeeded; ++i)
+      newFuturesPool.emplace(createFuture(_notifier));
+  }
 
   std::lock_guard<std::mutex> lock(_futuresPoolMutex);
   while (_futuresPool.size() < maxPoolSize && !newFuturesPool.empty()) {
@@ -127,9 +145,8 @@ std::shared_ptr<::ucxx::Future> Worker::getFuture()
     ret = popFuture();
   }
   if (ret == nullptr) {
-    PyGILState_STATE state = PyGILState_Ensure();
-    ret                    = createFuture(_notifier);
-    PyGILState_Release(state);
+    GilState gil;
+    ret = createFuture(_notifier);
   }
 
   ucxx_trace_req("getFuture: %p %p", ret.get(), ret->getHandle());

--- a/cpp/python/src/worker.cpp
+++ b/cpp/python/src/worker.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <functional>
@@ -52,23 +52,36 @@ std::shared_ptr<::ucxx::Worker> createWorker(std::shared_ptr<Context> context,
 
 void Worker::populateFuturesPool()
 {
-  if (_enableFuture) {
-    ucxx_trace_req("ucxx::python::Worker::%s, Worker: %p, populateFuturesPool: %p",
-                   __func__,
-                   this,
-                   shared_from_this().get());
-    // If the pool goes under half expected size, fill it up again.
-    if (_futuresPool.size() < 50) {
-      std::lock_guard<std::mutex> lock(_futuresPoolMutex);
-      PyGILState_STATE state = PyGILState_Ensure();
-      while (_futuresPool.size() < 100)
-        _futuresPool.emplace(createFuture(_notifier));
-      PyGILState_Release(state);
-    }
-  } else {
+  if (!_enableFuture) {
     throw std::runtime_error(
       "Worker future support disabled, please set enableFuture=true when creating the "
       "Worker to use this method.");
+  }
+
+  ucxx_trace_req("ucxx::python::Worker::%s, Worker: %p, populateFuturesPool: %p",
+                 __func__,
+                 this,
+                 shared_from_this().get());
+
+  constexpr size_t maxPoolSize = 100;
+  constexpr size_t minPoolSize = maxPoolSize / 2;
+  size_t futuresNeeded         = 0;
+  {
+    std::lock_guard<std::mutex> lock(_futuresPoolMutex);
+    if (_futuresPool.size() >= minPoolSize) return;
+    futuresNeeded = maxPoolSize - _futuresPool.size();
+  }
+
+  decltype(_futuresPool) newFuturesPool;
+  PyGILState_STATE state = PyGILState_Ensure();
+  for (size_t i = 0; i < futuresNeeded; ++i)
+    newFuturesPool.emplace(createFuture(_notifier));
+  PyGILState_Release(state);
+
+  std::lock_guard<std::mutex> lock(_futuresPoolMutex);
+  while (_futuresPool.size() < maxPoolSize && !newFuturesPool.empty()) {
+    _futuresPool.emplace(std::move(newFuturesPool.front()));
+    newFuturesPool.pop();
   }
 }
 
@@ -79,39 +92,48 @@ void Worker::clearFuturesPool()
                    __func__,
                    this,
                    shared_from_this().get());
-    std::lock_guard<std::mutex> lock(_futuresPoolMutex);
-    PyGILState_STATE state = PyGILState_Ensure();
     decltype(_futuresPool) newFuturesPool;
-    std::swap(_futuresPool, newFuturesPool);
-    PyGILState_Release(state);
+    {
+      std::lock_guard<std::mutex> lock(_futuresPoolMutex);
+      std::swap(_futuresPool, newFuturesPool);
+    }
   }
 }
 
 std::shared_ptr<::ucxx::Future> Worker::getFuture()
 {
-  if (_enableFuture) {
-    if (_futuresPool.size() == 0) {
-      ucxx_warn(
-        "No Futures available during getFuture(), make sure the Notifier is running "
-        "running and calling populateFuturesPool() periodically. Filling futures pool "
-        "now, but this may be inefficient.");
-      populateFuturesPool();
-    }
-
-    std::shared_ptr<::ucxx::Future> ret{nullptr};
-    {
-      std::lock_guard<std::mutex> lock(_futuresPoolMutex);
-      ret = _futuresPool.front();
-      _futuresPool.pop();
-    }
-    ucxx_trace_req("getFuture: %p %p", ret.get(), ret->getHandle());
-    return std::dynamic_pointer_cast<::ucxx::Future>(ret);
-  } else {
+  if (!_enableFuture) {
     throw std::runtime_error(
       "Worker future support disabled, please set enableFuture=true when creating the "
       "Worker to use this method.");
-    return nullptr;
   }
+
+  auto popFuture = [this]() -> std::shared_ptr<::ucxx::Future> {
+    std::lock_guard<std::mutex> lock(_futuresPoolMutex);
+    if (_futuresPool.empty()) return nullptr;
+
+    auto ret = _futuresPool.front();
+    _futuresPool.pop();
+    return ret;
+  };
+
+  auto ret = popFuture();
+  if (ret == nullptr) {
+    ucxx_warn(
+      "No Futures available during getFuture(), make sure the Notifier is running "
+      "running and calling populateFuturesPool() periodically. Filling futures pool "
+      "now, but this may be inefficient.");
+    populateFuturesPool();
+    ret = popFuture();
+  }
+  if (ret == nullptr) {
+    PyGILState_STATE state = PyGILState_Ensure();
+    ret                    = createFuture(_notifier);
+    PyGILState_Release(state);
+  }
+
+  ucxx_trace_req("getFuture: %p %p", ret.get(), ret->getHandle());
+  return ret;
 }
 
 RequestNotifierWaitState Worker::waitRequestNotifier(uint64_t periodNs)


### PR DESCRIPTION
Before this change `populateFuturesPool()` read `_futuresPool.size()` outside the mutex, and `getFuture()` also read `_futuresPool.size()` outside the mutex. A concrete race can occur while the [Python notifier thread](https://github.com/rapidsai/ucxx/blob/main/python/ucxx/ucxx/_lib_async/notifier_thread.py) runs `Worker::populateFuturesPool()` and concurrently a request future is fulfilled by another thread via `Worker::getFuture()`.