### PR TITLE
Add UCX reset retries for distributed-ucxx tests

### DIFF
--- a/python/distributed-ucxx/distributed_ucxx/tests/test_nanny.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_nanny.py
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
 
 from distributed import Nanny, Scheduler
 from distributed.utils_test import gen_test
@@ -16,6 +18,10 @@ class KeyboardInterruptWorker(Worker):
         self.loop.add_callback(raise_err)
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    only_rerun="Trying to reset UCX but not all Endpoints and/or Listeners are closed",
+)
 @gen_test(timeout=120)
 async def test_nanny_closed_by_keyboard_interrupt(ucxx_loop):
     async with Scheduler(protocol="ucx", dashboard_address=":0") as s:

--- a/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
+++ b/python/distributed-ucxx/distributed_ucxx/tests/test_ucxx.py
@@ -90,6 +90,10 @@ async def test_comm_objs(ucxx_loop):
     assert comm.peer_address == serv_comm.local_address
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    only_rerun="Trying to reset UCX but not all Endpoints and/or Listeners are closed",
+)
 @gen_test()
 async def test_ucxx_specific(ucxx_loop):
     """
@@ -317,6 +321,10 @@ async def test_stress(
                 await x
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    only_rerun="Trying to reset UCX but not all Endpoints and/or Listeners are closed",
+)
 @gen_test()
 async def test_simple(
     ucxx_loop,


### PR DESCRIPTION
Mark `test_nanny_closed_by_keyboard_interrupt`, `test_ucxx_specific`, and `test_simple` as flaky with the same UCX reset retry configuration used by other distributed-ucxx tests, retrying only when teardown hits `Trying to reset UCX but not all Endpoints and/or Listeners are closed`. This is possibly failing more frequently due to the recent upgrade to Dask/Distributed 2026.3.0.
