### PR TITLE
Fix progress thread stop timeout handling

### DIFF
--- a/cpp/include/ucxx/worker_progress_thread.h
+++ b/cpp/include/ucxx/worker_progress_thread.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -47,8 +48,11 @@ typedef void* ProgressThreadStartCallbackArg;
  */
 class WorkerProgressThread {
  private:
-  std::thread _thread{};                                       ///< Thread object
-  std::shared_ptr<bool> _stop{std::make_shared<bool>(false)};  ///< Signal to stop on next iteration
+  std::thread _thread{};  ///< Thread object
+  std::shared_ptr<std::atomic_bool> _stop{
+    std::make_shared<std::atomic_bool>(false)};  ///< Signal to stop on next iteration
+  std::shared_ptr<std::atomic_bool> _finished{
+    std::make_shared<std::atomic_bool>(false)};  ///< Whether the thread function has returned
   bool _pollingMode{false};  ///< Whether thread will use polling mode to progress
   SignalWorkerFunction _signalWorkerFunction{
     nullptr};  ///< Function signaling worker to wake the progress event (when _pollingMode is
@@ -71,6 +75,8 @@ class WorkerProgressThread {
    * @param[in] progressFunction            user-defined progress function implementation.
    * @param[in] stop                        reference to the stop signal causing the
    *                                        progress loop to terminate.
+   * @param[in] finished                    reference to the signal set when the thread function
+   *                                        returns.
    * @param[in] setThreadId                 callback function executed before the
    *                                        `startCallback` with a purpose of setting the
    *                                        thread ID with the parent so it is known before
@@ -83,7 +89,8 @@ class WorkerProgressThread {
    */
   static void progressUntilSync(
     std::function<bool(void)> progressFunction,
-    std::shared_ptr<bool> stop,
+    std::shared_ptr<std::atomic_bool> stop,
+    std::shared_ptr<std::atomic_bool> finished,
     std::function<void(void)> setThreadId,
     ProgressThreadStartCallback startCallback,
     ProgressThreadStartCallbackArg startCallbackArg,

--- a/cpp/src/worker_progress_thread.cpp
+++ b/cpp/src/worker_progress_thread.cpp
@@ -2,17 +2,31 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <chrono>
+#include <cstdint>
+#include <exception>
 #include <memory>
+#include <stdexcept>
+#include <thread>
 
 #include <ucxx/log.h>
 #include <ucxx/utils/callback_notifier.h>
 #include <ucxx/worker_progress_thread.h>
 
 namespace ucxx {
+namespace {
+
+constexpr uint64_t stopTimeoutNs{3000000000};
+constexpr uint64_t stopSignalIntervalNs{100000000};
+constexpr std::chrono::nanoseconds stopTimeout{stopTimeoutNs};
+constexpr std::chrono::nanoseconds stopSignalInterval{stopSignalIntervalNs};
+
+}  // namespace
 
 void WorkerProgressThread::progressUntilSync(
   std::function<bool(void)> progressFunction,
-  std::shared_ptr<bool> stop,
+  std::shared_ptr<std::atomic_bool> stop,
+  std::shared_ptr<std::atomic_bool> finished,
   std::function<void(void)> setThreadId,
   ProgressThreadStartCallback startCallback,
   ProgressThreadStartCallbackArg startCallbackArg,
@@ -27,13 +41,15 @@ void WorkerProgressThread::progressUntilSync(
 
   if (startCallback) startCallback(startCallbackArg);
 
-  while (!*stop) {
+  while (!stop->load(std::memory_order_acquire)) {
     delayedSubmissionCollection->processPre();
 
     progressFunction();
 
     delayedSubmissionCollection->processPost();
   }
+
+  finished->store(true, std::memory_order_release);
 }
 
 WorkerProgressThread::WorkerProgressThread(
@@ -53,6 +69,7 @@ WorkerProgressThread::WorkerProgressThread(
   _thread = std::thread(WorkerProgressThread::progressUntilSync,
                         progressFunction,
                         _stop,
+                        _finished,
                         setThreadId,
                         _startCallback,
                         _startCallbackArg,
@@ -68,22 +85,66 @@ void WorkerProgressThread::stop()
     return;
   }
 
+  auto directStop = [this]() {
+    _stop->store(true, std::memory_order_release);
+    _signalWorkerFunction();
+  };
+
+  auto waitForThreadFinished = [this]() {
+    const auto deadline = std::chrono::steady_clock::now() + stopTimeout;
+    while (!_finished->load(std::memory_order_acquire)) {
+      _signalWorkerFunction();
+
+      const auto now = std::chrono::steady_clock::now();
+      if (now >= deadline) return false;
+
+      auto sleepPeriod = std::chrono::duration_cast<std::chrono::nanoseconds>(deadline - now);
+      if (sleepPeriod > stopSignalInterval) sleepPeriod = stopSignalInterval;
+      std::this_thread::sleep_for(sleepPeriod);
+    }
+
+    return true;
+  };
+
   utils::CallbackNotifier callbackNotifierPre{};
   auto idPre = _delayedSubmissionCollection->registerGenericPre(
     [&callbackNotifierPre]() { callbackNotifierPre.set(); });
   _signalWorkerFunction();
-  if (!callbackNotifierPre.wait(3000000000)) {
-    _delayedSubmissionCollection->cancelGenericPre(idPre);
+  if (!callbackNotifierPre.wait(stopTimeoutNs, _signalWorkerFunction, stopSignalIntervalNs)) {
+    try {
+      _delayedSubmissionCollection->cancelGenericPre(idPre);
+    } catch (const std::runtime_error& e) {
+      ucxx_warn("Could not cancel progress thread stop pre callback: %s", e.what());
+    }
   }
 
+  bool directStopRequired = false;
   utils::CallbackNotifier callbackNotifierPost{};
   auto idPost = _delayedSubmissionCollection->registerGenericPost([this, &callbackNotifierPost]() {
-    *_stop = true;
+    _stop->store(true, std::memory_order_release);
     callbackNotifierPost.set();
   });
   _signalWorkerFunction();
-  if (!callbackNotifierPost.wait(3000000000)) {
-    _delayedSubmissionCollection->cancelGenericPost(idPost);
+  if (!callbackNotifierPost.wait(stopTimeoutNs, _signalWorkerFunction, stopSignalIntervalNs)) {
+    directStopRequired = true;
+    try {
+      _delayedSubmissionCollection->cancelGenericPost(idPost);
+    } catch (const std::runtime_error& e) {
+      ucxx_warn("Could not cancel progress thread stop post callback: %s", e.what());
+    }
+  }
+
+  if (directStopRequired) {
+    ucxx_warn(
+      "Timed out waiting for worker progress thread stop callback; requesting direct stop");
+    directStop();
+  }
+
+  if (!waitForThreadFinished()) {
+    ucxx_error(
+      "Worker progress thread did not stop within %lu ns; terminating to avoid an indefinite join",
+      stopTimeoutNs);
+    std::terminate();
   }
 
   _thread.join();


### PR DESCRIPTION
## Summary
- make the progress-thread stop state atomic so it can be safely set from the caller
- keep the existing pre/post shutdown synchronization path
- if the stop-setting post callback times out, request a direct stop, repeatedly wake the worker, and fail explicitly if the thread still does not exit

## Why
`WorkerProgressThread::stop()` could cancel the timed-out post callback and then call `join()` even though `_stop` was never set. In that state the progress loop can continue forever and the caller blocks indefinitely.

## Validation
- `git diff --check`
- Tried `cmake -S cpp -B cpp/build/local-check -G Ninja -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DBUILD_EXAMPLES=OFF -DUCXX_ENABLE_CCCL=OFF`; configure is blocked locally because UCX is not installed (`ucxConfig.cmake` / `ucx-config.cmake` not found).
