### PR TITLE
Fix progress thread shutdown hang after stop callback timeout

### DIFF
--- a/cpp/include/ucxx/worker_progress_thread.h
+++ b/cpp/include/ucxx/worker_progress_thread.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -47,6 +48,27 @@ typedef void* ProgressThreadStartCallbackArg;
  * the program to block until that stage is reached.
  */
 class WorkerProgressThread {
+ public:
+  /**
+   * @brief Progress thread stop synchronization configuration.
+   */
+  struct StopConfig {
+    uint64_t callbackTimeoutNs;  ///< Maximum time to wait for each stop callback.
+    uint64_t signalIntervalNs;   ///< Interval for waking the worker while waiting.
+
+    /**
+     * @brief Create stop synchronization configuration.
+     *
+     * @param[in] callbackTimeoutNs maximum time in nanoseconds to wait for each stop callback.
+     * @param[in] signalIntervalNs interval in nanoseconds for waking the worker while waiting.
+     */
+    explicit StopConfig(uint64_t callbackTimeoutNs = 3000000000,
+                        uint64_t signalIntervalNs  = 100000000)
+      : callbackTimeoutNs(callbackTimeoutNs), signalIntervalNs(signalIntervalNs)
+    {
+    }
+  };
+
  private:
   std::thread _thread{};  ///< Thread object
   std::shared_ptr<std::atomic<bool>> _stop{
@@ -196,6 +218,16 @@ class WorkerProgressThread {
    * Raises the stop signal and joins the thread.
    */
   void stop();
+
+  /**
+   * @brief Stop the progress thread with custom stop synchronization parameters.
+   *
+   * Raises the stop signal and joins the thread. This overload is intended for tests that need
+   * deterministic stop callback timeout behavior.
+   *
+   * @param[in] stopConfig  progress thread stop synchronization configuration.
+   */
+  void stop(StopConfig stopConfig);
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/worker_progress_thread.h
+++ b/cpp/include/ucxx/worker_progress_thread.h
@@ -216,18 +216,10 @@ class WorkerProgressThread {
    * @brief Stop the progress thread.
    *
    * Raises the stop signal and joins the thread.
-   */
-  void stop();
-
-  /**
-   * @brief Stop the progress thread with custom stop synchronization parameters.
-   *
-   * Raises the stop signal and joins the thread. This overload is intended for tests that need
-   * deterministic stop callback timeout behavior.
    *
    * @param[in] stopConfig  progress thread stop synchronization configuration.
    */
-  void stop(StopConfig stopConfig);
+  void stop(StopConfig stopConfig = StopConfig{});
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/worker_progress_thread.h
+++ b/cpp/include/ucxx/worker_progress_thread.h
@@ -61,6 +61,8 @@ class WorkerProgressThread {
      *
      * @param[in] callbackTimeoutNs maximum time in nanoseconds to wait for each stop callback.
      * @param[in] signalIntervalNs interval in nanoseconds for waking the worker while waiting.
+     *                             A value of 0 disables periodic wakeups: the worker is signaled
+     *                             once before each wait and not again until the wait returns.
      */
     explicit StopConfig(uint64_t callbackTimeoutNs = 3000000000,
                         uint64_t signalIntervalNs  = 100000000)

--- a/cpp/include/ucxx/worker_progress_thread.h
+++ b/cpp/include/ucxx/worker_progress_thread.h
@@ -1,9 +1,10 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -47,8 +48,9 @@ typedef void* ProgressThreadStartCallbackArg;
  */
 class WorkerProgressThread {
  private:
-  std::thread _thread{};                                       ///< Thread object
-  std::shared_ptr<bool> _stop{std::make_shared<bool>(false)};  ///< Signal to stop on next iteration
+  std::thread _thread{};  ///< Thread object
+  std::shared_ptr<std::atomic<bool>> _stop{
+    std::make_shared<std::atomic<bool>>(false)};  ///< Signal to stop on next iteration
   bool _pollingMode{false};  ///< Whether thread will use polling mode to progress
   SignalWorkerFunction _signalWorkerFunction{
     nullptr};  ///< Function signaling worker to wake the progress event (when _pollingMode is
@@ -83,7 +85,7 @@ class WorkerProgressThread {
    */
   static void progressUntilSync(
     std::function<bool(void)> progressFunction,
-    std::shared_ptr<bool> stop,
+    std::shared_ptr<std::atomic<bool>> stop,
     std::function<void(void)> setThreadId,
     ProgressThreadStartCallback startCallback,
     ProgressThreadStartCallbackArg startCallbackArg,

--- a/cpp/src/worker_progress_thread.cpp
+++ b/cpp/src/worker_progress_thread.cpp
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include <cstdint>
 #include <memory>
 #include <stdexcept>
 
@@ -11,12 +10,6 @@
 #include <ucxx/worker_progress_thread.h>
 
 namespace ucxx {
-namespace {
-
-constexpr uint64_t stopCallbackTimeoutNs{3000000000};
-constexpr uint64_t stopSignalIntervalNs{100000000};
-
-}  // namespace
 
 void WorkerProgressThread::progressUntilSync(
   std::function<bool(void)> progressFunction,
@@ -69,7 +62,9 @@ WorkerProgressThread::WorkerProgressThread(
 
 WorkerProgressThread::~WorkerProgressThread() { stop(); }
 
-void WorkerProgressThread::stop()
+void WorkerProgressThread::stop() { stop(StopConfig{}); }
+
+void WorkerProgressThread::stop(StopConfig stopConfig)
 {
   if (!_thread.joinable()) {
     ucxx_debug("Worker progress thread not running or already stopped");
@@ -81,7 +76,7 @@ void WorkerProgressThread::stop()
     [&callbackNotifierPre]() { callbackNotifierPre.set(); });
   _signalWorkerFunction();
   if (!callbackNotifierPre.wait(
-        stopCallbackTimeoutNs, _signalWorkerFunction, stopSignalIntervalNs)) {
+        stopConfig.callbackTimeoutNs, _signalWorkerFunction, stopConfig.signalIntervalNs)) {
     try {
       _delayedSubmissionCollection->cancelGenericPre(idPre);
     } catch (const std::runtime_error&) {
@@ -96,7 +91,7 @@ void WorkerProgressThread::stop()
   });
   _signalWorkerFunction();
   if (!callbackNotifierPost.wait(
-        stopCallbackTimeoutNs, _signalWorkerFunction, stopSignalIntervalNs)) {
+        stopConfig.callbackTimeoutNs, _signalWorkerFunction, stopConfig.signalIntervalNs)) {
     _stop->store(true, std::memory_order_release);
     _signalWorkerFunction();
     try {

--- a/cpp/src/worker_progress_thread.cpp
+++ b/cpp/src/worker_progress_thread.cpp
@@ -1,18 +1,26 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <cstdint>
 #include <memory>
+#include <stdexcept>
 
 #include <ucxx/log.h>
 #include <ucxx/utils/callback_notifier.h>
 #include <ucxx/worker_progress_thread.h>
 
 namespace ucxx {
+namespace {
+
+constexpr uint64_t stopCallbackTimeoutNs{3000000000};
+constexpr uint64_t stopSignalIntervalNs{100000000};
+
+}  // namespace
 
 void WorkerProgressThread::progressUntilSync(
   std::function<bool(void)> progressFunction,
-  std::shared_ptr<bool> stop,
+  std::shared_ptr<std::atomic<bool>> stop,
   std::function<void(void)> setThreadId,
   ProgressThreadStartCallback startCallback,
   ProgressThreadStartCallbackArg startCallbackArg,
@@ -27,7 +35,7 @@ void WorkerProgressThread::progressUntilSync(
 
   if (startCallback) startCallback(startCallbackArg);
 
-  while (!*stop) {
+  while (!stop->load(std::memory_order_acquire)) {
     delayedSubmissionCollection->processPre();
 
     progressFunction();
@@ -72,18 +80,30 @@ void WorkerProgressThread::stop()
   auto idPre = _delayedSubmissionCollection->registerGenericPre(
     [&callbackNotifierPre]() { callbackNotifierPre.set(); });
   _signalWorkerFunction();
-  if (!callbackNotifierPre.wait(3000000000)) {
-    _delayedSubmissionCollection->cancelGenericPre(idPre);
+  if (!callbackNotifierPre.wait(
+        stopCallbackTimeoutNs, _signalWorkerFunction, stopSignalIntervalNs)) {
+    try {
+      _delayedSubmissionCollection->cancelGenericPre(idPre);
+    } catch (const std::runtime_error&) {
+      // The callback started concurrently with cancellation and will signal the notifier.
+    }
   }
 
   utils::CallbackNotifier callbackNotifierPost{};
   auto idPost = _delayedSubmissionCollection->registerGenericPost([this, &callbackNotifierPost]() {
-    *_stop = true;
+    _stop->store(true, std::memory_order_release);
     callbackNotifierPost.set();
   });
   _signalWorkerFunction();
-  if (!callbackNotifierPost.wait(3000000000)) {
-    _delayedSubmissionCollection->cancelGenericPost(idPost);
+  if (!callbackNotifierPost.wait(
+        stopCallbackTimeoutNs, _signalWorkerFunction, stopSignalIntervalNs)) {
+    _stop->store(true, std::memory_order_release);
+    _signalWorkerFunction();
+    try {
+      _delayedSubmissionCollection->cancelGenericPost(idPost);
+    } catch (const std::runtime_error&) {
+      // The callback started concurrently with cancellation and will signal the notifier.
+    }
   }
 
   _thread.join();

--- a/cpp/src/worker_progress_thread.cpp
+++ b/cpp/src/worker_progress_thread.cpp
@@ -62,8 +62,6 @@ WorkerProgressThread::WorkerProgressThread(
 
 WorkerProgressThread::~WorkerProgressThread() { stop(); }
 
-void WorkerProgressThread::stop() { stop(StopConfig{}); }
-
 void WorkerProgressThread::stop(StopConfig stopConfig)
 {
   if (!_thread.joinable()) {

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -15,6 +15,8 @@
 #include <gtest/gtest.h>
 
 #include <ucxx/api.h>
+#include <ucxx/delayed_submission.h>
+#include <ucxx/worker_progress_thread.h>
 
 #include <type_traits>
 
@@ -112,45 +114,54 @@ class WorkerGenericCallbackSingleTest : public WorkerProgressTest {};
 
 TEST_F(WorkerTest, HandleIsValid) { ASSERT_TRUE(_worker->getHandle() != nullptr); }
 
-TEST_F(WorkerTest, StopProgressThreadDuringStartCallback)
+TEST(WorkerProgressThreadTest, StopDuringStartCallbackAfterPostCallbackTimeout)
 {
+  constexpr uint64_t stopCallbackTimeoutNs{1};
+  constexpr uint64_t stopSignalIntervalNs{0};
+  constexpr int directStopSignalCount{3};
+
   std::mutex m;
   std::condition_variable cv;
   bool startCallbackEntered{false};
   bool releaseStartCallback{false};
+  int signalCount{0};
 
-  _worker->setProgressThreadStartCallback(
+  auto delayedSubmissions = std::make_shared<ucxx::DelayedSubmissionCollection>(false);
+  ucxx::WorkerProgressThread progressThread(
+    false,
+    []() { return false; },
+    [&]() {
+      std::lock_guard<std::mutex> lock(m);
+      // With periodic stop signals disabled, the third signal is the direct-stop
+      // fallback after pre and post callback waits have timed out.
+      if (++signalCount == directStopSignalCount) {
+        releaseStartCallback = true;
+        cv.notify_all();
+      }
+    },
+    []() {},
     [&](void*) {
       std::unique_lock<std::mutex> lock(m);
       startCallbackEntered = true;
       cv.notify_all();
       cv.wait(lock, [&]() { return releaseStartCallback; });
     },
-    nullptr);
-
-  _worker->startProgressThread(false);
+    nullptr,
+    delayedSubmissions);
 
   {
     std::unique_lock<std::mutex> lock(m);
     ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(1), [&]() { return startCallbackEntered; }));
   }
 
-  std::thread stopThread([&]() { _worker->stopProgressThread(); });
-
-  // The current implementation waits three seconds for the pre callback and
-  // another three seconds for the post callback. Releasing after both timed out
-  // reproduces the path where the stop flag was never set by the progress
-  // thread itself.
-  std::this_thread::sleep_for(std::chrono::milliseconds(6500));
+  progressThread.stop(
+    ucxx::WorkerProgressThread::StopConfig{stopCallbackTimeoutNs, stopSignalIntervalNs});
 
   {
     std::lock_guard<std::mutex> lock(m);
-    releaseStartCallback = true;
+    EXPECT_GE(signalCount, directStopSignalCount);
   }
-  cv.notify_all();
-
-  stopThread.join();
-  EXPECT_FALSE(_worker->isProgressThreadRunning());
+  EXPECT_FALSE(progressThread.isRunning());
 }
 
 TEST_F(WorkerTest, QueryAttributes)

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -2,8 +2,12 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <vector>
 
@@ -107,6 +111,47 @@ class WorkerGenericCallbackTest : public WorkerProgressTest {};
 class WorkerGenericCallbackSingleTest : public WorkerProgressTest {};
 
 TEST_F(WorkerTest, HandleIsValid) { ASSERT_TRUE(_worker->getHandle() != nullptr); }
+
+TEST_F(WorkerTest, StopProgressThreadDuringStartCallback)
+{
+  std::mutex m;
+  std::condition_variable cv;
+  bool startCallbackEntered{false};
+  bool releaseStartCallback{false};
+
+  _worker->setProgressThreadStartCallback(
+    [&](void*) {
+      std::unique_lock<std::mutex> lock(m);
+      startCallbackEntered = true;
+      cv.notify_all();
+      cv.wait(lock, [&]() { return releaseStartCallback; });
+    },
+    nullptr);
+
+  _worker->startProgressThread(false);
+
+  {
+    std::unique_lock<std::mutex> lock(m);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(1), [&]() { return startCallbackEntered; }));
+  }
+
+  std::thread stopThread([&]() { _worker->stopProgressThread(); });
+
+  // The current implementation waits three seconds for the pre callback and
+  // another three seconds for the post callback. Releasing after both timed out
+  // reproduces the path where the stop flag was never set by the progress
+  // thread itself.
+  std::this_thread::sleep_for(std::chrono::milliseconds(6500));
+
+  {
+    std::lock_guard<std::mutex> lock(m);
+    releaseStartCallback = true;
+  }
+  cv.notify_all();
+
+  stopThread.join();
+  EXPECT_FALSE(_worker->isProgressThreadRunning());
+}
 
 TEST_F(WorkerTest, QueryAttributes)
 {


### PR DESCRIPTION
Fix an intermittent progress-thread shutdown hang that can occur when `stopProgressThread()` is called before the progress thread reaches the generic post callback that normally sets the stop flag.

Previously, if the stop post callback timed out and was canceled before running, `stop()` could still call `join()` while `_stop` remained false. Once the progress thread resumed, it could continue running indefinitely, leaving teardown stuck.

Supersedes and closes #684