### PR TITLE
Remove numba-cuda upper bound

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - libtool
 - make
 - ninja
-- numba-cuda>=0.22.1,<0.29.0
+- numba-cuda>=0.22.1
 - numpy>=1.23,<3.0
 - nvidia-ml-py>=12
 - pip

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - libtool
 - make
 - ninja
-- numba-cuda>=0.22.1,<0.29.0
+- numba-cuda>=0.22.1
 - numpy>=1.23,<3.0
 - nvidia-ml-py>=12
 - pip

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - libtool
 - make
 - ninja
-- numba-cuda>=0.22.1,<0.29.0
+- numba-cuda>=0.22.1
 - numpy>=1.23,<3.0
 - nvidia-ml-py>=12
 - pip

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - libtool
 - make
 - ninja
-- numba-cuda>=0.22.1,<0.29.0
+- numba-cuda>=0.22.1
 - numpy>=1.23,<3.0
 - nvidia-ml-py>=12
 - pip

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -385,7 +385,7 @@ dependencies:
       - output_types: [conda]
         packages:
           - gdb  # Used for timeout_with_stack.py
-          - &numba_cuda_test numba-cuda>=0.22.1,<0.29.0
+          - &numba_cuda_test numba-cuda>=0.22.1
           - psutil  # Used for timeout_with_stack.py
     specific:
       - output_types: [requirements, pyproject]
@@ -394,12 +394,12 @@ dependencies:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:
-              - &numba_cuda_cu12_test numba-cuda[cu12]>=0.22.1,<0.29.0
+              - &numba_cuda_cu12_test numba-cuda[cu12]>=0.22.1
           - matrix:
               cuda: "13.*"
               cuda_suffixed: "true"
             packages:
-              - &numba_cuda_cu13_test numba-cuda[cu13]>=0.22.1,<0.29.0
+              - &numba_cuda_cu13_test numba-cuda[cu13]>=0.22.1
           # fallback to numba-cuda with no extra CUDA packages if 'cuda_suffixed' isn't true
           - matrix:
             packages:

--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -47,7 +47,7 @@ docs = [
 test = [
     "cudf==26.8.*,>=0.0.0a0",
     "cupy-cuda13x>=13.6.0",
-    "numba-cuda>=0.22.1,<0.29.0",
+    "numba-cuda>=0.22.1",
     "numpy>=1.23,<3.0",
     "pytest",
     "pytest-rerunfailures!=16.0.0",

--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -44,7 +44,7 @@ test = [
     "cloudpickle",
     "cudf==26.8.*,>=0.0.0a0",
     "cupy-cuda13x>=13.6.0",
-    "numba-cuda>=0.22.1,<0.29.0",
+    "numba-cuda>=0.22.1",
     "pytest",
     "pytest-asyncio>=1.0.0",
     "pytest-rerunfailures!=16.0.0",


### PR DESCRIPTION
This PR removes the upper bound on the `numba-cuda` dependency,
leaving only the existing lower bound pins in place.

<hr>

Part of this work:

* https://github.com/rapidsai/build-planning/issues/245