### PR TITLE
Update docs to use NVIDIA Sphinx theme

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -33,7 +33,6 @@ dependencies:
 - pkg-config
 - pre-commit
 - psutil
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - pytest-asyncio>=1.0.0
 - pytest-rerunfailures!=16.0.0
@@ -47,4 +46,6 @@ dependencies:
 - setuptools>=77.0.0
 - sphinx>=8.1.0
 - ucx>=1.18.0,<1.21
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -33,7 +33,6 @@ dependencies:
 - pkg-config
 - pre-commit
 - psutil
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - pytest-asyncio>=1.0.0
 - pytest-rerunfailures!=16.0.0
@@ -47,4 +46,6 @@ dependencies:
 - setuptools>=77.0.0
 - sphinx>=8.1.0
 - ucx>=1.18.0,<1.21
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-129_arch-x86_64

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -33,7 +33,6 @@ dependencies:
 - pkg-config
 - pre-commit
 - psutil
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - pytest-asyncio>=1.0.0
 - pytest-rerunfailures!=16.0.0
@@ -47,4 +46,6 @@ dependencies:
 - setuptools>=77.0.0
 - sphinx>=8.1.0
 - ucx>=1.19.0,<1.21
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -33,7 +33,6 @@ dependencies:
 - pkg-config
 - pre-commit
 - psutil
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - pytest-asyncio>=1.0.0
 - pytest-rerunfailures!=16.0.0
@@ -47,4 +46,6 @@ dependencies:
 - setuptools>=77.0.0
 - sphinx>=8.1.0
 - ucx>=1.19.0,<1.21
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-133_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -327,15 +327,9 @@ dependencies:
         packages:
           - *doxygen
           - make
-          # Minimum version for safe parallel writing again.
-          # https://github.com/pydata/pydata-sphinx-theme/pull/1859
-          # https://github.com/pydata/pydata-sphinx-theme/releases/tag/v0.15.4
-          - pydata-sphinx-theme>=0.15.4
-          # Needed for safe parallel writes as with the pydata-sphinx-theme pin above
-          # https://github.com/sphinx-doc/sphinx/issues/12409
-          # https://github.com/sphinx-doc/sphinx/pull/12888
-          # https://github.com/sphinx-doc/sphinx/releases/tag/v8.1.0
           - sphinx>=8.1.0
+          - pip:
+              - nvidia-sphinx-theme
   py_version:
     specific:
       - output_types: conda

--- a/docs/ucxx/source/conf.py
+++ b/docs/ucxx/source/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # Configuration file for the Sphinx documentation builder.
@@ -87,8 +87,7 @@ html_theme_options = {
 # a list of builtin themes.
 #
 
-html_theme = "pydata_sphinx_theme"
-html_logo = "_static/RAPIDS-logo-purple.png"
+html_theme = "nvidia_sphinx_theme"
 
 
 # Theme options are theme-specific and customize the look and feel of a theme
@@ -197,8 +196,4 @@ autoclass_content = "class"
 
 
 def setup(app):
-    app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
-    app.add_js_file(
-        "https://docs.rapids.ai/assets/js/custom.js", loading_method="defer"
-    )
     app.setup_extension("sphinx.ext.autodoc")

--- a/docs/ucxx/source/conf.py
+++ b/docs/ucxx/source/conf.py
@@ -73,10 +73,14 @@ pygments_style = "sphinx"
 
 html_theme_options = {
     "external_links": [],
-    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
-    "icon_links": [],
-    "github_url": "https://github.com/rapidsai/ucxx",
-    "twitter_url": "https://twitter.com/rapidsai",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/rapidsai/ucxx",
+            "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        },
+    ],
     "show_toc_level": 1,
     "navbar_align": "right",
     "navigation_with_keys": True,

--- a/docs/ucxx/source/conf.py
+++ b/docs/ucxx/source/conf.py
@@ -15,7 +15,7 @@ from packaging.version import Version
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 # General information about the project.
-project = "ucxx"
+project = "NVIDIA UCXX"
 copyright = f"2018-{datetime.datetime.today().year}, NVIDIA Corporation"
 author = "NVIDIA Corporation"
 

--- a/docs/ucxx/source/conf.py
+++ b/docs/ucxx/source/conf.py
@@ -15,7 +15,7 @@ from packaging.version import Version
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 # General information about the project.
-project = "NVIDIA UCXX"
+project = "UCXX"
 copyright = f"2018-{datetime.datetime.today().year}, NVIDIA Corporation"
 author = "NVIDIA Corporation"
 

--- a/docs/ucxx/source/index.rst
+++ b/docs/ucxx/source/index.rst
@@ -1,7 +1,7 @@
-NVIDIA UCXX Documentation
-=========================
+UCXX Documentation
+==================
 
-NVIDIA UCXX is the Python interface for `UCX <https://github.com/openucx/ucx>`_, a low-level high-performance networking library. UCX and UCXX support several transport methods including InfiniBand and NVLink while still using traditional networking protocols like TCP.
+UCXX is the Python interface for `UCX <https://github.com/openucx/ucx>`_, a low-level high-performance networking library. UCX and UCXX support several transport methods including InfiniBand and NVLink while still using traditional networking protocols like TCP.
 
 
 .. image:: _static/Architecture.png

--- a/docs/ucxx/source/index.rst
+++ b/docs/ucxx/source/index.rst
@@ -1,7 +1,7 @@
-UCXX
-====
+NVIDIA UCXX Documentation
+=========================
 
-UCXX is the Python interface for `UCX <https://github.com/openucx/ucx>`_, a low-level high-performance networking library. UCX and UCXX support several transport methods including InfiniBand and NVLink while still using traditional networking protocols like TCP.
+NVIDIA UCXX is the Python interface for `UCX <https://github.com/openucx/ucx>`_, a low-level high-performance networking library. UCX and UCXX support several transport methods including InfiniBand and NVLink while still using traditional networking protocols like TCP.
 
 
 .. image:: _static/Architecture.png


### PR DESCRIPTION
## Description

Updates the Sphinx documentation to use `nvidia_sphinx_theme` with the theme's default left navigation.

This replaces the previous Sphinx theme dependency, removes the legacy shared RAPIDS CSS/JavaScript injection where present, and regenerates dependency manifests.

Contributes to rapidsai/build-planning#300.

## Validation

- Commit-time pre-commit hooks passed, including generated dependency files.
- Doxygen completed and `make dirhtml O="-j 8"` passed in the CUDA 13.3 devcontainer.
- Rendered HTML loads the NVIDIA theme, uses the default left navigation, and contains no legacy shared RAPIDS asset URLs.

