### PR TITLE
test against oldest cuda-core, refactor testing dependencies configuration

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -20,7 +20,7 @@ conda config --set channel_priority strict
 rapids-dependency-file-generator \
   --output conda \
   --file-key test_python \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" \
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
   --prepend-channel "${CPP_CHANNEL}" \
   --prepend-channel "${PYTHON_CHANNEL}" \
   | tee env.yaml

--- a/ci/test_python_distributed.sh
+++ b/ci/test_python_distributed.sh
@@ -20,7 +20,7 @@ conda config --set channel_priority strict
 rapids-dependency-file-generator \
   --output conda \
   --file-key test_python_distributed \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" \
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
   --prepend-channel "${CPP_CHANNEL}" \
   --prepend-channel "${PYTHON_CHANNEL}" \
   | tee env.yaml

--- a/conda/recipes/ucxx/recipe.yaml
+++ b/conda/recipes/ucxx/recipe.yaml
@@ -238,7 +238,6 @@ outputs:
         - setuptools>=77.0.0
         - wheel
       run:
-        - cuda-core >=0.5.1
         - python
         - pyyaml >=6
         - rapids-dask-dependency ${{ rapids_version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -22,10 +22,11 @@ files:
       - run_python_ucxx
       - run_python_distributed_ucxx
       - test_cpp
+      - test_python_common
       - test_python_ucxx
-      - test_python_distributed_ucxx
       - depends_on_cudf
       - depends_on_cupy
+      - depends_on_numba_cuda
       - depends_on_rmm
       - depends_on_ucx_run
   test_cpp:
@@ -45,6 +46,7 @@ files:
       - depends_on_cupy
       - depends_on_cudf
       - depends_on_libucxx
+      - depends_on_numba_cuda
       - depends_on_ucxx
       - depends_on_ucxx_tests
   test_python_distributed:
@@ -52,10 +54,11 @@ files:
     includes:
       - cuda_version
       - py_version
-      - test_python_distributed_ucxx
+      - test_python_common
       - depends_on_cupy
       - depends_on_cudf
       - depends_on_libucxx
+      - depends_on_numba_cuda
       - depends_on_ucxx
       - depends_on_distributed_ucxx
   checks:
@@ -130,9 +133,11 @@ files:
       table: project.optional-dependencies
       key: test
     includes:
+      - test_python_common
       - test_python_ucxx
       - depends_on_cupy
       - depends_on_cudf
+      - depends_on_numba_cuda
   py_build_distributed_ucxx:
     output: pyproject
     pyproject_dir: python/distributed-ucxx
@@ -155,9 +160,10 @@ files:
       table: project.optional-dependencies
       key: test
     includes:
-      - test_python_distributed_ucxx
+      - test_python_common
       - depends_on_cupy
       - depends_on_cudf
+      - depends_on_numba_cuda
 channels:
   - rapidsai-nightly
   - rapidsai
@@ -373,47 +379,14 @@ dependencies:
         packages:
           - rapids-dask-dependency==26.8.*,>=0.0.0a0
           - pyyaml>=6
-          - cuda-core>=0.5.1
   test_cpp:
     common:
       - output_types: conda
         packages:
           - *cmake_ver
-          - gdb  # Used for timeout_with_stack.py
-          - psutil  # Used for timeout_with_stack.py
-  test_python_ucxx:
-    common:
-      - output_types: [conda, requirements, pyproject]
-        packages:
-          - cloudpickle
-          - pytest
-          - pytest-asyncio>=1.0.0
-          - rapids-dask-dependency==26.8.*,>=0.0.0a0
-          - pytest-rerunfailures!=16.0.0  # See https://github.com/pytest-dev/pytest-rerunfailures/issues/302
-          - pytest-xdist
-      - output_types: [conda]
-        packages:
-          - gdb  # Used for timeout_with_stack.py
-          - &numba_cuda_test numba-cuda>=0.22.1
-          - psutil  # Used for timeout_with_stack.py
-    specific:
-      - output_types: pyproject
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - &numba_cuda_cu12_test numba-cuda[cu12]>=0.22.1
-          - matrix:
-              cuda: "13.*"
-              cuda_suffixed: "true"
-            packages:
-              - &numba_cuda_cu13_test numba-cuda[cu13]>=0.22.1
-          # fallback to numba-cuda with no extra CUDA packages if 'cuda_suffixed' isn't true
-          - matrix:
-            packages:
-              - *numba_cuda_test
-  test_python_distributed_ucxx:
+          - &gdb gdb  # Used for timeout_with_stack.py
+          - &psutil psutil  # Used for timeout_with_stack.py
+  test_python_common:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
@@ -422,25 +395,26 @@ dependencies:
           - pytest-rerunfailures!=16.0.0  # See https://github.com/pytest-dev/pytest-rerunfailures/issues/302
       - output_types: [conda]
         packages:
-          - gdb  # Used for timeout_with_stack.py
-          - *numba_cuda_test
-          - psutil  # Used for timeout_with_stack.py
+          - *gdb  # Used for timeout_with_stack.py
+          - *psutil  # Used for timeout_with_stack.py
     specific:
-      - output_types: [requirements, pyproject]
+      - output_types: [conda, requirements, pyproject]
         matrices:
           - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
+              dependencies: "oldest"
             packages:
-              - *numba_cuda_cu12_test
-          - matrix:
-              cuda: "13.*"
-              cuda_suffixed: "true"
-            packages:
-              - *numba_cuda_cu13_test
+              - cuda-core==0.5.1
+              - numpy==2.0.*
           - matrix:
             packages:
-              - *numba_cuda_test
+  test_python_ucxx:
+    common:
+      - output_types: [conda, requirements, pyproject]
+        packages:
+          - cloudpickle
+          - pytest-asyncio>=1.0.0
+          - rapids-dask-dependency==26.8.*,>=0.0.0a0
+          - pytest-xdist
   depends_on_cupy:
     common:
       - output_types: conda
@@ -477,6 +451,28 @@ dependencies:
           - matrix:
             packages:
               - cupy-cuda13x[ctk]>=14.0.1,!=14.1.0
+  depends_on_numba_cuda:
+    common:
+      - output_types: [conda]
+        packages:
+        - &numba_cuda numba-cuda>=0.22.1
+    specific:
+      - output_types: pyproject
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - numba-cuda[cu12]>=0.22.1
+          - matrix:
+              cuda: "13.*"
+              cuda_suffixed: "true"
+            packages:
+              - numba-cuda[cu13]>=0.22.1
+          # fallback to numba-cuda with no extra CUDA packages if 'cuda_suffixed' isn't true
+          - matrix:
+            packages:
+              - *numba_cuda
   depends_on_librmm:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -23,6 +23,7 @@ files:
       - run_python_distributed_ucxx
       - test_cpp
       - test_python_common
+      - test_python_distributed_ucxx
       - test_python_ucxx
       - depends_on_cudf
       - depends_on_cupy
@@ -42,6 +43,8 @@ files:
     includes:
       - cuda_version
       - py_version
+      - test_python_common
+      - test_python_distributed_ucxx
       - test_python_ucxx
       - depends_on_cupy
       - depends_on_cudf
@@ -55,6 +58,7 @@ files:
       - cuda_version
       - py_version
       - test_python_common
+      - test_python_distributed_ucxx
       - depends_on_cupy
       - depends_on_cudf
       - depends_on_libucxx
@@ -133,11 +137,11 @@ files:
       table: project.optional-dependencies
       key: test
     includes:
-      - test_python_common
-      - test_python_ucxx
       - depends_on_cupy
       - depends_on_cudf
       - depends_on_numba_cuda
+      - test_python_common
+      - test_python_ucxx
   py_build_distributed_ucxx:
     output: pyproject
     pyproject_dir: python/distributed-ucxx
@@ -160,10 +164,11 @@ files:
       table: project.optional-dependencies
       key: test
     includes:
-      - test_python_common
       - depends_on_cupy
       - depends_on_cudf
       - depends_on_numba_cuda
+      - test_python_common
+      - test_python_distributed_ucxx
 channels:
   - rapidsai-nightly
   - rapidsai
@@ -390,7 +395,6 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - *numpy
           - pytest
           - pytest-rerunfailures!=16.0.0  # See https://github.com/pytest-dev/pytest-rerunfailures/issues/302
       - output_types: [conda]
@@ -407,6 +411,11 @@ dependencies:
               - numpy==2.0.*
           - matrix:
             packages:
+  test_python_distributed_ucxx:
+    common:
+      - output_types: [conda, requirements, pyproject]
+        packages:
+          - *numpy
   test_python_ucxx:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/distributed-ucxx/pyproject.toml
+++ b/python/distributed-ucxx/pyproject.toml
@@ -20,7 +20,6 @@ license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
-    "cuda-core>=0.5.1",
     "pyyaml>=6",
     "rapids-dask-dependency==26.8.*,>=0.0.0a0",
     "ucxx==0.51.*,>=0.0.0a0",

--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -45,6 +45,7 @@ test = [
     "cudf==26.8.*,>=0.0.0a0",
     "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "numba-cuda>=0.22.1",
+    "numpy>=2.0,<3.0",
     "pytest",
     "pytest-asyncio>=1.0.0",
     "pytest-rerunfailures!=16.0.0",

--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -45,7 +45,6 @@ test = [
     "cudf==26.8.*,>=0.0.0a0",
     "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "numba-cuda>=0.22.1",
-    "numpy>=2.0,<3.0",
     "pytest",
     "pytest-asyncio>=1.0.0",
     "pytest-rerunfailures!=16.0.0",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/285

This project is already not depending on `cuda-python` and carrying the same `cuda-core` floor I'm proposing across RAPIDS (`>=0.5.1`).

This proposes some other changes based on things I noticed while investigating that:

* adds explicit testing against the oldest versions of `cuda-core` and `numpy` the project supports (ref: https://github.com/rapidsai/build-planning/issues/81)
* refactors `dependencies.yaml` to reduce duplication between `ucxx` and `distributed-ucxx` testing dependencies
* cleans up some dependencies (see inline comments)