### PR TITLE
Rename managed Active Message APIs

### DIFF
--- a/cpp/include/ucxx/constructors.h
+++ b/cpp/include/ucxx/constructors.h
@@ -24,7 +24,7 @@ class MemoryHandle;
 class Notifier;
 class RemoteKey;
 class Request;
-class RequestAm;
+class RequestAmManaged;
 class RequestEndpointClose;
 class RequestFlush;
 class RequestMem;
@@ -108,12 +108,21 @@ namespace detail {
   std::shared_ptr<Endpoint> endpoint, SerializedRemoteKey serializedRemoteKey);
 
 // Transfers
-[[nodiscard]] std::shared_ptr<RequestAm> createRequestAm(
+[[nodiscard]] std::shared_ptr<RequestAmManaged> createRequestAmManaged(
   std::shared_ptr<Endpoint> endpoint,
-  const std::variant<data::AmSend, data::AmReceive> requestData,
+  const std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData,
   const bool enablePythonFuture,
   RequestCallbackUserFunction callbackFunction,
   RequestCallbackUserData callbackData);
+
+[[deprecated(
+  "Use createRequestAmManaged() instead.")]] [[nodiscard]] std::shared_ptr<RequestAmManaged>
+createRequestAm(std::shared_ptr<Endpoint> endpoint,
+                const std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData,
+                const bool enablePythonFuture,
+                RequestCallbackUserFunction callbackFunction,
+                RequestCallbackUserData callbackData);
+
 [[nodiscard]] std::shared_ptr<RequestEndpointClose> createRequestEndpointClose(
   std::shared_ptr<Endpoint> endpoint,
   const data::EndpointClose requestData,

--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -390,44 +390,30 @@ class Endpoint : public Component {
                         EndpointCloseCallbackUserData closeCallbackArg);
 
   /**
-   * @brief Enqueue an active message send operation.
+   * @brief Enqueue a managed Active Message send.
    *
-   * Enqueue an active message send operation, returning a `std::shared_ptr<ucxx::Request>`
-   * that can be later awaited and checked for errors. This is a non-blocking operation, and
-   * the status of the transfer must be verified from the resulting request object before
-   * the data can be released.
+   * Managed Active Messages use UCXX's worker-managed AM receive handler on the remote
+   * worker. The send payload is transferred with `ucp_am_send_nbx`, and UCXX stores its own
+   * metadata in the UCX AM header so the receiver can allocate the destination buffer,
+   * preserve the user header, and complete a `RequestAmManaged`.
    *
-   * An optional `receiverCallbackInfo` may be specified, in which case the remote worker
-   * obligatorily needs to have registered a callback with the same `receiverCallbackInfo`
-   * in order to execute the callback when the active message is received. When this is
-   * specified, `amRecv()` will _NOT_ match this message, which is instead handled by the
-   * remote worker's callback.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
+   * If `receiverCallbackInfo` is not set, the message is matched with an
+   * `amManagedRecv()` request for this endpoint. Matching works whether the receive request
+   * is posted before or after the message arrives. If `receiverCallbackInfo` is set, the
+   * remote worker delivers the completed receive request to the matching callback registered
+   * with `Worker::registerManagedAmReceiverCallback()`.
    *
    * @param[in] buffer                  a raw pointer to the data to be sent.
-   * @param[in] length                  the size in bytes of the tag message to be sent.
+   * @param[in] length                  the size in bytes of the message to be sent.
    * @param[in] memoryType              the memory type of the buffer.
-   * @param[in] receiverCallbackInfo    the owner name and unique identifier of the receiver
-                                        callback.
-   * @param[in] enablePythonFuture      whether a python future should be created and
-   *                                    subsequently notified.
-   * @param[in] callbackFunction        user-defined callback function to call upon
-                                        completion.
-   * @param[in] callbackData            user-defined data to pass to the `callbackFunction`.
+   * @param[in] receiverCallbackInfo    optional receiver callback identifier.
+   * @param[in] enablePythonFuture      whether a Python future should be created.
+   * @param[in] callbackFunction        user-defined callback to call upon completion.
+   * @param[in] callbackData            data to pass to `callbackFunction`.
    *
-   * @returns Request to be subsequently checked for the completion and its state.
+   * @returns Request to be subsequently checked for completion and state.
    */
-  [[nodiscard]] std::shared_ptr<Request> amSend(
+  [[nodiscard]] std::shared_ptr<Request> amManagedSend(
     const void* const buffer,
     const size_t length,
     const ucs_memory_type_t memoryType,
@@ -437,38 +423,27 @@ class Endpoint : public Component {
     RequestCallbackUserData callbackData                             = nullptr);
 
   /**
-   * @brief Create a builder for an active message send operation.
+   * @brief Enqueue a managed Active Message send with explicit send parameters.
    *
-   * Calling this method only creates the builder. Finalizing it with `.build()` or
-   * implicit conversion invokes the same request-creation path as `amSend()`.
+   * Equivalent to `amManagedSend(buffer, length, memoryType, ...)`, but the full
+   * `AmSendParams` object is supplied by the caller. `params` controls the UCX AM send flags
+   * and datatype, the sender memory type reported to the receiver, the receiver allocation
+   * policy, optional receiver callback routing, and optional user header bytes.
    *
-   * @param[in] buffer                  a raw pointer to the data to be sent.
-   * @param[in] length                  the size in bytes of the message to be sent.
-   * @param[in] memoryType              the memory type of the buffer.
-   *
-   * @returns Builder to configure optional parameters and submit the request.
-   */
-  [[nodiscard]] RequestAmBuilder amSendBuilder(const void* const buffer,
-                                               const size_t length,
-                                               const ucs_memory_type_t memoryType);
-
-  /**
-   * @brief Enqueue an active message send operation with explicit policy parameters.
-   *
-   * This overload extends `amSend()` with explicit UCX datatype/flags controls and receive
-   * allocation policy metadata while keeping callback behavior identical to the legacy API.
+   * If `params.receiverCallbackInfo` is not set, the remote message is matched with
+   * `amManagedRecv()`. If it is set, the remote worker delivers the completed receive request
+   * to the matching managed receiver callback.
    *
    * @param[in] buffer              a raw pointer to the data to be sent.
    * @param[in] length              the size in bytes of the message to be sent.
-   * @param[in] params              active message send parameters.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
+   * @param[in] params              managed Active Message send parameters.
+   * @param[in] enablePythonFuture  whether a Python future should be created.
+   * @param[in] callbackFunction    user-defined callback to call upon completion.
+   * @param[in] callbackData        data to pass to `callbackFunction`.
    *
-   * @returns Request to be subsequently checked for the completion and its state.
+   * @returns Request to be subsequently checked for completion and state.
    */
-  [[nodiscard]] std::shared_ptr<Request> amSend(
+  [[nodiscard]] std::shared_ptr<Request> amManagedSend(
     const void* const buffer,
     const size_t length,
     const AmSendParams& params,
@@ -477,37 +452,21 @@ class Endpoint : public Component {
     RequestCallbackUserData callbackData         = nullptr);
 
   /**
-   * @brief Create a builder for an active message send operation with explicit policy parameters.
+   * @brief Enqueue a managed Active Message send with IOV datatype.
    *
-   * Calling this method only creates the builder. Finalizing it with `.build()` or
-   * implicit conversion invokes the same request-creation path as `amSend()`.
+   * Sends a scatter-gather payload through the same managed AM protocol as the contiguous
+   * overloads. `params.datatype` must be `UCP_DATATYPE_IOV`; the receiver still observes one
+   * managed message and retrieves the completed payload from the resulting receive request.
    *
-   * @param[in] buffer              a raw pointer to the data to be sent.
-   * @param[in] length              the size in bytes of the message to be sent.
-   * @param[in] params              active message send parameters.
+   * @param[in] iov                 vector of IOV segments to send.
+   * @param[in] params              send parameters (datatype must be `UCP_DATATYPE_IOV`).
+   * @param[in] enablePythonFuture  whether a Python future should be created.
+   * @param[in] callbackFunction    user-defined callback to call upon completion.
+   * @param[in] callbackData        data to pass to `callbackFunction`.
    *
-   * @returns Builder to configure optional parameters and submit the request.
+   * @returns Request to be subsequently checked for completion and state.
    */
-  [[nodiscard]] RequestAmBuilder amSendBuilder(const void* const buffer,
-                                               const size_t length,
-                                               const AmSendParams& params);
-
-  /**
-   * @brief Enqueue an active message send operation with IOV datatype.
-   *
-   * This overload submits `UCP_DATATYPE_IOV` active message sends.
-   *
-   * @param[in] iov                 vector of IOV segments to be sent.
-   * @param[in] params              active message send parameters. Datatype must be
-   *                                `UCP_DATATYPE_IOV`.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  [[nodiscard]] std::shared_ptr<Request> amSend(
+  [[nodiscard]] std::shared_ptr<Request> amManagedSend(
     std::vector<ucp_dt_iov_t> iov,
     const AmSendParams& params,
     const bool enablePythonFuture                = false,
@@ -515,33 +474,23 @@ class Endpoint : public Component {
     RequestCallbackUserData callbackData         = nullptr);
 
   /**
-   * @brief Create a builder for an active message send operation with IOV datatype.
+   * @brief Enqueue a managed Active Message receive.
    *
-   * Calling this method only creates the builder. Finalizing it with `.build()` or
-   * implicit conversion invokes the same request-creation path as `amSend()`.
+   * Receives the next managed Active Message sent from this endpoint's peer without a
+   * `receiverCallbackInfo`. The worker keeps separate pools for posted receives and arrived
+   * messages, so this call may either wait for a future message or consume a message that has
+   * already arrived.
    *
-   * @param[in] iov                 vector of IOV segments to be sent.
-   * @param[in] params              active message send parameters. Datatype must be
-   *                                `UCP_DATATYPE_IOV`.
+   * The received payload is allocated by the receiving worker according to the sender's
+   * memory type and allocation policy. Host allocation is available by default; applications
+   * receiving other memory types must register allocators with
+   * `Worker::registerManagedAmAllocator()`. Once the request completes, use
+   * `Request::getRecvBuffer()` to access the payload and `Request::getRecvHeader()` to access
+   * the sender-provided user header.
    *
-   * @returns Builder to configure optional parameters and submit the request.
-   */
-  [[nodiscard]] RequestAmBuilder amSendBuilder(std::vector<ucp_dt_iov_t> iov,
-                                               const AmSendParams& params);
-
-  /**
-   * @brief Enqueue an active message receive operation.
-   *
-   * Enqueue an active message receive operation, returning a
-   * `std::shared_ptr<ucxx::Request>` that can be later awaited and checked for errors,
-   * making data available via the return value's `getRecvBuffer()` method once the
-   * operation completes successfully. This is a non-blocking operation, and the status of
-   * the transfer must be verified from the resulting request object before the data can be
-   * consumed.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
+   * @param[in] enablePythonFuture  whether a Python future should be created.
+   * @param[in] callbackFunction    user-defined callback to call upon completion.
+   * @param[in] callbackData        data to pass to `callbackFunction`.
    *
    * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
    * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
@@ -550,27 +499,105 @@ class Endpoint : public Component {
    * in which case the callback will also execute immediately within the calling thread and
    * before the method returns.
    *
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
+   * @returns Request to be subsequently checked for completion state and data.
    */
-  [[nodiscard]] std::shared_ptr<Request> amRecv(
+  [[nodiscard]] std::shared_ptr<Request> amManagedRecv(
     const bool enablePythonFuture                = false,
     RequestCallbackUserFunction callbackFunction = nullptr,
     RequestCallbackUserData callbackData         = nullptr);
 
   /**
-   * @brief Create a builder for an active message receive operation.
+   * @brief Create a builder for a managed Active Message send.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
-   * implicit conversion invokes the same request-creation path as `amRecv()`.
+   * implicit conversion invokes the same managed AM request-creation path as
+   * `amManagedSend()`.
+   *
+   * @param[in] buffer      a raw pointer to the data to be sent.
+   * @param[in] length      the size in bytes of the message to be sent.
+   * @param[in] memoryType  the memory type of the buffer.
+   *
+   * @returns Builder to configure optional parameters and submit the request.
+   */
+  [[nodiscard]] RequestAmBuilder amSendBuilder(const void* const buffer,
+                                               const size_t length,
+                                               const ucs_memory_type_t memoryType);
+
+  /**
+   * @brief Create a builder for a managed Active Message send.
+   *
+   * Calling this method only creates the builder. Finalizing it with `.build()` or
+   * implicit conversion invokes the same managed AM request-creation path as
+   * `amManagedSend()`.
+   *
+   * @param[in] buffer  a raw pointer to the data to be sent.
+   * @param[in] length  the size in bytes of the message to be sent.
+   * @param[in] params  managed Active Message send parameters.
+   *
+   * @returns Builder to configure optional parameters and submit the request.
+   */
+  [[nodiscard]] RequestAmBuilder amSendBuilder(const void* const buffer,
+                                               const size_t length,
+                                               const AmSendParams& params);
+
+  /**
+   * @brief Create a builder for a managed Active Message send with IOV datatype.
+   *
+   * Calling this method only creates the builder. Finalizing it with `.build()` or
+   * implicit conversion invokes the same managed AM request-creation path as
+   * `amManagedSend()`.
+   *
+   * @param[in] iov     vector of IOV segments to send.
+   * @param[in] params  managed Active Message send parameters.
+   *
+   * @returns Builder to configure optional parameters and submit the request.
+   */
+  [[nodiscard]] RequestAmBuilder amSendBuilder(std::vector<ucp_dt_iov_t> iov,
+                                               const AmSendParams& params);
+
+  /**
+   * @brief Create a builder for a managed Active Message receive.
+   *
+   * Calling this method only creates the builder. Finalizing it with `.build()` or
+   * implicit conversion invokes the same managed AM request-creation path as
+   * `amManagedRecv()`.
    *
    * @returns Builder to configure optional parameters and submit the request.
    */
   [[nodiscard]] RequestAmBuilder amRecvBuilder();
+
+  /// @deprecated Use `amManagedSend()` instead.
+  [[deprecated("Use amManagedSend() instead.")]] [[nodiscard]] std::shared_ptr<Request> amSend(
+    const void* const buffer,
+    const size_t length,
+    const ucs_memory_type_t memoryType,
+    const std::optional<AmReceiverCallbackInfo> receiverCallbackInfo = std::nullopt,
+    const bool enablePythonFuture                                    = false,
+    RequestCallbackUserFunction callbackFunction                     = nullptr,
+    RequestCallbackUserData callbackData                             = nullptr);
+
+  /// @deprecated Use `amManagedSend()` instead.
+  [[deprecated("Use amManagedSend() instead.")]] [[nodiscard]] std::shared_ptr<Request> amSend(
+    const void* const buffer,
+    const size_t length,
+    const AmSendParams& params,
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
+
+  /// @deprecated Use `amManagedSend()` instead.
+  [[deprecated("Use amManagedSend() instead.")]] [[nodiscard]] std::shared_ptr<Request> amSend(
+    std::vector<ucp_dt_iov_t> iov,
+    const AmSendParams& params,
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
+
+  /// @deprecated Use `amManagedRecv()` instead.
+  [[deprecated("Use amManagedRecv() instead.")]] [[nodiscard]] std::shared_ptr<Request> amRecv(
+    const bool enablePythonFuture                = false,
+    RequestCallbackUserFunction callbackFunction = nullptr,
+    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Enqueue a memory put operation.

--- a/cpp/include/ucxx/internal/request_am.h
+++ b/cpp/include/ucxx/internal/request_am.h
@@ -19,60 +19,60 @@ namespace ucxx {
 
 class Buffer;
 class InflightRequests;
-class RequestAm;
+class RequestAmManaged;
 class Request;
 class Worker;
 
 namespace internal {
 
-class AmData;
+class ManagedAmData;
 
 /**
- * @brief Handle receiving of a `ucxx::RequestAm`.
+ * @brief Handle receiving of a `ucxx::RequestAmManaged`.
  *
- * Handle receiving of a `ucxx::RequestAm`, delivering the message to the user and
- * notifying of completion.
+ * Handle receiving of a `ucxx::RequestAmManaged`, delivering the message to the user
+ * and notifying of completion.
  */
-class RecvAmMessage {
+class ManagedRecvAmMessage {
  public:
-  internal::AmData* _amData{nullptr};  ///< Active messages data
-  ucp_ep_h _ep{nullptr};               ///< Handle containing address of the reply endpoint
-  std::shared_ptr<RequestAm> _request{
+  internal::ManagedAmData* _amData{nullptr};  ///< Managed active messages data
+  ucp_ep_h _ep{nullptr};                      ///< Handle containing address of the reply endpoint
+  std::shared_ptr<RequestAmManaged> _request{
     nullptr};  ///< Request which will later be notified/delivered to user
   std::shared_ptr<Buffer> _buffer{nullptr};  ///< Buffer containing the received data
 
-  RecvAmMessage()                                = delete;
-  RecvAmMessage(const RecvAmMessage&)            = delete;
-  RecvAmMessage& operator=(RecvAmMessage const&) = delete;
-  RecvAmMessage(RecvAmMessage&& o)               = delete;
-  RecvAmMessage& operator=(RecvAmMessage&& o)    = delete;
+  ManagedRecvAmMessage()                                       = delete;
+  ManagedRecvAmMessage(const ManagedRecvAmMessage&)            = delete;
+  ManagedRecvAmMessage& operator=(ManagedRecvAmMessage const&) = delete;
+  ManagedRecvAmMessage(ManagedRecvAmMessage&& o)               = delete;
+  ManagedRecvAmMessage& operator=(ManagedRecvAmMessage&& o)    = delete;
 
   /**
-   * @brief Constructor of `ucxx::RecvAmMessage`.
+   * @brief Constructor of `ucxx::ManagedRecvAmMessage`.
    *
-   * Construct the object, setting attributes that are later needed by the callback.
-   *
-   * @param[in] amData              active messages worker data.
-   * @param[in] ep                  handle containing address of the reply endpoint (i.e.,
-                                    endpoint where user is requesting to receive).
+   * @param[in] amData              managed active messages worker data.
+   * @param[in] ep                  handle containing address of the reply endpoint.
    * @param[in] request             request to be later notified/delivered to user.
    * @param[in] buffer              buffer containing the received data
    * @param[in] receiverCallback    receiver callback to execute when request completes.
    * @param[in] userHeader          user-defined header associated with the received message.
    */
-  RecvAmMessage(internal::AmData* amData,
-                ucp_ep_h ep,
-                std::shared_ptr<RequestAm> request,
-                std::shared_ptr<Buffer> buffer,
-                AmReceiverCallbackType receiverCallback = AmReceiverCallbackType(),
-                std::vector<std::byte> userHeader       = {});
+  ManagedRecvAmMessage(internal::ManagedAmData* amData,
+                       ucp_ep_h ep,
+                       std::shared_ptr<RequestAmManaged> request,
+                       std::shared_ptr<Buffer> buffer,
+                       AmReceiverCallbackType receiverCallback = AmReceiverCallbackType(),
+                       std::vector<std::byte> userHeader       = {});
+
+  /**
+   * @brief Set the UCP request on the underlying `RequestAmManaged`.
+   *
+   * @param[in] request the UCP request associated to the active message receive operation.
+   */
+  void setUcpRequest(void* request);
 
   /**
    * @brief Execute the `ucxx::Request::callback()`.
-   *
-   * Execute the `ucxx::Request::callback()` method to set the status of the request, the
-   * buffer containing the data received and release the reference to this object from
-   * `AmData`.
    *
    * @param[in] request the UCP request associated to the active message receive operation.
    * @param[in] status  the completion status of the UCP request.
@@ -80,10 +80,10 @@ class RecvAmMessage {
   void callback(void* request, ucs_status_t status);
 };
 
-typedef std::unordered_map<ucp_ep_h, std::queue<std::shared_ptr<RequestAm>>> AmPoolType;
-typedef std::map<std::shared_ptr<RequestAm>,
-                 std::shared_ptr<RecvAmMessage>,
-                 std::owner_less<std::shared_ptr<RequestAm>>>
+typedef std::unordered_map<ucp_ep_h, std::queue<std::shared_ptr<RequestAmManaged>>> AmPoolType;
+typedef std::map<std::shared_ptr<RequestAmManaged>,
+                 std::shared_ptr<ManagedRecvAmMessage>,
+                 std::owner_less<std::shared_ptr<RequestAmManaged>>>
   RecvAmMessageMapType;
 
 typedef std::unordered_map<AmReceiverCallbackIdType, AmReceiverCallbackType>
@@ -93,13 +93,13 @@ typedef std::
     AmReceiverCallbackOwnerMapType;
 
 /**
- * @brief Active Message data owned by a `ucxx::Worker`.
+ * @brief Active Message data owned by a `ucxx::Worker` for the managed AM API.
  *
- * Receiving Active Messages are handled directly by a `ucxx::Worker` without the user
- * necessarily creating a `ucxx::RequestAm` for it. When there is an incoming message, the
- * worker will populate the internal pool of received messages in an orderly-fashion.
+ * Receiving managed Active Messages are handled directly by a `ucxx::Worker` without the
+ * user necessarily creating a `ucxx::RequestAmManaged` for it. When there is an incoming
+ * message, the worker populates the internal pool of received messages in an orderly fashion.
  */
-class AmData {
+class ManagedAmData {
  public:
   std::weak_ptr<Worker> _worker{};  ///< The worker to which the Active Message callback belongs
   std::string _ownerString{};       ///< The owner string used for logging
@@ -116,6 +116,9 @@ class AmData {
   std::unordered_map<ucs_memory_type_t, AmAllocatorType>
     _allocators{};  ///< Default and user-defined active message allocators
 };
+
+using AmData        = ManagedAmData;
+using RecvAmMessage = ManagedRecvAmMessage;
 
 }  // namespace internal
 

--- a/cpp/include/ucxx/request_am.h
+++ b/cpp/include/ucxx/request_am.h
@@ -21,32 +21,44 @@ namespace ucxx {
 class Buffer;
 
 namespace internal {
-class RecvAmMessage;
+class ManagedRecvAmMessage;
 }  // namespace internal
 
 /**
- * @brief Send or receive a message with the UCX Active Message API.
+ * @brief Request type for UCXX managed Active Message operations.
  *
- * Send or receive a message with the UCX Active Message API, using non-blocking UCP calls
- * `ucp_am_send_nbx` or `ucp_am_recv_data_nbx`.
+ * Managed Active Messages are UCXX-managed transfers built on UCX Active Messages. Sends use
+ * UCXX's managed AM handler on the remote worker and carry a UCXX header containing the
+ * sender memory type, receiver allocation policy, optional receiver callback information, and
+ * optional user header bytes.
+ *
+ * A `RequestAmManaged` may represent either a send request or a receive request. Receive
+ * requests are completed by the worker's managed AM receive callback, which deserializes the
+ * UCXX header, allocates the receive buffer, handles eager or rendezvous payload delivery,
+ * and either matches the message with an `amManagedRecv()` request or invokes a registered
+ * receiver callback.
+ *
  */
-class RequestAm : public Request {
+class RequestAmManaged : public Request {
  private:
-  friend class internal::RecvAmMessage;
+  friend class internal::ManagedRecvAmMessage;
 
   std::vector<std::byte> _header{};  ///< Retain copy of header bytes for send requests as
                                      ///< workaround for
                                      ///< https://github.com/openucx/ucx/issues/10424
 
   /**
-   * @brief Private constructor of `ucxx::RequestAm`.
+   * @brief Private constructor of `ucxx::RequestAmManaged`.
    *
-   * This is the internal implementation of `ucxx::RequestAm` constructor, made private
-   * not to be called directly. This constructor is made private to ensure all UCXX objects
-   * are shared pointers and the correct lifetime management of each one.
+   * This constructor creates the internal request object for either a managed AM send or a
+   * managed AM receive, depending on `requestData`. It is private to ensure requests are
+   * owned through `std::shared_ptr` and participate in UCXX request lifetime management.
    *
    * Instead the user should use one of the following:
    *
+   * - `ucxx::Endpoint::amManagedSend()`
+   * - `ucxx::createRequestAmManaged()`
+   * - `ucxx::Endpoint::amManagedRecv()`
    * - `ucxx::Endpoint::amSendBuilder()`
    * - `ucxx::Endpoint::amRecvBuilder()`
    * - `ucxx::requestAmBuilder()`
@@ -63,24 +75,26 @@ class RequestAm : public Request {
    * @param[in] callbackFunction    user-defined callback function to call upon completion.
    * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
    */
-  RequestAm(std::shared_ptr<Component> endpointOrWorker,
-            const std::variant<data::AmSend, data::AmReceive> requestData,
-            std::string operationName,
-            const bool enablePythonFuture                = false,
-            RequestCallbackUserFunction callbackFunction = nullptr,
-            RequestCallbackUserData callbackData         = nullptr);
+  RequestAmManaged(std::shared_ptr<Component> endpointOrWorker,
+                   const std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData,
+                   std::string operationName,
+                   const bool enablePythonFuture                = false,
+                   RequestCallbackUserFunction callbackFunction = nullptr,
+                   RequestCallbackUserData callbackData         = nullptr);
 
  public:
   /**
-   * @brief Constructor for `std::shared_ptr<ucxx::RequestAm>`.
+   * @brief Factory for a managed Active Message request.
    *
-   * The constructor for a `std::shared_ptr<ucxx::RequestAm>` object, creating an active
-   * message request, returning a pointer to a request object that can be later awaited and
-   * checked for errors. This is a non-blocking operation, and the status of the transfer
-   * must be verified from the resulting request object before the data can be released if
-   * this is a send operation, or consumed if this is a receive operation. Received data is
-   * available via the `getRecvBuffer()` method if the receive transfer request completed
-   * successfully.
+   * Creates a managed AM send request when `requestData` contains `data::AmSendManaged`, or
+   * a managed AM receive request when it contains `data::AmReceiveManaged`. Send requests are
+   * later submitted with `RequestAmManaged::request()`. Receive requests are completed by the
+   * worker's managed AM receive callback and may match a message that arrived before or after
+   * the receive request was created.
+   *
+   * Received payload data is available via `getRecvBuffer()` after a receive request
+   * completes successfully. Sender-provided user header bytes are available via
+   * `getRecvHeader()`.
    *
    * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
    * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
@@ -100,11 +114,22 @@ class RequestAm : public Request {
    * @param[in] callbackFunction    user-defined callback function to call upon completion.
    * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
    *
-   * @returns The `shared_ptr<ucxx::RequestAm>` object
+   * @returns The `shared_ptr<ucxx::RequestAmManaged>` object
    */
-  friend std::shared_ptr<RequestAm> createRequestAm(
+  friend std::shared_ptr<RequestAmManaged> createRequestAmManaged(
     std::shared_ptr<Endpoint> endpoint,
-    const std::variant<data::AmSend, data::AmReceive> requestData,
+    const std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData,
+    const bool enablePythonFuture,
+    RequestCallbackUserFunction callbackFunction,
+    RequestCallbackUserData callbackData);
+
+  /**
+   * @brief Deprecated factory for `RequestAmManaged`.
+   * @deprecated Use `createRequestAmManaged()` instead.
+   */
+  friend std::shared_ptr<RequestAmManaged> createRequestAm(
+    std::shared_ptr<Endpoint> endpoint,
+    const std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData,
     const bool enablePythonFuture,
     RequestCallbackUserFunction callbackFunction,
     RequestCallbackUserData callbackData);
@@ -120,41 +145,34 @@ class RequestAm : public Request {
   void populateDelayedSubmission() override;
 
   /**
-   * @brief Create and submit an active message send request.
+   * @brief Create and submit a managed active message send request.
    *
-   * This is the method that should be called to actually submit an active message send
-   * request. It is meant to be called from `populateDelayedSubmission()`, which is decided
-   * at the discretion of `std::shared_ptr<ucxx::Worker>`. See `populateDelayedSubmission()`
-   * for more details.
+   * Serializes the managed AM header, calls `ucp_am_send_nbx` on the reserved managed AM
+   * handler ID, and publishes the resulting UCX request. This method is valid only for
+   * send-side `RequestAmManaged` objects and is normally called by
+   * `populateDelayedSubmission()`.
    */
   void request();
 
   /**
-   * @brief Receive callback registered by `ucxx::Worker`.
+   * @brief Receive callback registered by `ucxx::Worker` for the managed AM API.
    *
-   * This is the receive callback registered by the `ucxx::Worker` to handle incoming active
-   * messages. For each incoming active message, a proper buffer will be allocated based on
-   * the header sent by the remote endpoint using the default allocator or one registered by
-   * the user via `ucxx::Worker::registerAmAllocator()`. Following that, the message is
-   * immediately received onto the buffer and a `UCS_OK` or the proper error status is set
-   * onto the `RequestAm` that is returned to the user, or will be later handled by another
-   * callback when the message is ready. If the callback is executed when a user has already
-   * requested received of the active message, the buffer and status will be set on the
-   * earliest request, otherwise a new request is created and saved in a pool that will be
-   * already populated and ready for consumption or waiting for the internal callback when
-   * requested.
+   * Handles incoming managed Active Messages for the worker-managed AM handler. The callback
+   * deserializes the UCXX header, identifies the remote endpoint, allocates a receive buffer
+   * according to the sender memory type and memory policy, and completes payload transfer for
+   * either eager or rendezvous messages.
    *
-   * This is always called by `ucp_worker_progress()`, and thus will happen in the same
-   * thread that is called from, when using the worker progress thread, this is called from
-   * the progress thread.
+   * Messages without receiver callback information are matched through the worker's
+   * managed-receive pools, allowing either request-before-message or message-before-request
+   * ordering. Messages with receiver callback information are delivered to the registered
+   * callback after the receive request completes.
    *
-   * param[in,out] arg  pointer to the `AmData` object held by the `ucxx::Worker` who
-   *                    registered this callback.
-   * param[in] header pointer to the header containing the sender buffer's memory type.
-   * param[in] header_length  length in bytes of the receive header.
-   * param[in] data pointer to the buffer containing the remote endpoint's send data.
-   * param[in] length the length in bytes of the message to be received.
-   * param[in] param  UCP parameters of the active message being received.
+   * @param[in,out] arg            pointer to the `ManagedAmData` object held by the worker.
+   * @param[in]     header         header containing serialized UCXX metadata.
+   * @param[in]     header_length  length in bytes of the receive header.
+   * @param[in]     data           eager payload pointer or rendezvous data descriptor.
+   * @param[in]     length         length in bytes of the message payload.
+   * @param[in]     param          UCP parameters of the active message being received.
    */
   [[nodiscard]] static ucs_status_t recvCallback(void* arg,
                                                  const void* header,
@@ -167,5 +185,11 @@ class RequestAm : public Request {
 
   [[nodiscard]] std::string getRecvHeader() override;
 };
+
+/**
+ * @brief Deprecated alias for `RequestAmManaged`.
+ * @deprecated Use `RequestAmManaged` directly.
+ */
+[[deprecated("Use RequestAmManaged instead.")]] typedef RequestAmManaged RequestAm;
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/request_am_builder.h
+++ b/cpp/include/ucxx/request_am_builder.h
@@ -17,10 +17,10 @@ namespace ucxx {
 // Forward declarations
 class Endpoint;
 class Request;
-class RequestAm;
+class RequestAmManaged;
 
 /**
- * @brief Builder class for constructing `std::shared_ptr<ucxx::RequestAm>` objects.
+ * @brief Builder class for constructing `std::shared_ptr<ucxx::RequestAmManaged>` objects.
  *
  * @copydoc ucxx_request_builder_pattern
  *
@@ -34,14 +34,15 @@ class RequestAm;
  *                .callbackData(callbackData)
  *                .build();
  *
- *   std::shared_ptr<ucxx::RequestAm> amReq =
+ *   std::shared_ptr<ucxx::RequestAmManaged> amReq =
  *     ucxx::requestAmBuilder(endpoint, amReceiveData);
  * @endcode
  */
 class RequestAmBuilder : public RequestCallbackBuilderBase<RequestAmBuilder> {
  private:
-  std::shared_ptr<Endpoint> _endpoint;                       ///< Parent endpoint (required)
-  std::variant<data::AmSend, data::AmReceive> _requestData;  ///< Request-specific data (required)
+  std::shared_ptr<Endpoint> _endpoint;  ///< Parent endpoint (required)
+  std::variant<data::AmSendManaged, data::AmReceiveManaged>
+    _requestData;  ///< Request-specific data (required)
 
  public:
   /**
@@ -52,41 +53,42 @@ class RequestAmBuilder : public RequestCallbackBuilderBase<RequestAmBuilder> {
    *                         type-specific data.
    */
   explicit RequestAmBuilder(std::shared_ptr<Endpoint> endpoint,
-                            std::variant<data::AmSend, data::AmReceive> requestData);
+                            std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData);
 
   /**
-   * @brief Configure receiver callback metadata for active message sends.
+   * @brief Configure receiver callback metadata for managed Active Message sends.
    *
    * @param[in] info owner name and unique identifier of the receiver callback.
    * @return Reference to this builder for method chaining.
    *
-   * @throws std::logic_error if called for an active message receive builder.
+   * @throws std::logic_error if called for a managed Active Message receive builder.
    */
   RequestAmBuilder& receiverCallbackInfo(std::optional<AmReceiverCallbackInfo> info) &;
 
   /**
-   * @brief Configure receiver callback metadata for active message sends on a temporary builder.
+   * @brief Configure receiver callback metadata for managed Active Message sends on a temporary
+   * builder.
    *
    * @param[in] info owner name and unique identifier of the receiver callback.
    * @return Rvalue reference to this builder for method chaining.
    *
-   * @throws std::logic_error if called for an active message receive builder.
+   * @throws std::logic_error if called for a managed Active Message receive builder.
    */
   RequestAmBuilder&& receiverCallbackInfo(std::optional<AmReceiverCallbackInfo> info) &&;
 
   /**
-   * @brief Build and return the `RequestAm`.
+   * @brief Build and return the `RequestAmManaged`.
    *
-   * @return The constructed `shared_ptr<ucxx::RequestAm>` object.
+   * @return The constructed `shared_ptr<ucxx::RequestAmManaged>` object.
    */
-  [[nodiscard]] std::shared_ptr<RequestAm> build();
+  [[nodiscard]] std::shared_ptr<RequestAmManaged> build();
 
   /**
-   * @brief Implicit conversion operator to `shared_ptr<RequestAm>`.
+   * @brief Implicit conversion operator to `shared_ptr<RequestAmManaged>`.
    *
-   * @return The constructed `shared_ptr<ucxx::RequestAm>` object.
+   * @return The constructed `shared_ptr<ucxx::RequestAmManaged>` object.
    */
-  operator std::shared_ptr<RequestAm>();
+  operator std::shared_ptr<RequestAmManaged>();
 
   /**
    * @brief Implicit conversion operator to `shared_ptr<Request>`.
@@ -97,14 +99,15 @@ class RequestAmBuilder : public RequestCallbackBuilderBase<RequestAmBuilder> {
 };
 
 /**
- * @brief Create a RequestAmBuilder for constructing a `shared_ptr<ucxx::RequestAm>`.
+ * @brief Create a RequestAmBuilder for constructing a `shared_ptr<ucxx::RequestAmManaged>`.
  *
  * @param[in] endpoint     the parent endpoint (required).
  * @param[in] requestData  container of the specified message type (required).
  * @return A RequestAmBuilder object that can be used to set optional parameters.
  */
 [[nodiscard]] inline RequestAmBuilder requestAmBuilder(
-  std::shared_ptr<Endpoint> endpoint, std::variant<data::AmSend, data::AmReceive> requestData)
+  std::shared_ptr<Endpoint> endpoint,
+  std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData)
 {
   return RequestAmBuilder(std::move(endpoint), std::move(requestData));
 }

--- a/cpp/include/ucxx/request_builder_base.h
+++ b/cpp/include/ucxx/request_builder_base.h
@@ -106,8 +106,8 @@ class RequestBuilderBase {
  * @brief CRTP base for request builders that support completion callbacks.
  *
  * Extends `RequestBuilderBase` with `_callbackFunction` / `_callbackData` members and
- * their fluent setters. Used by builders for `RequestTag`, `RequestAm`, `RequestMem`,
- * `RequestFlush`, and `RequestEndpointClose`.
+ * their fluent setters. Used by builders for `RequestTag`, `RequestAmManaged`,
+ * `RequestMem`, `RequestFlush`, and `RequestEndpointClose`.
  *
  * @tparam Derived  The concrete builder type (CRTP).
  */

--- a/cpp/include/ucxx/request_data.h
+++ b/cpp/include/ucxx/request_data.h
@@ -22,12 +22,15 @@ class Buffer;
 namespace data {
 
 /**
- * @brief Data for an Active Message send.
+ * @brief Data for a managed Active Message send.
  *
- * Type identifying an Active Message send operation and containing data specific to this
- * request type.
+ * Stores the payload description and managed AM send parameters used by
+ * `RequestAmManaged`. The parameters are serialized into UCXX's managed AM header before
+ * the send is submitted, allowing the receiver to choose an allocator, preserve the user
+ * header, and either match the message with `amManagedRecv()` or route it to a registered
+ * receiver callback.
  */
-class AmSend {
+class AmSendManaged {
  public:
   const void* const _buffer{nullptr};      ///< The raw pointer where data to be sent is stored.
   const size_t _length{0};                 ///< Message length in bytes (contiguous datatype only).
@@ -44,65 +47,56 @@ class AmSend {
   const std::vector<std::byte> _userHeader{};  ///< Opaque user-defined header bytes.
 
   /**
-   * @brief Constructor for Active Message-specific send data.
+   * @brief Constructor for managed Active Message send data (contiguous).
    *
-   * Construct an object containing Active Message-specific send data.
-   *
-   * @param[in] buffer                  a raw pointer to the data to be sent.
-   * @param[in] length                  the size in bytes of the message to be sent.
-   * @param[in] params                  send parameters controlling datatype/flags/policies.
+   * @param[in] buffer  a raw pointer to the data to be sent.
+   * @param[in] length  the size in bytes of the message to be sent.
+   * @param[in] params  send parameters controlling datatype/flags/policies.
    */
-  explicit AmSend(const decltype(_buffer) buffer,
-                  const decltype(_length) length,
-                  const AmSendParams& params = AmSendParams{});
+  explicit AmSendManaged(const decltype(_buffer) buffer,
+                         const decltype(_length) length,
+                         const AmSendParams& params = AmSendParams{});
 
   /**
-   * @brief Constructor for Active Message-specific send data using IOV datatype.
-   *
-   * Construct an object containing Active Message-specific send data for `UCP_DATATYPE_IOV`.
+   * @brief Constructor for managed Active Message send data (IOV).
    *
    * @param[in] iov     vector of IOV segments to send.
    * @param[in] params  send parameters controlling datatype/flags/policies.
    */
-  explicit AmSend(decltype(_iov) iov, const AmSendParams& params = AmSendParams{});
+  explicit AmSendManaged(decltype(_iov) iov, const AmSendParams& params = AmSendParams{});
 
-  AmSend() = delete;
+  AmSendManaged() = delete;
 };
 
 /**
- * @brief Data for an Active Message receive.
+ * @brief Data for a managed Active Message receive.
  *
- * Type identifying an Active Message receive operation and containing data specific to this
- * request type.
+ * Stores the receive-side state populated by the worker's managed AM receive callback. When
+ * a managed receive completes, `_buffer` holds the received payload and `_userHeader` holds
+ * the sender-provided user header bytes.
  */
-class AmReceive {
+class AmReceiveManaged {
  public:
   std::shared_ptr<::ucxx::Buffer> _buffer{nullptr};  ///< The AM received message buffer
   std::vector<std::byte> _userHeader{};              ///< User-defined header bytes from the sender.
 
   /**
-   * @brief Constructor for Active Message-specific receive data.
-   *
-   * Construct an object containing Active Message-specific receive data. Currently no
-   * specific data to receive Active Message is supported, but this class exists to act as
-   * an operation identifier, providing interface compatibility.
+   * @brief Constructor for managed Active Message receive data.
    */
-  AmReceive();
+  AmReceiveManaged();
 };
 
 /**
  * @brief Data for an endpoint close operation.
  *
- * Type identifying an endpoint close operation and containing data specific to this request
- * type.
+ * Type identifying an endpoint close operation and containing data specific to this
+ * request type.
  */
 class EndpointClose {
  public:
   const bool _force{false};  ///< Whether to force endpoint closing.
   /**
    * @brief Constructor for endpoint close-specific data.
-   *
-   * Construct an object containing endpoint close-specific data.
    *
    * @param[in] force   force endpoint close if `true`, flush otherwise.
    */
@@ -120,8 +114,6 @@ class Flush {
  public:
   /**
    * @brief Constructor for flush-specific data.
-   *
-   * Construct an object containing flush-specific data.
    */
   Flush();
 };
@@ -141,10 +133,8 @@ class MemPut {
   /**
    * @brief Constructor for memory-specific data.
    *
-   * Construct an object containing memory-specific data.
-   *
    * @param[in] buffer      a raw pointer to the data to be sent.
-   * @param[in] length      the size in bytes of the tag message to be sent.
+   * @param[in] length      the size in bytes of the message to be sent.
    * @param[in] remoteAddr  the destination remote memory address to write to.
    * @param[in] rkey        the remote memory key associated with the remote memory address.
    */
@@ -159,8 +149,7 @@ class MemPut {
 /**
  * @brief Data for a memory receive.
  *
- * Type identifying a memory receive operation and containing data specific to this request
- * type.
+ * Type identifying a memory receive operation and containing data specific to this request type.
  */
 class MemGet {
  public:
@@ -172,10 +161,8 @@ class MemGet {
   /**
    * @brief Constructor for memory-specific data.
    *
-   * Construct an object containing memory-specific data.
-   *
    * @param[out] buffer     a raw pointer to the received data.
-   * @param[in]  length     the size in bytes of the tag message to be received.
+   * @param[in]  length     the size in bytes of the message to be received.
    * @param[in]  remoteAddr the source remote memory address to read from.
    * @param[in]  rkey       the remote memory key associated with the remote memory address.
    */
@@ -190,8 +177,7 @@ class MemGet {
 /**
  * @brief Data for a Stream send.
  *
- * Type identifying a Stream send operation and containing data specific to this request
- * type.
+ * Type identifying a Stream send operation and containing data specific to this request type.
  */
 class StreamSend {
  public:
@@ -201,10 +187,8 @@ class StreamSend {
   /**
    * @brief Constructor for stream-specific data.
    *
-   * Construct an object containing stream-specific data.
-   *
    * @param[in] buffer  a raw pointer to the data to be sent.
-   * @param[in] length  the size in bytes of the tag message to be sent.
+   * @param[in] length  the size in bytes of the message to be sent.
    */
   explicit StreamSend(const decltype(_buffer) buffer, const decltype(_length) length);
 
@@ -212,24 +196,21 @@ class StreamSend {
 };
 
 /**
- * @brief Data for an Stream receive.
+ * @brief Data for a Stream receive.
  *
- * Type identifying an Stream receive operation and containing data specific to this
- * request type.
+ * Type identifying a Stream receive operation and containing data specific to this request type.
  */
 class StreamReceive {
  public:
   void* _buffer{nullptr};     ///< The raw pointer where received data should be stored.
-  const size_t _length{0};    ///< The expected messaged length.
+  const size_t _length{0};    ///< The expected message length.
   size_t _lengthReceived{0};  ///< The actual received message length.
 
   /**
    * @brief Constructor for stream-specific data.
    *
-   * Construct an object containing stream-specific data.
-   *
    * @param[out] buffer   a raw pointer to the received data.
-   * @param[in]  length   the size in bytes of the tag message to be received.
+   * @param[in]  length   the size in bytes of the message to be received.
    */
   explicit StreamReceive(decltype(_buffer) buffer, const decltype(_length) length);
 
@@ -250,10 +231,8 @@ class TagSend {
   /**
    * @brief Constructor for tag-specific data.
    *
-   * Construct an object containing tag-specific data.
-   *
    * @param[in] buffer  a raw pointer to the data to be sent.
-   * @param[in] length  the size in bytes of the tag message to be sent.
+   * @param[in] length  the size in bytes of the message to be sent.
    * @param[in] tag     the tag to match.
    */
   explicit TagSend(const decltype(_buffer) buffer,
@@ -266,8 +245,7 @@ class TagSend {
 /**
  * @brief Data for a Tag receive.
  *
- * Type identifying a Tag receive operation and containing data specific to this request
- * type.
+ * Type identifying a Tag receive operation and containing data specific to this request type.
  */
 class TagReceive {
  public:
@@ -279,10 +257,8 @@ class TagReceive {
   /**
    * @brief Constructor for tag-specific data.
    *
-   * Construct an object containing send tag-specific data.
-   *
    * @param[out] buffer   a raw pointer to the received data.
-   * @param[in]  length   the size in bytes of the tag message to be received.
+   * @param[in]  length   the size in bytes of the message to be received.
    * @param[in]  tag      the tag to match.
    * @param[in]  tagMask  the tag mask to use (only used for receive operations).
    */
@@ -309,11 +285,7 @@ class TagReceiveWithHandle {
   /**
    * @brief Constructor for tag receive with handle-specific data.
    *
-   * Construct an object containing tag receive with handle-specific data.
-   *
-   * @param[out] buffer      a raw pointer to the received data. The buffer must be large
-   *                         enough to hold the message data, otherwise the behavior is
-   *                         undefined. The buffer must be pre-allocated.
+   * @param[out] buffer      a raw pointer to the received data.
    * @param[in]  probeInfo   the TagProbeInfo object containing message length and handle.
    */
   explicit TagReceiveWithHandle(decltype(_buffer) buffer, std::shared_ptr<TagProbeInfo> probeInfo);
@@ -337,12 +309,10 @@ class TagMultiSend {
   /**
    * @brief Constructor for send multi-buffer tag-specific data.
    *
-   * Construct an object containing tag/multi-buffer tag-specific data.
-   *
-   * @param[in] buffer  a raw pointers to the data to be sent.
-   * @param[in] length  the size in bytes of the tag messages to be sent.
+   * @param[in] buffer  raw pointers to the data to be sent.
+   * @param[in] length  sizes in bytes of the messages to be sent.
    * @param[in] isCUDA  flags indicating whether buffers being sent are CUDA.
-   * @param[in] tag     the tags to match.
+   * @param[in] tag     the tag to match.
    */
   explicit TagMultiSend(const decltype(_buffer)& buffer,
                         const decltype(_length)& length,
@@ -366,8 +336,6 @@ class TagMultiReceive {
   /**
    * @brief Constructor for receive multi-buffer tag-specific data.
    *
-   * Construct an object containing receive multi-buffer tag-specific data.
-   *
    * @param[in]  tag      the tag to match.
    * @param[in]  tagMask  the tag mask to use (only used for receive operations).
    */
@@ -377,8 +345,8 @@ class TagMultiReceive {
 };
 
 using RequestData = std::variant<std::monostate,
-                                 AmSend,
-                                 AmReceive,
+                                 AmSendManaged,
+                                 AmReceiveManaged,
                                  EndpointClose,
                                  Flush,
                                  MemPut,

--- a/cpp/include/ucxx/typedefs.h
+++ b/cpp/include/ucxx/typedefs.h
@@ -24,7 +24,7 @@ namespace ucxx {
 
 class Buffer;
 class Request;
-class RequestAm;
+class RequestAmManaged;
 
 /**
  * @brief Available logging levels.

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -13,6 +13,7 @@
 #include <thread>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include <ucp/api/ucp.h>
 
@@ -48,10 +49,10 @@ class Address;
 class Buffer;
 class Endpoint;
 class Listener;
-class RequestAm;
+class RequestAmManaged;
 
 namespace internal {
-class AmData;
+class ManagedAmData;
 }  // namespace internal
 
 /**
@@ -82,9 +83,16 @@ class Worker : public Component {
     nullptr};  ///< The argument to be passed to the progress thread start callback
   std::shared_ptr<DelayedSubmissionCollection> _delayedSubmissionCollection{
     nullptr};  ///< Collection of enqueued delayed submissions
-  friend std::shared_ptr<RequestAm> createRequestAm(
+  friend std::shared_ptr<RequestAmManaged> createRequestAmManaged(
     std::shared_ptr<Endpoint> endpoint,
-    const std::variant<data::AmSend, data::AmReceive> requestData,
+    const std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData,
+    const bool enablePythonFuture,
+    RequestCallbackUserFunction callbackFunction,
+    RequestCallbackUserData callbackData);
+
+  friend std::shared_ptr<RequestAmManaged> createRequestAm(
+    std::shared_ptr<Endpoint> endpoint,
+    const std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData,
     const bool enablePythonFuture,
     RequestCallbackUserFunction callbackFunction,
     RequestCallbackUserData callbackData);
@@ -98,8 +106,8 @@ class Worker : public Component {
   std::queue<std::shared_ptr<Future>>
     _futuresPool{};  ///< Futures pool to prevent running out of fresh futures
   std::shared_ptr<Notifier> _notifier{nullptr};  ///< Notifier object
-  std::shared_ptr<internal::AmData>
-    _amData;  ///< Worker data made available to Active Messages callback
+  std::shared_ptr<internal::ManagedAmData>
+    _managedAmData;  ///< Worker data made available to managed Active Messages callback
   BufferType _cudaBufferType{BufferType::Invalid};  ///< Preferred buffer type for CUDA allocations
 
  private:
@@ -112,21 +120,20 @@ class Worker : public Component {
   void drainWorkerTagRecv();
 
   /**
-   * @brief Get active message receive request.
+   * @brief Get managed active message receive request.
    *
-   * Returns an active message request from the pool if the worker has already begun
-   * handling a request with the active messages callback, otherwise creates a new request
-   * that is later populated with status and buffer by the active messages callback.
+   * Returns a managed active message request from the pool if the worker has already begun
+   * handling a request with the managed AM callback, otherwise creates a new request
+   * that is later populated with status and buffer by the managed AM callback.
    *
-   * @param[in] ep  the endpoint handle where receiving the message, the same handle that
-   *                will later be used to reply to the message.
+   * @param[in] ep  the endpoint handle where receiving the message.
    * @param[in] createAmRecvRequestFunction function to create a new request if one is not
    *                                        already available in the pool.
    *
    * @returns Request to be subsequently checked for the completion state and data.
    */
-  [[nodiscard]] std::shared_ptr<RequestAm> getAmRecv(
-    ucp_ep_h ep, std::function<std::shared_ptr<RequestAm>()> createAmRecvRequestFunction);
+  [[nodiscard]] std::shared_ptr<RequestAmManaged> getManagedAmRecv(
+    ucp_ep_h ep, std::function<std::shared_ptr<RequestAmManaged>()> createAmRecvRequestFunction);
 
   /**
    * @brief Stop the progress thread if running without raising warnings.
@@ -1023,92 +1030,59 @@ class Worker : public Component {
                                                          void* callbackArgs);
 
   /**
-   * @brief Register allocator for active messages.
+   * @brief Register allocator for managed active messages.
    *
-   * Register a new allocator for active messages. By default, only one allocator is defined
-   * for host memory (`UCS_MEMORY_TYPE_HOST`), and is used as a fallback when an allocator
-   * for the source's memory type is unavailable. In many circumstances relying exclusively
-   * on the host allocator is undesirable, for example when transferring CUDA buffers the
-   * destination is always going to be a host buffer and prevent the use of transports such
-   * as NVLink or InfiniBand+GPUDirectRDMA. For that reason it's important that the user
-   * defines those allocators that are important for the application.
+   * Register a buffer allocator for managed Active Messages. By default, only one
+   * allocator is defined for host memory (`UCS_MEMORY_TYPE_HOST`). When transferring
+   * device buffers, register an appropriate allocator (e.g., CCCLBuffer for CUDA) so
+   * the receiver can allocate correctly-typed buffers.
    *
-   * If the `memoryType` has already been registered, the previous allocator will be
-   * replaced by the new one. Be careful when doing this after transfers have started, there
-   * are no guarantees that inflight messages have not already been allocated with the old
-   * allocator for that type.
-   *
-   * @code{.cpp}
-   * // context is `std::shared_ptr<ucxx::Context>`
-   * auto worker = context->workerBuilder().build();
-   *
-   * worker->registerAmAllocator(UCS_MEMORY_TYPE_CUDA, [](size_t length) {
-   *   return std::make_shared<ucxx::CCCLBuffer>(length);
-   * });
-   * @endcode
+   * If `memoryType` has already been registered, the previous allocator is replaced.
    *
    * @param[in] memoryType  the memory type the allocator will be used for.
-   * @param[in] allocator   the allocator callable that will be used to allocate new
-   *                        active message buffers.
+   * @param[in] allocator   callable that allocates a buffer of the given size.
    */
-  void registerAmAllocator(ucs_memory_type_t memoryType, AmAllocatorType allocator);
+  void registerManagedAmAllocator(ucs_memory_type_t memoryType, AmAllocatorType allocator);
 
   /**
-   * @brief Register receiver callback for active messages.
+   * @brief Register receiver callback for managed active messages.
    *
-   * Register a new receiver callback for active messages. By default, active messages do
-   * not execute any callbacks on the receiving end unless one is specified when sending
-   * the message. If the message sender specifies a callback receiver identifier then the
-   * remote receiver needs to have a callback registered with the same identifier to
-   * execute when the request completes. To ensure multiple applications that do not know
-   * about each other can have coexisting callbacks where receiver identifiers may have
-   * the same value, an owner must be specified as well, which has the form of a string and
-   * should be reasonably unique to prevent accidentally calling callbacks from a separate
-   * application, thus names like "A" or "UCX" are discouraged in favor of more descriptive
-   * names such as "MyFastCommsProject", and the name "ucxx" is reserved.
+   * Register a receiver callback for managed Active Messages. The sender specifies a
+   * callback by owner name and ID; the receiver must register a matching callback before
+   * the message arrives. The owner string must be unique enough to avoid collisions;
+   * "ucxx" is reserved.
    *
-   * Because it is impossible to predict which callback would be called in such an event,
-   * the registered callback cannot be changed, thus calling this method with the same
-   * given owner and identifier will throw `std::runtime_error`.
+   * @throws std::runtime_error if a callback with the same owner+id is already registered,
+   *                            or if the reserved owner name "ucxx" is used.
    *
-   * @code{.cpp}
-   * // `worker` is `std::shared_ptr<ucxx::Worker>`
-   * auto callback = [](std::shared_ptr<ucxx::Request> req) {
-   *   std::cout << "The UCXX request address is " << (void*)req.get() << std::endl;
-   * };
-   *
-   * worker->registerAmReceiverCallback({"MyFastApp", 0}, callback};
-   * @endcode
-   *
-   * @throws std::runtime_error if a callback with same given owner and identifier is
-   *                            already registered, or if the reserved owner name "ucxx"
-   *                            is specified.
-   *
-   * @param[in] info      the owner name and unique identifier of the receiver callback.
-   * @param[in] callback  the callback to execute when the active message is received.
+   * @param[in] info      owner name and unique identifier of the receiver callback.
+   * @param[in] callback  the callback to execute when a managed Active Message is received.
    */
-  void registerAmReceiverCallback(AmReceiverCallbackInfo info, AmReceiverCallbackType callback);
+  void registerManagedAmReceiverCallback(AmReceiverCallbackInfo info,
+                                         AmReceiverCallbackType callback);
 
   /**
-   * @brief Check for uncaught active messages.
+   * @brief Check for uncaught managed active messages.
    *
-   * Checks the worker for any uncaught active messages. An uncaught active message is any
-   * active message that has been fully or partially received by the worker, but not matched
-   * by a corresponding `createRequestAmRecv()` call.
+   * Returns `true` if any managed Active Messages have been received but not yet matched
+   * by an `amManagedRecv()` call for the given endpoint.
    *
-   * @code{.cpp}
-   * // `worker` is `std::shared_ptr<ucxx::Worker>`
-   * // `ep` is a remote `std::shared_ptr<ucxx::Endpoint` to the local `worker`
-   * assert(!worker->amProbe(ep->getHandle()));
-   *
-   * ep->amSend(buffer, length);
-   *
-   * assert(worker->amProbe(0));
-   * @endcode
-   *
-   * @returns `true` if any uncaught messages were received, `false` otherwise.
+   * @param[in] endpointHandle  the endpoint handle to probe.
+   * @returns `true` if any unmatched messages exist.
    */
-  [[nodiscard]] bool amProbe(const ucp_ep_h endpointHandle) const;
+  [[nodiscard]] bool amManagedProbe(const ucp_ep_h endpointHandle) const;
+
+  /// @deprecated Use `registerManagedAmAllocator()` instead.
+  [[deprecated("Use registerManagedAmAllocator instead.")]] void registerAmAllocator(
+    ucs_memory_type_t memoryType, AmAllocatorType allocator);
+
+  /// @deprecated Use `registerManagedAmReceiverCallback()` instead.
+  [[deprecated("Use registerManagedAmReceiverCallback instead.")]] void registerAmReceiverCallback(
+    AmReceiverCallbackInfo info, AmReceiverCallbackType callback);
+
+  /// @deprecated Use `amManagedProbe()` instead.
+  [[deprecated("Use amManagedProbe instead.")]] [[nodiscard]] bool amProbe(
+    const ucp_ep_h endpointHandle) const;
 
   /**
    * @brief Enqueue a flush operation.

--- a/cpp/python/src/worker.cpp
+++ b/cpp/python/src/worker.cpp
@@ -56,12 +56,12 @@ std::shared_ptr<::ucxx::Worker> createWorker(std::shared_ptr<Context> context,
 
   // We can only get a `shared_ptr<Worker>` for the Active Messages callback after it's
   // been created, thus this cannot be in the constructor.
-  if (worker->_amData != nullptr) {
-    worker->_amData->_worker = worker;
+  if (worker->_managedAmData != nullptr) {
+    worker->_managedAmData->_worker = worker;
 
     std::stringstream ownerStream;
     ownerStream << "worker " << worker->getHandle();
-    worker->_amData->_ownerString = ownerStream.str();
+    worker->_managedAmData->_ownerString = ownerStream.str();
   }
 
   return worker;

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -484,7 +484,7 @@ size_t Endpoint::cancelInflightRequestsBlocking(uint64_t period, uint64_t maxAtt
 
 size_t Endpoint::getCancelingSize() const { return _inflightRequests->getCancelingSize(); }
 
-std::shared_ptr<Request> Endpoint::amSend(
+std::shared_ptr<Request> Endpoint::amManagedSend(
   const void* const buffer,
   const size_t length,
   const ucs_memory_type_t memoryType,
@@ -497,12 +497,45 @@ std::shared_ptr<Request> Endpoint::amSend(
   params.memoryType           = memoryType;
   params.receiverCallbackInfo = receiverCallbackInfo;
 
-  return amSend(buffer,
-                length,
-                params,
-                enablePythonFuture,
-                std::move(callbackFunction),
-                std::move(callbackData));
+  return amManagedSend(buffer, length, params, enablePythonFuture, callbackFunction, callbackData);
+}
+
+std::shared_ptr<Request> Endpoint::amManagedSend(const void* const buffer,
+                                                 const size_t length,
+                                                 const AmSendParams& params,
+                                                 const bool enablePythonFuture,
+                                                 RequestCallbackUserFunction callbackFunction,
+                                                 RequestCallbackUserData callbackData)
+{
+  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
+  return registerInflightRequest(createRequestAmManaged(endpoint,
+                                                        data::AmSendManaged(buffer, length, params),
+                                                        enablePythonFuture,
+                                                        callbackFunction,
+                                                        callbackData));
+}
+
+std::shared_ptr<Request> Endpoint::amManagedSend(std::vector<ucp_dt_iov_t> iov,
+                                                 const AmSendParams& params,
+                                                 const bool enablePythonFuture,
+                                                 RequestCallbackUserFunction callbackFunction,
+                                                 RequestCallbackUserData callbackData)
+{
+  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
+  return registerInflightRequest(createRequestAmManaged(endpoint,
+                                                        data::AmSendManaged(std::move(iov), params),
+                                                        enablePythonFuture,
+                                                        callbackFunction,
+                                                        callbackData));
+}
+
+std::shared_ptr<Request> Endpoint::amManagedRecv(const bool enablePythonFuture,
+                                                 RequestCallbackUserFunction callbackFunction,
+                                                 RequestCallbackUserData callbackData)
+{
+  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
+  return registerInflightRequest(createRequestAmManaged(
+    endpoint, data::AmReceiveManaged(), enablePythonFuture, callbackFunction, callbackData));
 }
 
 RequestAmBuilder Endpoint::amSendBuilder(const void* const buffer,
@@ -515,6 +548,44 @@ RequestAmBuilder Endpoint::amSendBuilder(const void* const buffer,
   return amSendBuilder(buffer, length, params);
 }
 
+RequestAmBuilder Endpoint::amSendBuilder(const void* const buffer,
+                                         const size_t length,
+                                         const AmSendParams& params)
+{
+  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
+  return RequestAmBuilder(std::move(endpoint), data::AmSendManaged(buffer, length, params));
+}
+
+RequestAmBuilder Endpoint::amSendBuilder(std::vector<ucp_dt_iov_t> iov, const AmSendParams& params)
+{
+  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
+  return RequestAmBuilder(std::move(endpoint), data::AmSendManaged(std::move(iov), params));
+}
+
+RequestAmBuilder Endpoint::amRecvBuilder()
+{
+  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
+  return RequestAmBuilder(std::move(endpoint), data::AmReceiveManaged());
+}
+
+std::shared_ptr<Request> Endpoint::amSend(
+  const void* const buffer,
+  const size_t length,
+  const ucs_memory_type_t memoryType,
+  const std::optional<AmReceiverCallbackInfo> receiverCallbackInfo,
+  const bool enablePythonFuture,
+  RequestCallbackUserFunction callbackFunction,
+  RequestCallbackUserData callbackData)
+{
+  return amManagedSend(buffer,
+                       length,
+                       memoryType,
+                       receiverCallbackInfo,
+                       enablePythonFuture,
+                       callbackFunction,
+                       callbackData);
+}
+
 std::shared_ptr<Request> Endpoint::amSend(const void* const buffer,
                                           const size_t length,
                                           const AmSendParams& params,
@@ -522,20 +593,7 @@ std::shared_ptr<Request> Endpoint::amSend(const void* const buffer,
                                           RequestCallbackUserFunction callbackFunction,
                                           RequestCallbackUserData callbackData)
 {
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestAm(endpoint,
-                                                 data::AmSend(buffer, length, params),
-                                                 enablePythonFuture,
-                                                 std::move(callbackFunction),
-                                                 std::move(callbackData)));
-}
-
-RequestAmBuilder Endpoint::amSendBuilder(const void* const buffer,
-                                         const size_t length,
-                                         const AmSendParams& params)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return RequestAmBuilder(std::move(endpoint), data::AmSend(buffer, length, params));
+  return amManagedSend(buffer, length, params, enablePythonFuture, callbackFunction, callbackData);
 }
 
 std::shared_ptr<Request> Endpoint::amSend(std::vector<ucp_dt_iov_t> iov,
@@ -544,36 +602,14 @@ std::shared_ptr<Request> Endpoint::amSend(std::vector<ucp_dt_iov_t> iov,
                                           RequestCallbackUserFunction callbackFunction,
                                           RequestCallbackUserData callbackData)
 {
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestAm(endpoint,
-                                                 data::AmSend(std::move(iov), params),
-                                                 enablePythonFuture,
-                                                 std::move(callbackFunction),
-                                                 std::move(callbackData)));
-}
-
-RequestAmBuilder Endpoint::amSendBuilder(std::vector<ucp_dt_iov_t> iov, const AmSendParams& params)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return RequestAmBuilder(std::move(endpoint), data::AmSend(std::move(iov), params));
+  return amManagedSend(std::move(iov), params, enablePythonFuture, callbackFunction, callbackData);
 }
 
 std::shared_ptr<Request> Endpoint::amRecv(const bool enablePythonFuture,
                                           RequestCallbackUserFunction callbackFunction,
                                           RequestCallbackUserData callbackData)
 {
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestAm(endpoint,
-                                                 data::AmReceive(),
-                                                 enablePythonFuture,
-                                                 std::move(callbackFunction),
-                                                 std::move(callbackData)));
-}
-
-RequestAmBuilder Endpoint::amRecvBuilder()
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return RequestAmBuilder(std::move(endpoint), data::AmReceive());
+  return amManagedRecv(enablePythonFuture, callbackFunction, callbackData);
 }
 
 std::shared_ptr<Request> Endpoint::memGet(void* buffer,

--- a/cpp/src/internal/request_am.cpp
+++ b/cpp/src/internal/request_am.cpp
@@ -16,18 +16,18 @@ namespace ucxx {
 
 namespace internal {
 
-RecvAmMessage::RecvAmMessage(internal::AmData* amData,
-                             ucp_ep_h ep,
-                             std::shared_ptr<RequestAm> request,
-                             std::shared_ptr<Buffer> buffer,
-                             AmReceiverCallbackType receiverCallback,
-                             std::vector<std::byte> userHeader)
+ManagedRecvAmMessage::ManagedRecvAmMessage(internal::ManagedAmData* amData,
+                                           ucp_ep_h ep,
+                                           std::shared_ptr<RequestAmManaged> request,
+                                           std::shared_ptr<Buffer> buffer,
+                                           AmReceiverCallbackType receiverCallback,
+                                           std::vector<std::byte> userHeader)
   : _amData(amData), _ep(ep), _request(request)
 {
   std::visit(data::dispatch{
-               [this, buffer, &userHeader](data::AmReceive& amReceive) {
-                 amReceive._buffer     = buffer;
-                 amReceive._userHeader = std::move(userHeader);
+               [this, buffer, &userHeader](data::AmReceiveManaged& amReceiveManaged) {
+                 amReceiveManaged._buffer     = buffer;
+                 amReceiveManaged._userHeader = std::move(userHeader);
                },
                [](auto) { throw std::runtime_error("Unreachable"); },
              },
@@ -40,10 +40,12 @@ RecvAmMessage::RecvAmMessage(internal::AmData* amData,
   }
 }
 
-void RecvAmMessage::callback(void* request, ucs_status_t status)
+void ManagedRecvAmMessage::setUcpRequest(void* request) { _request->_request = request; }
+
+void ManagedRecvAmMessage::callback(void* request, ucs_status_t status)
 {
   std::visit(data::dispatch{
-               [this, request, status](data::AmReceive) {
+               [this, request, status](data::AmReceiveManaged) {
                  _request->callback(request, status);
                  {
                    std::lock_guard<std::mutex> lock(_amData->_mutex);

--- a/cpp/src/request_am.cpp
+++ b/cpp/src/request_am.cpp
@@ -118,22 +118,24 @@ struct AmHeader {
   }
 };
 
-std::shared_ptr<RequestAm> createRequestAm(
+std::shared_ptr<RequestAmManaged> createRequestAmManaged(
   std::shared_ptr<Endpoint> endpoint,
-  const std::variant<data::AmSend, data::AmReceive> requestData,
+  const std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData,
   const bool enablePythonFuture                = false,
   RequestCallbackUserFunction callbackFunction = nullptr,
   RequestCallbackUserData callbackData         = nullptr)
 {
-  std::shared_ptr<RequestAm> req = std::visit(
+  std::shared_ptr<RequestAmManaged> req = std::visit(
     data::dispatch{
-      [endpoint, enablePythonFuture, callbackFunction, callbackData](data::AmSend amSend) {
-        auto req = std::shared_ptr<RequestAm>(new RequestAm(endpoint,
-                                                            amSend,
-                                                            std::move("amSend"),
-                                                            enablePythonFuture,
-                                                            callbackFunction,
-                                                            callbackData));
+      [endpoint, enablePythonFuture, callbackFunction, callbackData](
+        data::AmSendManaged amSendManaged) {
+        auto req =
+          std::shared_ptr<RequestAmManaged>(new RequestAmManaged(endpoint,
+                                                                 amSendManaged,
+                                                                 std::move("amManagedSend"),
+                                                                 enablePythonFuture,
+                                                                 callbackFunction,
+                                                                 callbackData));
 
         // A delayed notification request is not populated immediately, instead it is
         // delayed to allow the worker progress thread to set its status, and more
@@ -143,19 +145,21 @@ std::shared_ptr<RequestAm> createRequestAm(
 
         return req;
       },
-      [endpoint, enablePythonFuture, callbackFunction, callbackData](data::AmReceive amReceive) {
+      [endpoint, enablePythonFuture, callbackFunction, callbackData](
+        data::AmReceiveManaged amReceiveManaged) {
         auto worker = endpoint->getWorker();
 
         auto createRequest =
-          [endpoint, amReceive, enablePythonFuture, callbackFunction, callbackData]() {
-            return std::shared_ptr<RequestAm>(new RequestAm(endpoint,
-                                                            amReceive,
-                                                            std::move("amReceive"),
-                                                            enablePythonFuture,
-                                                            callbackFunction,
-                                                            callbackData));
+          [endpoint, amReceiveManaged, enablePythonFuture, callbackFunction, callbackData]() {
+            return std::shared_ptr<RequestAmManaged>(
+              new RequestAmManaged(endpoint,
+                                   amReceiveManaged,
+                                   std::move("amManagedRecv"),
+                                   enablePythonFuture,
+                                   callbackFunction,
+                                   callbackData));
           };
-        return worker->getAmRecv(endpoint->getHandle(), createRequest);
+        return worker->getManagedAmRecv(endpoint->getHandle(), createRequest);
       },
     },
     requestData);
@@ -163,12 +167,24 @@ std::shared_ptr<RequestAm> createRequestAm(
   return req;
 }
 
-RequestAm::RequestAm(std::shared_ptr<Component> endpointOrWorker,
-                     const std::variant<data::AmSend, data::AmReceive> requestData,
-                     std::string operationName,
-                     const bool enablePythonFuture,
-                     RequestCallbackUserFunction callbackFunction,
-                     RequestCallbackUserData callbackData)
+std::shared_ptr<RequestAmManaged> createRequestAm(
+  std::shared_ptr<Endpoint> endpoint,
+  const std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData,
+  const bool enablePythonFuture                = false,
+  RequestCallbackUserFunction callbackFunction = nullptr,
+  RequestCallbackUserData callbackData         = nullptr)
+{
+  return createRequestAmManaged(
+    endpoint, requestData, enablePythonFuture, callbackFunction, callbackData);
+}
+
+RequestAmManaged::RequestAmManaged(
+  std::shared_ptr<Component> endpointOrWorker,
+  const std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData,
+  std::string operationName,
+  const bool enablePythonFuture,
+  RequestCallbackUserFunction callbackFunction,
+  RequestCallbackUserData callbackData)
   : Request(endpointOrWorker,
             data::getRequestData(requestData),
             std::move(operationName),
@@ -177,21 +193,21 @@ RequestAm::RequestAm(std::shared_ptr<Component> endpointOrWorker,
             callbackData)
 {
   std::visit(data::dispatch{
-               [this](data::AmSend) {
+               [this](data::AmSendManaged) {
                  if (_endpoint == nullptr)
                    throw ucxx::Error("An endpoint is required to send active messages");
                },
-               [](data::AmReceive) {},
+               [](data::AmReceiveManaged) {},
              },
              requestData);
 }
 
-void RequestAm::cancel()
+void RequestAmManaged::cancel()
 {
   std::lock_guard<std::recursive_mutex> lock(_mutex);
   if (_status == UCS_INPROGRESS) {
     /**
-     * This is needed to ensure AM requests are cancelable, since they do not
+     * This is needed to ensure managed AM requests are cancelable, since they do not
      * use the `_request`, thus `ucp_request_cancel()` cannot cancel them.
      */
     setStatus(UCS_ERR_CANCELED);
@@ -218,27 +234,28 @@ static void _recvCompletedCallback(void* request,
                                    size_t /* length */,
                                    void* user_data)
 {
-  internal::RecvAmMessage* recvAmMessage = static_cast<internal::RecvAmMessage*>(user_data);
+  internal::ManagedRecvAmMessage* recvAmMessage =
+    static_cast<internal::ManagedRecvAmMessage*>(user_data);
   ucxx_trace_req_f(recvAmMessage->_request->getOwnerString().c_str(),
                    nullptr,
                    request,
-                   "amRecv",
+                   "amManagedRecv",
                    "amRecvCallback");
   recvAmMessage->callback(request, status);
 }
 
-ucs_status_t RequestAm::recvCallback(void* arg,
-                                     const void* header,
-                                     size_t header_length,
-                                     void* data,
-                                     size_t length,
-                                     const ucp_am_recv_param_t* param)
+ucs_status_t RequestAmManaged::recvCallback(void* arg,
+                                            const void* header,
+                                            size_t header_length,
+                                            void* data,
+                                            size_t length,
+                                            const ucp_am_recv_param_t* param)
 {
-  internal::AmData* amData = static_cast<internal::AmData*>(arg);
-  auto worker              = amData->_worker.lock();
-  auto& ownerString        = amData->_ownerString;
-  auto& recvPool           = amData->_recvPool;
-  auto& recvWait           = amData->_recvWait;
+  internal::ManagedAmData* amData = static_cast<internal::ManagedAmData*>(arg);
+  auto worker                     = amData->_worker.lock();
+  auto& ownerString               = amData->_ownerString;
+  auto& recvPool                  = amData->_recvPool;
+  auto& recvWait                  = amData->_recvWait;
 
   if ((param->recv_attr & UCP_AM_RECV_ATTR_FIELD_REPLY_EP) == 0)
     ucxx_error("UCP_AM_RECV_ATTR_FIELD_REPLY_EP not set");
@@ -263,40 +280,41 @@ ucs_status_t RequestAm::recvCallback(void* arg,
     return AmReceiverCallbackType();
   }();
 
-  std::shared_ptr<RequestAm> req{nullptr};
+  std::shared_ptr<RequestAmManaged> req{nullptr};
 
   {
     std::lock_guard<std::mutex> lock(amData->_mutex);
 
     auto reqs = recvWait.find(ep);
     if (amHeader.receiverCallbackInfo) {
-      req = std::shared_ptr<RequestAm>(new RequestAm(worker,
-                                                     data::AmReceive(),
-                                                     std::move("amReceive"),
-                                                     worker->isFutureEnabled(),
-                                                     nullptr,
-                                                     nullptr));
-      ucxx_trace_req_f(ownerString.c_str(), req.get(), nullptr, "amRecv", "receiverCallback");
+      req = std::shared_ptr<RequestAmManaged>(new RequestAmManaged(worker,
+                                                                   data::AmReceiveManaged(),
+                                                                   std::move("amManagedRecv"),
+                                                                   worker->isFutureEnabled(),
+                                                                   nullptr,
+                                                                   nullptr));
+      ucxx_trace_req_f(
+        ownerString.c_str(), req.get(), nullptr, "amManagedRecv", "receiverCallback");
     } else if (reqs != recvWait.end() && !reqs->second.empty()) {
       req = reqs->second.front();
       reqs->second.pop();
-      ucxx_trace_req_f(ownerString.c_str(), req.get(), nullptr, "amRecv", "recvWait");
+      ucxx_trace_req_f(ownerString.c_str(), req.get(), nullptr, "amManagedRecv", "recvWait");
     } else {
-      req             = std::shared_ptr<RequestAm>(new RequestAm(worker,
-                                                     data::AmReceive(),
-                                                     std::move("amReceive"),
-                                                     worker->isFutureEnabled(),
-                                                     nullptr,
-                                                     nullptr));
-      auto [queue, _] = recvPool.try_emplace(ep, std::queue<std::shared_ptr<RequestAm>>());
+      req             = std::shared_ptr<RequestAmManaged>(new RequestAmManaged(worker,
+                                                                   data::AmReceiveManaged(),
+                                                                   std::move("amManagedRecv"),
+                                                                   worker->isFutureEnabled(),
+                                                                   nullptr,
+                                                                   nullptr));
+      auto [queue, _] = recvPool.try_emplace(ep, std::queue<std::shared_ptr<RequestAmManaged>>());
       queue->second.push(req);
-      ucxx_trace_req_f(ownerString.c_str(), req.get(), nullptr, "amRecv", "recvPool");
+      ucxx_trace_req_f(ownerString.c_str(), req.get(), nullptr, "amManagedRecv", "recvPool");
     }
   }
 
   // Return immediately if the request's status has already been set before the
-  // callback executed, e.g., the user called `amRecv()` before the request arrived and
-  // canceled it.
+  // callback executed, e.g., the user called `amManagedRecv()` before the request arrived
+  // and canceled it.
   if (req->getStatus() != UCS_INPROGRESS) return req->getStatus();
 
   if (is_rndv) {
@@ -304,7 +322,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
       if (amHeader.memoryTypePolicy == AmSendMemoryTypePolicy::ErrorOnUnsupported) {
         ucxx_debug("No allocator registered for memory type %u and strict policy is active",
                    amHeader.memoryType);
-        internal::RecvAmMessage recvAmMessage(
+        internal::ManagedRecvAmMessage recvAmMessage(
           amData, ep, req, nullptr, receiverCallback, amHeader.userHeader);
         recvAmMessage.callback(nullptr, UCS_ERR_UNSUPPORTED);
         return UCS_ERR_UNSUPPORTED;
@@ -321,7 +339,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
       ucxx_debug("Exception calling allocator: %s", e.what());
     }
 
-    auto recvAmMessage = std::make_shared<internal::RecvAmMessage>(
+    auto recvAmMessage = std::make_shared<internal::ManagedRecvAmMessage>(
       amData, ep, req, buf, receiverCallback, amHeader.userHeader);
 
     ucp_request_param_t requestParam = {.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
@@ -343,7 +361,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
       ucxx_trace_req_f(ownerString.c_str(),
                        req.get(),
                        status,
-                       "amRecv rndv",
+                       "amManagedRecv rndv",
                        "recvCallback, ep: %p, buffer: %p, size: %lu, future: %p, future handle: %p",
                        ep,
                        buf->data(),
@@ -354,7 +372,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
       ucxx_trace_req_f(ownerString.c_str(),
                        req.get(),
                        status,
-                       "amRecv rndv",
+                       "amManagedRecv rndv",
                        "recvCallback, ep: %p, buffer: %p, size: %lu",
                        ep,
                        buf->data(),
@@ -381,7 +399,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
   } else {
     buf = amData->_allocators.at(UCS_MEMORY_TYPE_HOST)(length);
 
-    internal::RecvAmMessage recvAmMessage(
+    internal::ManagedRecvAmMessage recvAmMessage(
       amData, ep, req, buf, receiverCallback, amHeader.userHeader);
     if (buf == nullptr) {
       ucxx_debug("Failed to allocate %lu bytes of memory", length);
@@ -395,7 +413,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
       ucxx_trace_req_f(ownerString.c_str(),
                        req.get(),
                        nullptr,
-                       "amRecv eager",
+                       "amManagedRecv eager",
                        "recvCallback, ep: %p, buffer: %p, size: %lu, future: %p, future handle: %p",
                        ep,
                        buf->data(),
@@ -406,7 +424,7 @@ ucs_status_t RequestAm::recvCallback(void* arg,
       ucxx_trace_req_f(ownerString.c_str(),
                        req.get(),
                        nullptr,
-                       "amRecv eager",
+                       "amManagedRecv eager",
                        "recvCallback, ep: %p, buffer: %p, size: %lu",
                        ep,
                        buf->data(),
@@ -417,71 +435,73 @@ ucs_status_t RequestAm::recvCallback(void* arg,
   }
 }
 
-std::shared_ptr<Buffer> RequestAm::getRecvBuffer()
+std::shared_ptr<Buffer> RequestAmManaged::getRecvBuffer()
 {
   return std::visit(
     data::dispatch{
-      [](data::AmReceive amReceive) { return amReceive._buffer; },
+      [](data::AmReceiveManaged amReceiveManaged) { return amReceiveManaged._buffer; },
       [](auto) -> std::shared_ptr<Buffer> { throw std::runtime_error("Unreachable"); },
     },
     _requestData);
 }
 
-std::string RequestAm::getRecvHeader()
+std::string RequestAmManaged::getRecvHeader()
 {
   return std::visit(data::dispatch{
-                      [](const data::AmReceive& amReceive) {
-                        if (amReceive._userHeader.empty()) return std::string{};
+                      [](const data::AmReceiveManaged& amReceiveManaged) {
+                        if (amReceiveManaged._userHeader.empty()) return std::string{};
                         return std::string(
-                          reinterpret_cast<const char*>(amReceive._userHeader.data()),
-                          amReceive._userHeader.size());
+                          reinterpret_cast<const char*>(amReceiveManaged._userHeader.data()),
+                          amReceiveManaged._userHeader.size());
                       },
                       [](auto) -> std::string { return {}; },
                     },
                     _requestData);
 }
 
-void RequestAm::request()
+void RequestAmManaged::request()
 {
   std::visit(
     data::dispatch{
-      [this](const data::AmSend& amSend) {
+      [this](const data::AmSendManaged& amSendManaged) {
         ucp_request_param_t param = {
           .op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_DATATYPE |
                           UCP_OP_ATTR_FIELD_FLAGS | UCP_OP_ATTR_FIELD_USER_DATA,
-          .flags     = amSend._flags,
-          .datatype  = amSend._datatype,
+          .flags     = amSendManaged._flags,
+          .datatype  = amSendManaged._datatype,
           .user_data = this};
 
-        param.cb.send          = _amSendCallback;
-        AmHeader header        = {.memoryType           = amSend._memoryType,
-                                  .memoryTypePolicy     = amSend._memoryTypePolicy,
-                                  .receiverCallbackInfo = amSend._receiverCallbackInfo,
-                                  .userHeader           = amSend._userHeader};
+        param.cb.send = _amSendCallback;
+        AmHeader header{.memoryType           = amSendManaged._memoryType,
+                        .memoryTypePolicy     = amSendManaged._memoryTypePolicy,
+                        .receiverCallbackInfo = amSendManaged._receiverCallbackInfo,
+                        .userHeader           = amSendManaged._userHeader};
         _header                = header.serialize();
-        const void* sendBuffer = (amSend._datatype == UCP_DATATYPE_IOV)
-                                   ? reinterpret_cast<const void*>(amSend._iov.data())
-                                   : amSend._buffer;
+        const void* sendBuffer = (amSendManaged._datatype == UCP_DATATYPE_IOV)
+                                   ? reinterpret_cast<const void*>(amSendManaged._iov.data())
+                                   : amSendManaged._buffer;
         void* request          = ucp_am_send_nbx(_endpoint->getHandle(),
                                         0,
                                         reinterpret_cast<const void*>(_header.data()),
                                         _header.size(),
                                         sendBuffer,
-                                        amSend._count,
+                                        amSendManaged._count,
                                         &param);
 
         publishRequest(request);
       },
-      [](auto) { throw ucxx::UnsupportedError("Only send active messages can call request()"); },
+      [](auto) {
+        throw ucxx::UnsupportedError("Only managed send active messages can call request()");
+      },
     },
     _requestData);
 }
 
-void RequestAm::populateDelayedSubmission()
+void RequestAmManaged::populateDelayedSubmission()
 {
   bool terminate =
     std::visit(data::dispatch{
-                 [this](data::AmSend) {
+                 [this](data::AmSendManaged) {
                    if (_endpoint->getHandle() == nullptr) {
                      ucxx_warn("Endpoint was closed before message could be sent");
                      Request::callback(this, UCS_ERR_CANCELED);
@@ -521,14 +541,14 @@ void RequestAm::populateDelayedSubmission()
   };
 
   std::visit(data::dispatch{
-               [this, &log](data::AmSend amSend) {
-                 if (amSend._datatype == UCP_DATATYPE_IOV) {
+               [this, &log](data::AmSendManaged amSendManaged) {
+                 if (amSendManaged._datatype == UCP_DATATYPE_IOV) {
                    size_t totalLength{0};
-                   for (const auto& segment : amSend._iov)
+                   for (const auto& segment : amSendManaged._iov)
                      totalLength += segment.length;
-                   log(amSend._iov.data(), totalLength, amSend._memoryType);
+                   log(amSendManaged._iov.data(), totalLength, amSendManaged._memoryType);
                  } else {
-                   log(amSend._buffer, amSend._length, amSend._memoryType);
+                   log(amSendManaged._buffer, amSendManaged._length, amSendManaged._memoryType);
                  }
                },
                [](auto) { throw std::runtime_error("Unreachable"); },

--- a/cpp/src/request_am_builder.cpp
+++ b/cpp/src/request_am_builder.cpp
@@ -17,8 +17,9 @@
 
 namespace ucxx {
 
-RequestAmBuilder::RequestAmBuilder(std::shared_ptr<Endpoint> endpoint,
-                                   std::variant<data::AmSend, data::AmReceive> requestData)
+RequestAmBuilder::RequestAmBuilder(
+  std::shared_ptr<Endpoint> endpoint,
+  std::variant<data::AmSendManaged, data::AmReceiveManaged> requestData)
   : _endpoint(std::move(endpoint)), _requestData(std::move(requestData))
 {
 }
@@ -26,9 +27,9 @@ RequestAmBuilder::RequestAmBuilder(std::shared_ptr<Endpoint> endpoint,
 RequestAmBuilder& RequestAmBuilder::receiverCallbackInfo(
   std::optional<AmReceiverCallbackInfo> info) &
 {
-  auto* amSend = std::get_if<data::AmSend>(&_requestData);
+  auto* amSend = std::get_if<data::AmSendManaged>(&_requestData);
   if (amSend == nullptr)
-    throw std::logic_error("receiverCallbackInfo() is only valid for active message sends");
+    throw std::logic_error("receiverCallbackInfo() is only valid for managed Active Message sends");
 
   auto params                 = AmSendParams{};
   params.flags                = amSend->_flags;
@@ -40,9 +41,9 @@ RequestAmBuilder& RequestAmBuilder::receiverCallbackInfo(
 
   if (amSend->_datatype == UCP_DATATYPE_IOV) {
     auto iov = amSend->_iov;
-    _requestData.template emplace<data::AmSend>(std::move(iov), params);
+    _requestData.template emplace<data::AmSendManaged>(std::move(iov), params);
   } else {
-    _requestData.template emplace<data::AmSend>(amSend->_buffer, amSend->_length, params);
+    _requestData.template emplace<data::AmSendManaged>(amSend->_buffer, amSend->_length, params);
   }
 
   return *this;
@@ -55,16 +56,16 @@ RequestAmBuilder&& RequestAmBuilder::receiverCallbackInfo(
   return std::move(*this);
 }
 
-std::shared_ptr<RequestAm> RequestAmBuilder::build()
+std::shared_ptr<RequestAmManaged> RequestAmBuilder::build()
 {
   markBuilt();
-  auto req = ucxx::createRequestAm(
+  auto req = ucxx::createRequestAmManaged(
     _endpoint, _requestData, _enablePythonFuture, _callbackFunction, _callbackData);
   detail::registerInflightRequest(_endpoint, req);
   return req;
 }
 
-RequestAmBuilder::operator std::shared_ptr<RequestAm>() { return build(); }
+RequestAmBuilder::operator std::shared_ptr<RequestAmManaged>() { return build(); }
 
 RequestAmBuilder::operator std::shared_ptr<Request>() { return build(); }
 

--- a/cpp/src/request_data.cpp
+++ b/cpp/src/request_data.cpp
@@ -19,7 +19,9 @@ namespace ucxx {
 
 namespace data {
 
-AmSend::AmSend(const void* const buffer, const size_t length, const AmSendParams& params)
+AmSendManaged::AmSendManaged(const void* const buffer,
+                             const size_t length,
+                             const AmSendParams& params)
   : _buffer(buffer),
     _length(length),
     _iov(),
@@ -38,7 +40,7 @@ AmSend::AmSend(const void* const buffer, const size_t length, const AmSendParams
     throw std::runtime_error("Buffer cannot be a nullptr when length is > 0.");
 }
 
-AmSend::AmSend(std::vector<ucp_dt_iov_t> iov, const AmSendParams& params)
+AmSendManaged::AmSendManaged(std::vector<ucp_dt_iov_t> iov, const AmSendParams& params)
   : _buffer(nullptr),
     _length(0),
     _iov(std::move(iov)),
@@ -61,7 +63,7 @@ AmSend::AmSend(std::vector<ucp_dt_iov_t> iov, const AmSendParams& params)
   }
 }
 
-AmReceive::AmReceive() {}
+AmReceiveManaged::AmReceiveManaged() {}
 
 EndpointClose::EndpointClose(const bool force) : _force(force) {}
 

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -53,20 +53,20 @@ Worker::Worker(std::shared_ptr<Context> context,
     std::make_shared<DelayedSubmissionCollection>(enableDelayedSubmission);
 
   if (context->getFeatureFlags() & UCP_FEATURE_AM) {
-    unsigned int AM_MSG_ID            = 0;
-    _amData                           = std::make_shared<internal::AmData>();
-    _amData->_registerInflightRequest = [this](std::shared_ptr<Request> req) {
+    unsigned int AM_MSG_ID                   = 0;
+    _managedAmData                           = std::make_shared<internal::ManagedAmData>();
+    _managedAmData->_registerInflightRequest = [this](std::shared_ptr<Request> req) {
       return registerInflightRequest(req);
     };
-    registerAmAllocator(UCS_MEMORY_TYPE_HOST,
-                        [](size_t length) { return std::make_shared<HostBuffer>(length); });
+    registerManagedAmAllocator(UCS_MEMORY_TYPE_HOST,
+                               [](size_t length) { return std::make_shared<HostBuffer>(length); });
 
     ucp_am_handler_param_t am_handler_param = {.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID |
                                                              UCP_AM_HANDLER_PARAM_FIELD_CB |
                                                              UCP_AM_HANDLER_PARAM_FIELD_ARG,
                                                .id  = AM_MSG_ID,
-                                               .cb  = RequestAm::recvCallback,
-                                               .arg = _amData.get()};
+                                               .cb  = RequestAmManaged::recvCallback,
+                                               .arg = _managedAmData.get()};
     utils::ucsErrorThrow(ucp_worker_set_am_recv_handler(_handle, &am_handler_param));
   }
 
@@ -119,13 +119,13 @@ void Worker::drainWorkerTagRecv()
   }
 }
 
-std::shared_ptr<RequestAm> Worker::getAmRecv(
-  ucp_ep_h ep, std::function<std::shared_ptr<RequestAm>()> createAmRecvRequestFunction)
+std::shared_ptr<RequestAmManaged> Worker::getManagedAmRecv(
+  ucp_ep_h ep, std::function<std::shared_ptr<RequestAmManaged>()> createAmRecvRequestFunction)
 {
-  std::lock_guard<std::mutex> lock(_amData->_mutex);
+  std::lock_guard<std::mutex> lock(_managedAmData->_mutex);
 
-  auto& recvPool = _amData->_recvPool;
-  auto& recvWait = _amData->_recvWait;
+  auto& recvPool = _managedAmData->_recvPool;
+  auto& recvWait = _managedAmData->_recvWait;
 
   auto reqs = recvPool.find(ep);
   if (reqs != recvPool.end() && !reqs->second.empty()) {
@@ -134,7 +134,7 @@ std::shared_ptr<RequestAm> Worker::getAmRecv(
     return req;
   } else {
     auto req        = createAmRecvRequestFunction();
-    auto [queue, _] = recvWait.try_emplace(ep, std::queue<std::shared_ptr<RequestAm>>());
+    auto [queue, _] = recvWait.try_emplace(ep, std::queue<std::shared_ptr<RequestAmManaged>>());
     queue->second.push(req);
     return req;
   }
@@ -147,12 +147,12 @@ std::shared_ptr<Worker> createWorker(std::shared_ptr<Context> context,
   auto worker = std::shared_ptr<Worker>(new Worker(context, enableDelayedSubmission, enableFuture));
   // We can only get a `shared_ptr<Worker>` for the Active Messages callback after it's
   // been created, thus this cannot be in the constructor.
-  if (worker->_amData != nullptr) {
-    worker->_amData->_worker = worker;
+  if (worker->_managedAmData != nullptr) {
+    worker->_managedAmData->_worker = worker;
 
     std::stringstream ownerStream;
     ownerStream << "worker " << worker->getHandle();
-    worker->_amData->_ownerString = ownerStream.str();
+    worker->_managedAmData->_ownerString = ownerStream.str();
   }
 
   return worker;
@@ -755,30 +755,44 @@ std::shared_ptr<Listener> Worker::createListener(uint16_t port,
   return listener;
 }
 
+void Worker::registerManagedAmAllocator(ucs_memory_type_t memoryType, AmAllocatorType allocator)
+{
+  if (_managedAmData == nullptr)
+    throw std::runtime_error("Active Messages was not enabled during context creation");
+  _managedAmData->_allocators.insert_or_assign(memoryType, allocator);
+}
+
+void Worker::registerManagedAmReceiverCallback(AmReceiverCallbackInfo info,
+                                               AmReceiverCallbackType callback)
+{
+  if (info.owner == "ucxx") throw std::runtime_error("The owner name 'ucxx' is reserved.");
+  if (_managedAmData->_receiverCallbacks.find(info.owner) ==
+      _managedAmData->_receiverCallbacks.end())
+    _managedAmData->_receiverCallbacks[info.owner] = {};
+  if (_managedAmData->_receiverCallbacks[info.owner].find(info.id) !=
+      _managedAmData->_receiverCallbacks[info.owner].end())
+    throw std::runtime_error("Callback with given owner and identifier is already registered");
+
+  _managedAmData->_receiverCallbacks[info.owner][info.id] = callback;
+}
+
+bool Worker::amManagedProbe(const ucp_ep_h endpointHandle) const
+{
+  return _managedAmData->_recvPool.find(endpointHandle) != _managedAmData->_recvPool.end();
+}
+
 void Worker::registerAmAllocator(ucs_memory_type_t memoryType, AmAllocatorType allocator)
 {
-  if (_amData == nullptr)
-    throw std::runtime_error("Active Messages was not enabled during context creation");
-  _amData->_allocators.insert_or_assign(memoryType, allocator);
+  registerManagedAmAllocator(memoryType, allocator);
 }
 
 void Worker::registerAmReceiverCallback(AmReceiverCallbackInfo info,
                                         AmReceiverCallbackType callback)
 {
-  if (info.owner == "ucxx") throw std::runtime_error("The owner name 'ucxx' is reserved.");
-  if (_amData->_receiverCallbacks.find(info.owner) == _amData->_receiverCallbacks.end())
-    _amData->_receiverCallbacks[info.owner] = {};
-  if (_amData->_receiverCallbacks[info.owner].find(info.id) !=
-      _amData->_receiverCallbacks[info.owner].end())
-    throw std::runtime_error("Callback with given owner and identifier is already registered");
-
-  _amData->_receiverCallbacks[info.owner][info.id] = callback;
+  registerManagedAmReceiverCallback(info, callback);
 }
 
-bool Worker::amProbe(const ucp_ep_h endpointHandle) const
-{
-  return _amData->_recvPool.find(endpointHandle) != _amData->_recvPool.end();
-}
+bool Worker::amProbe(const ucp_ep_h endpointHandle) const { return amManagedProbe(endpointHandle); }
 
 std::shared_ptr<Request> Worker::flush(const bool enableFuture,
                                        RequestCallbackUserFunction callbackFunction,

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -3,13 +3,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>
+#include <cstring>
 #include <memory>
+#include <mutex>
 #include <numeric>
 #include <stdexcept>
 #include <string>
 #include <tuple>
 #include <ucp/api/ucp.h>
 #include <ucs/type/status.h>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -237,7 +240,7 @@ class RequestTest
   }
 };
 
-TEST_P(RequestTest, ProgressAm)
+TEST_P(RequestTest, ProgressManagedAm)
 {
   if (_progressMode == ProgressMode::Wait) {
     GTEST_SKIP() << "Interrupting UCP worker progress operation in wait mode is not possible";
@@ -245,7 +248,7 @@ TEST_P(RequestTest, ProgressAm)
 
   if (_registerCustomAmAllocator && _memoryType == UCS_MEMORY_TYPE_CUDA) {
 #if UCXX_ENABLE_CCCL
-    _worker->registerAmAllocator(UCS_MEMORY_TYPE_CUDA, [](size_t length) {
+    _worker->registerManagedAmAllocator(UCS_MEMORY_TYPE_CUDA, [](size_t length) {
       return std::make_shared<ucxx::CCCLBuffer>(length);
     });
 #else
@@ -257,8 +260,8 @@ TEST_P(RequestTest, ProgressAm)
 
   // Submit and wait for transfers to complete
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendPtr[0], _messageSize, _memoryType));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amManagedSend(_sendPtr[0], _messageSize, _memoryType));
+  requests.push_back(_ep->amManagedRecv());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq = requests[1];
@@ -277,7 +280,7 @@ TEST_P(RequestTest, ProgressAm)
   ASSERT_THAT(_recv[0], ContainerEq(_send[0]));
 }
 
-TEST_P(RequestTest, ProgressAmIovHost)
+TEST_P(RequestTest, ProgressManagedAmIovHost)
 {
   if (_progressMode == ProgressMode::Wait) {
     GTEST_SKIP() << "Interrupting UCP worker progress operation in wait mode is not possible";
@@ -304,8 +307,8 @@ TEST_P(RequestTest, ProgressAmIovHost)
   amSendParams.memoryType = UCS_MEMORY_TYPE_HOST;
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(iov, amSendParams));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amManagedSend(iov, amSendParams));
+  requests.push_back(_ep->amManagedRecv());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq    = requests[1];
@@ -318,19 +321,20 @@ TEST_P(RequestTest, ProgressAmIovHost)
   ASSERT_THAT(recv, ContainerEq(send));
 }
 
-TEST_P(RequestTest, ProgressAmIovValidation)
+TEST_P(RequestTest, ProgressManagedAmIovValidation)
 {
   auto amSendParams       = ucxx::AmSendParams{};
   amSendParams.datatype   = UCP_DATATYPE_IOV;
   amSendParams.memoryType = UCS_MEMORY_TYPE_HOST;
 
-  EXPECT_THROW(std::ignore = _ep->amSend(std::vector<ucp_dt_iov_t>{}, amSendParams),
+  EXPECT_THROW(std::ignore = _ep->amManagedSend(std::vector<ucp_dt_iov_t>{}, amSendParams),
                std::runtime_error);
 
   std::vector<ucp_dt_iov_t> iovWithNullBuffer(1);
   iovWithNullBuffer[0].buffer = nullptr;
   iovWithNullBuffer[0].length = 16;
-  EXPECT_THROW(std::ignore = _ep->amSend(iovWithNullBuffer, amSendParams), std::runtime_error);
+  EXPECT_THROW(std::ignore = _ep->amManagedSend(iovWithNullBuffer, amSendParams),
+               std::runtime_error);
 
   std::vector<int> send{1, 2, 3, 4};
   std::vector<ucp_dt_iov_t> validIov(1);
@@ -339,10 +343,10 @@ TEST_P(RequestTest, ProgressAmIovValidation)
 
   auto wrongDatatypeParams     = amSendParams;
   wrongDatatypeParams.datatype = ucp_dt_make_contig(1);
-  EXPECT_THROW(std::ignore = _ep->amSend(validIov, wrongDatatypeParams), std::runtime_error);
+  EXPECT_THROW(std::ignore = _ep->amManagedSend(validIov, wrongDatatypeParams), std::runtime_error);
 }
 
-TEST_P(RequestTest, ProgressAmMemoryTypePolicyStrict)
+TEST_P(RequestTest, ProgressManagedAmMemoryTypePolicyStrict)
 {
   if (_progressMode == ProgressMode::Wait) {
     GTEST_SKIP() << "Interrupting UCP worker progress operation in wait mode is not possible";
@@ -356,8 +360,8 @@ TEST_P(RequestTest, ProgressAmMemoryTypePolicyStrict)
   amSendParams.memoryTypePolicy = ucxx::AmSendMemoryTypePolicy::ErrorOnUnsupported;
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(send.data(), send.size(), amSendParams));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amManagedSend(send.data(), send.size(), amSendParams));
+  requests.push_back(_ep->amManagedRecv());
 
   // Wait for completion without calling checkError(), since the receive request
   // is expected to complete with UCS_ERR_UNSUPPORTED.
@@ -369,7 +373,7 @@ TEST_P(RequestTest, ProgressAmMemoryTypePolicyStrict)
   ASSERT_EQ(requests[1]->getStatus(), UCS_ERR_UNSUPPORTED);
 }
 
-TEST_P(RequestTest, ProgressAmReceiverCallback)
+TEST_P(RequestTest, ProgressManagedAmReceiverCallback)
 {
   if (_progressMode == ProgressMode::Wait) {
     GTEST_SKIP() << "Interrupting UCP worker progress operation in wait mode is not possible";
@@ -377,7 +381,7 @@ TEST_P(RequestTest, ProgressAmReceiverCallback)
 
   if (_registerCustomAmAllocator && _memoryType == UCS_MEMORY_TYPE_CUDA) {
 #if UCXX_ENABLE_CCCL
-    _worker->registerAmAllocator(UCS_MEMORY_TYPE_CUDA, [](size_t length) {
+    _worker->registerManagedAmAllocator(UCS_MEMORY_TYPE_CUDA, [](size_t length) {
       return std::make_shared<ucxx::CCCLBuffer>(length);
     });
 #else
@@ -401,13 +405,14 @@ TEST_P(RequestTest, ProgressAmReceiverCallback)
         receivedRequests.push_back(req);
       }
     });
-  _worker->registerAmReceiverCallback(receiverCallbackInfo, callback);
+  _worker->registerManagedAmReceiverCallback(receiverCallbackInfo, callback);
 
   allocate(1, false);
 
   // Submit and wait for transfers to complete
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendPtr[0], _messageSize, _memoryType, receiverCallbackInfo));
+  requests.push_back(
+    _ep->amManagedSend(_sendPtr[0], _messageSize, _memoryType, receiverCallbackInfo));
   waitRequests(_worker, requests, _progressWorker);
 
   while (receivedRequests.size() < 1)
@@ -431,7 +436,7 @@ TEST_P(RequestTest, ProgressAmReceiverCallback)
   ASSERT_THAT(_recv[0], ContainerEq(_send[0]));
 }
 
-TEST_P(RequestTest, ProgressAmUserHeader)
+TEST_P(RequestTest, ProgressManagedAmUserHeader)
 {
   if (_progressMode == ProgressMode::Wait) {
     GTEST_SKIP() << "Interrupting UCP worker progress operation in wait mode is not possible";
@@ -449,8 +454,8 @@ TEST_P(RequestTest, ProgressAmUserHeader)
   amSendParams.setUserHeader(sentHeader);
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendPtr[0], _messageSize, amSendParams));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amManagedSend(_sendPtr[0], _messageSize, amSendParams));
+  requests.push_back(_ep->amManagedRecv());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq = requests[1];
@@ -461,7 +466,7 @@ TEST_P(RequestTest, ProgressAmUserHeader)
   ASSERT_THAT(_recv[0], ContainerEq(_send[0]));
 }
 
-TEST_P(RequestTest, ProgressAmIovUserHeader)
+TEST_P(RequestTest, ProgressManagedAmIovUserHeader)
 {
   if (_progressMode == ProgressMode::Wait) {
     GTEST_SKIP() << "Interrupting UCP worker progress operation in wait mode is not possible";
@@ -491,8 +496,8 @@ TEST_P(RequestTest, ProgressAmIovUserHeader)
   amSendParams.setUserHeader(sentHeader);
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(iov, amSendParams));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amManagedSend(iov, amSendParams));
+  requests.push_back(_ep->amManagedRecv());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq    = requests[1];
@@ -506,7 +511,7 @@ TEST_P(RequestTest, ProgressAmIovUserHeader)
   ASSERT_THAT(recv, ContainerEq(send));
 }
 
-TEST_P(RequestTest, ProgressAmEmptyUserHeader)
+TEST_P(RequestTest, ProgressManagedAmEmptyUserHeader)
 {
   if (_progressMode == ProgressMode::Wait) {
     GTEST_SKIP() << "Interrupting UCP worker progress operation in wait mode is not possible";
@@ -520,8 +525,8 @@ TEST_P(RequestTest, ProgressAmEmptyUserHeader)
 
   // Send without user header (default empty)
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendPtr[0], _messageSize, _memoryType));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amManagedSend(_sendPtr[0], _messageSize, _memoryType));
+  requests.push_back(_ep->amManagedRecv());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq = requests[1];
@@ -650,11 +655,11 @@ TEST_F(RequestAttributesDisabledTest, Stream)
   ASSERT_THAT(_recvBuf, ::testing::ContainerEq(_sendBuf));
 }
 
-TEST_F(RequestAttributesDisabledTest, Am)
+TEST_F(RequestAttributesDisabledTest, ManagedAm)
 {
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendBuf.data(), kMessageSize, UCS_MEMORY_TYPE_HOST));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amManagedSend(_sendBuf.data(), kMessageSize, UCS_MEMORY_TYPE_HOST));
+  requests.push_back(_ep->amManagedRecv());
   waitRequests(_worker, requests, _progressWorker);
 
   expectAllThrow(requests);
@@ -733,7 +738,7 @@ TEST_P(RequestTest, ProgressStreamRequestAttributes)
   ASSERT_THAT(_recv[0], ContainerEq(_send[0]));
 }
 
-TEST_P(RequestTest, ProgressAmRequestAttributes)
+TEST_P(RequestTest, ProgressManagedAmRequestAttributes)
 {
   if (_messageSize < _rndvThresh)
     GTEST_SKIP() << "Eager messages complete inline without a UCP request to query";
@@ -745,8 +750,8 @@ TEST_P(RequestTest, ProgressAmRequestAttributes)
   allocate(1, false);
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendPtr[0], _messageSize, _memoryType));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amManagedSend(_sendPtr[0], _messageSize, _memoryType));
+  requests.push_back(_ep->amManagedRecv());
   waitRequests(_worker, requests, _progressWorker);
 
   for (const auto& request : requests) {

--- a/cpp/tests/request_builders.cpp
+++ b/cpp/tests/request_builders.cpp
@@ -421,7 +421,7 @@ TEST_F(RequestBuilderTest, AllBuilderAutoTypes)
   static_assert(std::is_same<decltype(tagBuilder), ucxx::RequestTagBuilder>::value,
                 "auto without .build() is RequestTagBuilder");
 
-  auto amBuilder = ucxx::requestAmBuilder(_ep, ucxx::data::AmSend(buf.data(), sizeof(int)));
+  auto amBuilder = ucxx::requestAmBuilder(_ep, ucxx::data::AmSendManaged(buf.data(), sizeof(int)));
   static_assert(std::is_same<decltype(amBuilder), ucxx::RequestAmBuilder>::value,
                 "auto without .build() is RequestAmBuilder");
 
@@ -521,8 +521,8 @@ TEST(RequestBuilderTraitsTest, AllBuildersAreMoveOnly)
 
 TEST(RequestBuilderTraitsTest, BuildAndConversionRequireNonConstBuilders)
 {
-  assertBuildRequiresNonConstBuilder<ucxx::RequestAmBuilder, ucxx::RequestAm>();
-  assertConversionRequiresNonConstBuilder<ucxx::RequestAmBuilder, ucxx::RequestAm>();
+  assertBuildRequiresNonConstBuilder<ucxx::RequestAmBuilder, ucxx::RequestAmManaged>();
+  assertConversionRequiresNonConstBuilder<ucxx::RequestAmBuilder, ucxx::RequestAmManaged>();
   assertConversionRequiresNonConstBuilder<ucxx::RequestAmBuilder, ucxx::Request>();
 
   assertBuildRequiresNonConstBuilder<ucxx::RequestEndpointCloseBuilder,

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -18,6 +18,8 @@
 #include <ucxx/delayed_submission.h>
 #include <ucxx/worker_progress_thread.h>
 
+#include <type_traits>
+
 #include "include/utils.h"
 
 namespace {
@@ -408,27 +410,27 @@ TEST_F(WorkerTest, TagProbeConsumeHandle)
   }
 }
 
-TEST_F(WorkerTest, AmProbe)
+TEST_F(WorkerTest, ManagedAmProbe)
 {
   auto progressWorker = getProgressFunction(_worker, ProgressMode::Polling);
   auto ep             = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
 
-  ASSERT_FALSE(_worker->amProbe(ep->getHandle()));
+  ASSERT_FALSE(_worker->amManagedProbe(ep->getHandle()));
 
   std::vector<int> buf{123};
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(ep->amSend(buf.data(), buf.size() * sizeof(int), UCS_MEMORY_TYPE_HOST));
+  requests.push_back(ep->amManagedSend(buf.data(), buf.size() * sizeof(int), UCS_MEMORY_TYPE_HOST));
   waitRequests(_worker, requests, progressWorker);
 
   loopWithTimeout(std::chrono::milliseconds(5000), [this, progressWorker, ep]() {
     progressWorker();
-    return _worker->amProbe(ep->getHandle());
+    return _worker->amManagedProbe(ep->getHandle());
   });
 
-  ASSERT_TRUE(_worker->amProbe(ep->getHandle()));
+  ASSERT_TRUE(_worker->amManagedProbe(ep->getHandle()));
 }
 
-TEST_P(WorkerProgressTest, ProgressAm)
+TEST_P(WorkerProgressTest, ProgressManagedAm)
 {
   if (_progressMode == ProgressMode::Wait) {
     // TODO: Is this the same reason as TagMulti?
@@ -440,8 +442,9 @@ TEST_P(WorkerProgressTest, ProgressAm)
   std::vector<int> send{123};
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(ep->amSend(send.data(), send.size() * sizeof(int), UCS_MEMORY_TYPE_HOST));
-  requests.push_back(ep->amRecv());
+  requests.push_back(
+    ep->amManagedSend(send.data(), send.size() * sizeof(int), UCS_MEMORY_TYPE_HOST));
+  requests.push_back(ep->amManagedRecv());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq    = requests[1];
@@ -455,7 +458,7 @@ TEST_P(WorkerProgressTest, ProgressAm)
   ASSERT_EQ(recvAbstract[0], send[0]);
 }
 
-TEST_P(WorkerProgressTest, ProgressAmReceiverCallback)
+TEST_P(WorkerProgressTest, ProgressManagedAmReceiverCallback)
 {
   if (_progressMode == ProgressMode::Wait) {
     // TODO: Is this the same reason as TagMulti?
@@ -478,15 +481,15 @@ TEST_P(WorkerProgressTest, ProgressAmReceiverCallback)
         receivedRequests.push_back(req);
       }
     });
-  _worker->registerAmReceiverCallback(receiverCallbackInfo, callback);
+  _worker->registerManagedAmReceiverCallback(receiverCallbackInfo, callback);
 
   auto ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
 
   std::vector<int> send{123};
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(
-    ep->amSend(send.data(), send.size() * sizeof(int), UCS_MEMORY_TYPE_HOST, receiverCallbackInfo));
+  requests.push_back(ep->amManagedSend(
+    send.data(), send.size() * sizeof(int), UCS_MEMORY_TYPE_HOST, receiverCallbackInfo));
   waitRequests(_worker, requests, _progressWorker);
 
   while (receivedRequests.size() < 1)


### PR DESCRIPTION
Make the existing UCXX-managed Active Message protocol explicit in the C++ API. Rename `RequestAm` and the managed request-data/internal helper types to `RequestAmManaged`, `AmSendManaged`, `AmReceiveManaged`, `ManagedAmData`, and `ManagedRecvAmMessage`.

Add `amManagedSend`/`amManagedRecv` and managed `Worker` methods while keeping deprecated compatibility wrappers for the previous names.