### PR TITLE
Avoid retaining listener tracebacks in UCXX log records

### DIFF
--- a/python/ucxx/ucxx/_lib_async/listener.py
+++ b/python/ucxx/ucxx/_lib_async/listener.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 import os
 import threading
+import traceback
 import weakref
 
 import ucxx._lib.libucxx as ucx_api
@@ -16,6 +17,16 @@ from .exchange_peer_info import exchange_peer_info
 from .utils import hash64bits
 
 logger = logging.getLogger("ucx")
+
+
+def _log_exception(message):
+    """Log the current exception without retaining traceback frame references."""
+    logger.error(
+        "%s\n%s",
+        message,
+        traceback.format_exc().rstrip(),
+        stacklevel=2,
+    )
 
 
 class ActiveClients:
@@ -194,11 +205,11 @@ async def _listener_handler_coroutine(
             try:
                 await func(ep)
             except Exception:
-                logger.exception("Uncaught listener callback error")
+                _log_exception("Uncaught listener callback error")
         else:
             func(ep)
     except Exception:
-        logger.exception("Unexpected error in listener handler coroutine")
+        _log_exception("Unexpected error in listener handler coroutine")
     finally:
         active_clients.dec(ident)
         del ep

--- a/python/ucxx/ucxx/_lib_async/tests/test_listener.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_listener.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import gc
+import logging
+import weakref
+
+import pytest
+
+from ucxx._lib_async import listener as listener_mod
+
+
+class _ActiveClients:
+    def inc(self, ident):
+        pass
+
+    def dec(self, ident):
+        pass
+
+
+class _ConnectionRequest:
+    handle = 1
+
+
+class _Context:
+    pass
+
+
+class _Endpoint:
+    def __init__(self, endpoint, ctx, tags):
+        self.ctx = ctx
+        self._tags = tags
+
+
+class _LogCaptureHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "log_message", "exception_message"),
+    [
+        (
+            "peer-info",
+            "Unexpected error in listener handler coroutine",
+            "RuntimeError: peer info exchange failed",
+        ),
+        (
+            "callback",
+            "Uncaught listener callback error",
+            "RuntimeError: listener callback failed",
+        ),
+    ],
+)
+async def test_listener_handler_exception_log_does_not_retain_context(
+    monkeypatch,
+    failure,
+    log_message,
+    exception_message,
+):
+    async def fail_peer_info_exchange(*args, **kwargs):
+        raise RuntimeError("peer info exchange failed")
+
+    async def exchange_peer_info(*args, **kwargs):
+        return {"msg_tag": 2}
+
+    async def fail_callback(ep):
+        raise RuntimeError("listener callback failed")
+
+    def noop_callback(ep):
+        pass
+
+    if failure == "peer-info":
+        exchange_peer_info = fail_peer_info_exchange
+        callback = noop_callback
+    else:
+        callback = fail_callback
+
+    monkeypatch.setattr(
+        listener_mod,
+        "exchange_peer_info",
+        exchange_peer_info,
+    )
+    monkeypatch.setattr(
+        listener_mod,
+        "Endpoint",
+        _Endpoint,
+    )
+
+    log_handler = _LogCaptureHandler()
+    listener_mod.logger.addHandler(log_handler)
+    try:
+        ctx = _Context()
+        ctx_ref = weakref.ref(ctx)
+
+        await listener_mod._listener_handler_coroutine(
+            conn_request=_ConnectionRequest(),
+            ctx=ctx,
+            func=callback,
+            endpoint_error_handling=True,
+            connect_timeout=1,
+            ident=1,
+            active_clients=_ActiveClients(),
+        )
+        del ctx
+
+        gc.collect()
+
+        assert log_handler.records
+        record = log_handler.records[-1]
+        assert log_message in record.getMessage()
+        assert record.exc_info is None
+        assert exception_message in record.getMessage()
+        assert ctx_ref() is None
+    finally:
+        listener_mod.logger.removeHandler(log_handler)


### PR DESCRIPTION
Pytest 9.1.0 now captures logs from non-propagating loggers, including UCXX's `ucx` logger. Listener errors logged with `logger.exception(...)` therefore leave traceback objects in captured `LogRecord.exc_info`, which can keep listener frames and UCXX context objects alive until pytest teardown completes.

This updates listener exception logging to format the traceback into the log message instead of storing it in `LogRecord.exc_info`. The visible traceback is preserved, but pytest no longer retains traceback frame references through fixture teardown.

Changes included:
- Add a helper for listener exception logging that preserves traceback text without retaining traceback objects.
- Use that helper for listener callback failures and listener handler failures.
- Add regression coverage for peer-info exchange failures and listener callback failures, verifying:
  - the exception text is still logged
  - `LogRecord.exc_info` is not retained
  - the listener context can be garbage collected