### PR TITLE
Bump cuda-core minimum to 0.5.1

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=4.0
-- cuda-core>=0.3.2
+- cuda-core>=0.5.1
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=4.0
-- cuda-core>=0.3.2
+- cuda-core>=0.5.1
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=4.0
-- cuda-core>=0.3.2
+- cuda-core>=0.5.1
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.3

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=4.0
-- cuda-core>=0.3.2
+- cuda-core>=0.5.1
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.3

--- a/conda/recipes/ucxx/recipe.yaml
+++ b/conda/recipes/ucxx/recipe.yaml
@@ -98,7 +98,7 @@ outputs:
         - libucxx =${{ version }}
         - cuda-cudart-dev
       run:
-        - cuda-core >=0.3.2
+        - cuda-core >=0.5.1
         - numpy >=1.23,<3.0
         # 'nvidia-ml-py' provides the 'pynvml' module
         - nvidia-ml-py>=12
@@ -238,7 +238,7 @@ outputs:
         - setuptools>=77.0.0
         - wheel
       run:
-        - cuda-core >=0.3.2
+        - cuda-core >=0.5.1
         - python
         - pyyaml >=6
         - rapids-dask-dependency ${{ rapids_version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -366,14 +366,14 @@ dependencies:
           - &numpy numpy>=1.23,<3.0
           # 'nvidia-ml-py' provides the 'pynvml' module
           - nvidia-ml-py>=12
-          - cuda-core>=0.3.2
+          - cuda-core>=0.5.1
   run_python_distributed_ucxx:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
           - rapids-dask-dependency==26.8.*,>=0.0.0a0
           - pyyaml>=6
-          - cuda-core>=0.3.2
+          - cuda-core>=0.5.1
   test_cpp:
     common:
       - output_types: conda

--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -20,7 +20,7 @@ license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
-    "cuda-core>=0.3.2",
+    "cuda-core>=0.5.1",
     "pyyaml>=6",
     "rapids-dask-dependency==26.8.*,>=0.0.0a0",
     "ucxx==0.51.*,>=0.0.0a0",

--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 license = "BSD-3-Clause"
 requires-python = ">=3.11"
 dependencies = [
-    "cuda-core>=0.3.2",
+    "cuda-core>=0.5.1",
     "libucxx==0.51.*,>=0.0.0a0",
     "numpy>=1.23,<3.0",
     "nvidia-ml-py>=12",

--- a/python/ucxx/ucxx/_cuda_context.py
+++ b/python/ucxx/ucxx/_cuda_context.py
@@ -21,7 +21,7 @@ def _get_device_class():
             return Device
         except ImportError as e:
             raise ImportError(
-                "CUDA context management requires cuda-core (cuda-core>=0.3.2)."
+                "CUDA context management requires cuda-core (cuda-core>=0.5.1)."
             ) from e
 
 


### PR DESCRIPTION
Bumps the minimum supported cuda-core version from 0.3.2 to 0.5.1 in dependency metadata, generated conda environment files, and the matching import error message.

This aligns with numba-cuda-mlir's lower bound, which helps us align the compatible bounds across RAPIDS.