### PR TITLE
Backport fixes for Velox to release/0.50

### DIFF
--- a/cmake/RAPIDS.cmake
+++ b/cmake/RAPIDS.cmake
@@ -8,7 +8,7 @@
 # This is the preferred entry point for projects using rapids-cmake
 #
 # Enforce the minimum required CMake version for all users
-cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
 # Allow users to control which version is used
 if(NOT rapids-cmake-version OR NOT rapids-cmake-version MATCHES [[^([0-9][0-9])\.([0-9][0-9])$]])

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - automake
 - c-compiler
 - cloudpickle
-- cmake>=4.0
+- cmake>=3.26.4,!=3.30.0
 - cuda-core>=0.3.2
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - automake
 - c-compiler
 - cloudpickle
-- cmake>=4.0
+- cmake>=3.26.4,!=3.30.0
 - cuda-core>=0.3.2
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - automake
 - c-compiler
 - cloudpickle
-- cmake>=4.0
+- cmake>=3.26.4,!=3.30.0
 - cuda-core>=0.3.2
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - automake
 - c-compiler
 - cloudpickle
-- cmake>=4.0
+- cmake>=3.26.4,!=3.30.0
 - cuda-core>=0.3.2
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/recipes/libucxx/conda_build_config.yaml
+++ b/conda/recipes/libucxx/conda_build_config.yaml
@@ -14,7 +14,7 @@ c_stdlib_version:
   - "2.28"
 
 cmake:
-  - ">=4.0"
+  - ">=3.26.4"
 
 ucx:
   - "==1.18.*"  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("12")]

--- a/conda/recipes/ucxx/conda_build_config.yaml
+++ b/conda/recipes/ucxx/conda_build_config.yaml
@@ -14,7 +14,7 @@ c_stdlib_version:
   - "2.28"
 
 cmake:
-  - ">=4.0"
+  - ">=3.26.4"
 
 ucx:
   - "==1.18.*"  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("12")]

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -5,7 +5,7 @@
 # cmake-format: on
 # =================================================================================
 
-cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 include(../cmake/rapids_config.cmake)
 include(rapids-cmake)

--- a/cpp/python/CMakeLists.txt
+++ b/cpp/python/CMakeLists.txt
@@ -5,7 +5,7 @@
 # cmake-format: on
 # ======================================================================================================
 
-cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 include(../../cmake/rapids_config.cmake)
 include(rapids-cmake)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -169,7 +169,7 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - &cmake_ver cmake>=4.0
+          - &cmake_ver cmake>=3.26.4,!=3.30.0
           - librmm==26.6.*
           - ninja
       - output_types: [requirements, pyproject]

--- a/python/libucxx/CMakeLists.txt
+++ b/python/libucxx/CMakeLists.txt
@@ -5,7 +5,7 @@
 # cmake-format: on
 # =============================================================================
 
-cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 file(READ "${CMAKE_CURRENT_LIST_DIR}/../../VERSION" _version_contents)
 if(_version_contents MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+).*$")

--- a/python/libucxx/pyproject.toml
+++ b/python/libucxx/pyproject.toml
@@ -60,7 +60,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
-    "cmake>=4.0",
+    "cmake>=3.26.4,!=3.30.0",
     "librmm==26.6.*",
     "libucx>=1.19.0,<1.19.1",
     "ninja",

--- a/python/ucxx/CMakeLists.txt
+++ b/python/ucxx/CMakeLists.txt
@@ -5,7 +5,7 @@
 # cmake-format: on
 # =================================================================================
 
-cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 file(READ "${CMAKE_CURRENT_LIST_DIR}/../../VERSION" _version_contents)
 if(_version_contents MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+).*$")

--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -60,7 +60,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
-    "cmake>=4.0",
+    "cmake>=3.26.4,!=3.30.0",
     "cython>=3.2.2",
     "librmm==26.6.*",
     "libucxx==0.50.*",


### PR DESCRIPTION
This PR backports fixes needed in Velox to `release/0.50`. A hotfix release is not required, we only need a branch based on `release/0.50` until Velox is updated to use CMake 4.x in its CI.

This reverts commit babdcfa0e5c26ebec146c12088b669efbecf1b95.
