### PR TITLE
Support binding listener to a specific IP address or hostname

### DIFF
--- a/cpp/include/ucxx/constructors.h
+++ b/cpp/include/ucxx/constructors.h
@@ -41,6 +41,7 @@ namespace detail {
 [[nodiscard]] std::shared_ptr<Address> createAddressFromString(std::string_view addressString);
 
 [[nodiscard]] std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
+                                                       std::string ipAddress,
                                                        uint16_t port,
                                                        ucp_listener_conn_callback_t callback,
                                                        void* callbackArgs);

--- a/cpp/include/ucxx/constructors.h
+++ b/cpp/include/ucxx/constructors.h
@@ -41,7 +41,7 @@ namespace detail {
 [[nodiscard]] std::shared_ptr<Address> createAddressFromString(std::string_view addressString);
 
 [[nodiscard]] std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
-                                                       std::string ipAddress,
+                                                       std::string host,
                                                        uint16_t port,
                                                        ucp_listener_conn_callback_t callback,
                                                        void* callbackArgs);

--- a/cpp/include/ucxx/constructors.h
+++ b/cpp/include/ucxx/constructors.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once

--- a/cpp/include/ucxx/listener.h
+++ b/cpp/include/ucxx/listener.h
@@ -20,6 +20,7 @@ class Listener;
 
 namespace detail {
 [[nodiscard]] std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
+                                                       std::string ipAddress,
                                                        uint16_t port,
                                                        ucp_listener_conn_callback_t callback,
                                                        void* callbackArgs);
@@ -50,12 +51,16 @@ class Listener : public Component {
    *
    *
    * @param[in] worker        the worker from which to create the listener.
+   * @param[in] ipAddress     the hostname or IP address which the listener should be
+   *                          bound to, an empty string binds to all interfaces
+   *                          (wildcard).
    * @param[in] port          the port which the listener should be bound to.
    * @param[in] callback      user-defined callback to be executed on incoming client
    *                          connections.
    * @param[in] callbackArgs  argument to be passed to the callback.
    */
   Listener(std::shared_ptr<Worker> worker,
+           std::string ipAddress,
            uint16_t port,
            ucp_listener_conn_callback_t callback,
            void* callbackArgs);
@@ -100,6 +105,9 @@ class Listener : public Component {
    * @endcode
    *
    * @param[in] worker        the worker from which to create the listener.
+   * @param[in] ipAddress     the hostname or IP address which the listener should be
+   *                          bound to, an empty string binds to all interfaces
+   *                          (wildcard).
    * @param[in] port          the port which the listener should be bound to.
    * @param[in] callback      user-defined callback to be executed on incoming client
    *                          connections.
@@ -108,6 +116,7 @@ class Listener : public Component {
    * @returns The `shared_ptr<ucxx::Listener>` object.
    */
   friend std::shared_ptr<Listener> detail::createListener(std::shared_ptr<Worker> worker,
+                                                          std::string ipAddress,
                                                           uint16_t port,
                                                           ucp_listener_conn_callback_t callback,
                                                           void* callbackArgs);

--- a/cpp/include/ucxx/listener.h
+++ b/cpp/include/ucxx/listener.h
@@ -20,7 +20,7 @@ class Listener;
 
 namespace detail {
 [[nodiscard]] std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
-                                                       std::string ipAddress,
+                                                       std::string host,
                                                        uint16_t port,
                                                        ucp_listener_conn_callback_t callback,
                                                        void* callbackArgs);
@@ -51,7 +51,7 @@ class Listener : public Component {
    *
    *
    * @param[in] worker        the worker from which to create the listener.
-   * @param[in] ipAddress     the hostname or IP address which the listener should be
+   * @param[in] host          the hostname or IP address which the listener should be
    *                          bound to, an empty string binds to all interfaces
    *                          (wildcard).
    * @param[in] port          the port which the listener should be bound to.
@@ -60,7 +60,7 @@ class Listener : public Component {
    * @param[in] callbackArgs  argument to be passed to the callback.
    */
   Listener(std::shared_ptr<Worker> worker,
-           std::string ipAddress,
+           std::string host,
            uint16_t port,
            ucp_listener_conn_callback_t callback,
            void* callbackArgs);
@@ -105,7 +105,7 @@ class Listener : public Component {
    * @endcode
    *
    * @param[in] worker        the worker from which to create the listener.
-   * @param[in] ipAddress     the hostname or IP address which the listener should be
+   * @param[in] host          the hostname or IP address which the listener should be
    *                          bound to, an empty string binds to all interfaces
    *                          (wildcard).
    * @param[in] port          the port which the listener should be bound to.
@@ -116,7 +116,7 @@ class Listener : public Component {
    * @returns The `shared_ptr<ucxx::Listener>` object.
    */
   friend std::shared_ptr<Listener> detail::createListener(std::shared_ptr<Worker> worker,
-                                                          std::string ipAddress,
+                                                          std::string host,
                                                           uint16_t port,
                                                           ucp_listener_conn_callback_t callback,
                                                           void* callbackArgs);

--- a/cpp/include/ucxx/listener.h
+++ b/cpp/include/ucxx/listener.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once

--- a/cpp/include/ucxx/listener_builder.h
+++ b/cpp/include/ucxx/listener_builder.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include <ucp/api/ucp.h>
@@ -55,6 +56,19 @@ class ListenerBuilder final {
    * @return The constructed `shared_ptr<ucxx::Listener>` object.
    */
   operator std::shared_ptr<Listener>();
+
+  /**
+   * @brief Set the hostname or IP address the listener should bind to.
+   *
+   * By default the listener binds to all interfaces (wildcard). Use this to restrict
+   * the listener to a specific interface, e.g., `"127.0.0.1"` to accept connections
+   * from the local host only.
+   *
+   * @param[in] ipAddress hostname or IP address the listener should bind to, an empty
+   *                      string binds to all interfaces.
+   * @return Reference to this builder for method chaining.
+   */
+  ListenerBuilder& ipAddress(std::string ipAddress);
 
   /**
    * @brief Build and return the `Listener`.

--- a/cpp/include/ucxx/listener_builder.h
+++ b/cpp/include/ucxx/listener_builder.h
@@ -64,11 +64,11 @@ class ListenerBuilder final {
    * the listener to a specific interface, e.g., `"127.0.0.1"` to accept connections
    * from the local host only.
    *
-   * @param[in] ipAddress hostname or IP address the listener should bind to, an empty
-   *                      string binds to all interfaces.
+   * @param[in] host hostname or IP address the listener should bind to, an empty
+   *                 string binds to all interfaces.
    * @return Reference to this builder for method chaining.
    */
-  ListenerBuilder& ipAddress(std::string ipAddress);
+  ListenerBuilder& host(std::string host);
 
   /**
    * @brief Build and return the `Listener`.

--- a/cpp/include/ucxx/listener_builder.h
+++ b/cpp/include/ucxx/listener_builder.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -18,6 +18,7 @@
 namespace ucxx {
 
 Listener::Listener(std::shared_ptr<Worker> worker,
+                   std::string ipAddress,
                    uint16_t port,
                    ucp_listener_conn_callback_t callback,
                    void* callbackArgs)
@@ -28,7 +29,7 @@ Listener::Listener(std::shared_ptr<Worker> worker,
   ucp_listener_params_t params = {
     .field_mask   = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR | UCP_LISTENER_PARAM_FIELD_CONN_HANDLER,
     .conn_handler = {.cb = callback, .arg = callbackArgs}};
-  auto info               = ucxx::utils::get_addrinfo(NULL, port);
+  auto info = ucxx::utils::get_addrinfo(ipAddress.empty() ? nullptr : ipAddress.c_str(), port);
   params.sockaddr.addr    = info->ai_addr;
   params.sockaddr.addrlen = info->ai_addrlen;
 
@@ -68,11 +69,13 @@ Listener::~Listener()
 namespace detail {
 
 std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
+                                         std::string ipAddress,
                                          uint16_t port,
                                          ucp_listener_conn_callback_t callback,
                                          void* callbackArgs)
 {
-  return std::shared_ptr<Listener>(new Listener(worker, port, callback, callbackArgs));
+  return std::shared_ptr<Listener>(
+    new Listener(worker, std::move(ipAddress), port, callback, callbackArgs));
 }
 
 }  // namespace detail
@@ -82,7 +85,7 @@ std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
                                          ucp_listener_conn_callback_t callback,
                                          void* callbackArgs)
 {
-  return detail::createListener(std::move(worker), port, callback, callbackArgs);
+  return detail::createListener(std::move(worker), std::string{}, port, callback, callbackArgs);
 }
 
 EndpointBuilder Listener::endpointBuilder(ucp_conn_request_h connRequest)

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -18,7 +18,7 @@
 namespace ucxx {
 
 Listener::Listener(std::shared_ptr<Worker> worker,
-                   std::string ipAddress,
+                   std::string host,
                    uint16_t port,
                    ucp_listener_conn_callback_t callback,
                    void* callbackArgs)
@@ -29,7 +29,7 @@ Listener::Listener(std::shared_ptr<Worker> worker,
   ucp_listener_params_t params = {
     .field_mask   = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR | UCP_LISTENER_PARAM_FIELD_CONN_HANDLER,
     .conn_handler = {.cb = callback, .arg = callbackArgs}};
-  auto info = ucxx::utils::get_addrinfo(ipAddress.empty() ? nullptr : ipAddress.c_str(), port);
+  auto info = ucxx::utils::get_addrinfo(host.empty() ? nullptr : host.c_str(), port);
   params.sockaddr.addr    = info->ai_addr;
   params.sockaddr.addrlen = info->ai_addrlen;
 
@@ -69,13 +69,13 @@ Listener::~Listener()
 namespace detail {
 
 std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
-                                         std::string ipAddress,
+                                         std::string host,
                                          uint16_t port,
                                          ucp_listener_conn_callback_t callback,
                                          void* callbackArgs)
 {
   return std::shared_ptr<Listener>(
-    new Listener(worker, std::move(ipAddress), port, callback, callbackArgs));
+    new Listener(worker, std::move(host), port, callback, callbackArgs));
 }
 
 }  // namespace detail

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -29,7 +29,7 @@ Listener::Listener(std::shared_ptr<Worker> worker,
   ucp_listener_params_t params = {
     .field_mask   = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR | UCP_LISTENER_PARAM_FIELD_CONN_HANDLER,
     .conn_handler = {.cb = callback, .arg = callbackArgs}};
-  auto info = ucxx::utils::get_addrinfo(host.empty() ? nullptr : host.c_str(), port);
+  auto info               = ucxx::utils::get_addrinfo(host.empty() ? nullptr : host.c_str(), port);
   params.sockaddr.addr    = info->ai_addr;
   params.sockaddr.addrlen = info->ai_addrlen;
 

--- a/cpp/src/listener_builder.cpp
+++ b/cpp/src/listener_builder.cpp
@@ -14,7 +14,7 @@ namespace ucxx {
 
 struct ListenerBuilder::Impl {
   std::shared_ptr<Worker> worker{nullptr};
-  std::string ipAddress{};
+  std::string host{};
   uint16_t port{0};
   ucp_listener_conn_callback_t callback{nullptr};
   void* callbackArgs{nullptr};
@@ -35,16 +35,16 @@ ListenerBuilder::ListenerBuilder(std::shared_ptr<Worker> worker,
 
 UCXX_BUILDER_PIMPL_DEFAULTS(ListenerBuilder, Listener)
 
-ListenerBuilder& ListenerBuilder::ipAddress(std::string ipAddress)
+ListenerBuilder& ListenerBuilder::host(std::string host)
 {
-  _impl->ipAddress = std::move(ipAddress);
+  _impl->host = std::move(host);
   return *this;
 }
 
 std::shared_ptr<Listener> ListenerBuilder::build()
 {
   return detail::createListener(
-    _impl->worker, _impl->ipAddress, _impl->port, _impl->callback, _impl->callbackArgs);
+    _impl->worker, _impl->host, _impl->port, _impl->callback, _impl->callbackArgs);
 }
 
 }  // namespace ucxx

--- a/cpp/src/listener_builder.cpp
+++ b/cpp/src/listener_builder.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
+#include <string>
 #include <utility>
 
 #include <ucxx/constructors.h>
@@ -13,6 +14,7 @@ namespace ucxx {
 
 struct ListenerBuilder::Impl {
   std::shared_ptr<Worker> worker{nullptr};
+  std::string ipAddress{};
   uint16_t port{0};
   ucp_listener_conn_callback_t callback{nullptr};
   void* callbackArgs{nullptr};
@@ -33,9 +35,16 @@ ListenerBuilder::ListenerBuilder(std::shared_ptr<Worker> worker,
 
 UCXX_BUILDER_PIMPL_DEFAULTS(ListenerBuilder, Listener)
 
+ListenerBuilder& ListenerBuilder::ipAddress(std::string ipAddress)
+{
+  _impl->ipAddress = std::move(ipAddress);
+  return *this;
+}
+
 std::shared_ptr<Listener> ListenerBuilder::build()
 {
-  return detail::createListener(_impl->worker, _impl->port, _impl->callback, _impl->callbackArgs);
+  return detail::createListener(
+    _impl->worker, _impl->ipAddress, _impl->port, _impl->callback, _impl->callbackArgs);
 }
 
 }  // namespace ucxx

--- a/cpp/src/listener_builder.cpp
+++ b/cpp/src/listener_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -751,7 +751,7 @@ std::shared_ptr<Listener> Worker::createListener(uint16_t port,
                                                  void* callbackArgs)
 {
   auto worker   = std::static_pointer_cast<Worker>(shared_from_this());
-  auto listener = detail::createListener(worker, port, callback, callbackArgs);
+  auto listener = detail::createListener(worker, std::string{}, port, callback, callbackArgs);
   return listener;
 }
 

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -762,7 +762,7 @@ std::shared_ptr<Listener> Worker::createListener(uint16_t port,
                                                  void* callbackArgs)
 {
   auto worker   = std::static_pointer_cast<Worker>(shared_from_this());
-  auto listener = detail::createListener(worker, port, callback, callbackArgs);
+  auto listener = detail::createListener(worker, std::string{}, port, callback, callbackArgs);
   return listener;
 }
 

--- a/cpp/tests/component_builders.cpp
+++ b/cpp/tests/component_builders.cpp
@@ -531,6 +531,20 @@ TEST_F(ComponentBuilderTest, ListenerBuilder)
   ASSERT_GT(listener->getPort(), 0u);
 }
 
+TEST_F(ComponentBuilderTest, ListenerBuilderIpAddress)
+{
+  auto builder = ucxx::ListenerBuilder(_worker, 0, listenerCallback, nullptr);
+  static_assert(
+    std::is_same<decltype(builder.ipAddress("127.0.0.1")), ucxx::ListenerBuilder&>::value,
+    "ListenerBuilder::ipAddress returns ListenerBuilder& for chaining");
+
+  auto listener = builder.ipAddress("127.0.0.1").build();
+  ASSERT_TRUE(listener != nullptr);
+  ASSERT_TRUE(listener->getHandle() != nullptr);
+  ASSERT_EQ(listener->getIp(), "127.0.0.1");
+  ASSERT_GT(listener->getPort(), 0u);
+}
+
 TEST_F(ComponentBuilderTest, MemoryHandleBuilder)
 {
   std::vector<char> buffer(128);

--- a/cpp/tests/component_builders.cpp
+++ b/cpp/tests/component_builders.cpp
@@ -531,14 +531,14 @@ TEST_F(ComponentBuilderTest, ListenerBuilder)
   ASSERT_GT(listener->getPort(), 0u);
 }
 
-TEST_F(ComponentBuilderTest, ListenerBuilderIpAddress)
+TEST_F(ComponentBuilderTest, ListenerBuilderHost)
 {
   auto builder = ucxx::ListenerBuilder(_worker, 0, listenerCallback, nullptr);
   static_assert(
-    std::is_same<decltype(builder.ipAddress("127.0.0.1")), ucxx::ListenerBuilder&>::value,
-    "ListenerBuilder::ipAddress returns ListenerBuilder& for chaining");
+    std::is_same<decltype(builder.host("127.0.0.1")), ucxx::ListenerBuilder&>::value,
+    "ListenerBuilder::host returns ListenerBuilder& for chaining");
 
-  auto listener = builder.ipAddress("127.0.0.1").build();
+  auto listener = builder.host("127.0.0.1").build();
   ASSERT_TRUE(listener != nullptr);
   ASSERT_TRUE(listener->getHandle() != nullptr);
   ASSERT_EQ(listener->getIp(), "127.0.0.1");

--- a/cpp/tests/component_builders.cpp
+++ b/cpp/tests/component_builders.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>

--- a/cpp/tests/component_builders.cpp
+++ b/cpp/tests/component_builders.cpp
@@ -534,9 +534,6 @@ TEST_F(ComponentBuilderTest, ListenerBuilder)
 TEST_F(ComponentBuilderTest, ListenerBuilderHost)
 {
   auto builder = ucxx::ListenerBuilder(_worker, 0, listenerCallback, nullptr);
-  static_assert(
-    std::is_same<decltype(builder.host("127.0.0.1")), ucxx::ListenerBuilder&>::value,
-    "ListenerBuilder::host returns ListenerBuilder& for chaining");
 
   auto listener = builder.host("127.0.0.1").build();
   ASSERT_TRUE(listener != nullptr);

--- a/cpp/tests/listener.cpp
+++ b/cpp/tests/listener.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
+#include <tuple>
 #include <ucs/config/types.h>
 #include <ucs/type/status.h>
 #include <vector>
@@ -311,5 +312,49 @@ TEST_P(ListenerPortTest, Port)
 }
 
 INSTANTIATE_TEST_SUITE_P(PortAssignment, ListenerPortTest, ::testing::Values(0, 12345));
+
+class ListenerIpAddressTest : public ListenerTestBase, public ::testing::Test {
+ protected:
+  virtual void SetUp() { _worker = _context->createWorker(); }
+};
+
+TEST_F(ListenerIpAddressTest, BindToIpAddress)
+{
+  auto listenerContainer = createListenerContainer();
+  auto listener          = _worker->listenerBuilder(0, listenerCallback, listenerContainer.get())
+                    .ipAddress("127.0.0.1")
+                    .build();
+  listenerContainer->listener = listener;
+  auto progress               = getProgressFunction(_worker, ProgressMode::Polling);
+
+  progress();
+
+  ASSERT_EQ(listener->getIp(), "127.0.0.1");
+  ASSERT_GE(listener->getPort(), 1024);
+
+  auto ep = _worker->endpointBuilder("127.0.0.1", listener->getPort()).build();
+  while (listenerContainer->endpoint == nullptr)
+    progress();
+
+  std::vector<std::shared_ptr<ucxx::Request>> requests;
+
+  std::vector<int> client_buf{123};
+  std::vector<int> server_buf{0};
+  requests.push_back(ep->tagSend(client_buf.data(), client_buf.size() * sizeof(int), ucxx::Tag{0}));
+  requests.push_back(listenerContainer->endpoint->tagRecv(
+    &server_buf.front(), server_buf.size() * sizeof(int), ucxx::Tag{0}, ucxx::TagMaskFull));
+  ::waitRequests(_worker, requests, progress);
+
+  ASSERT_EQ(server_buf[0], client_buf[0]);
+}
+
+TEST_F(ListenerIpAddressTest, BindToInvalidIpAddress)
+{
+  auto listenerContainer = createListenerContainer();
+  EXPECT_THROW(std::ignore = _worker->listenerBuilder(0, listenerCallback, listenerContainer.get())
+                               .ipAddress("invalid-address!")
+                               .build(),
+               ucxx::Error);
+}
 
 }  // namespace

--- a/cpp/tests/listener.cpp
+++ b/cpp/tests/listener.cpp
@@ -313,16 +313,16 @@ TEST_P(ListenerPortTest, Port)
 
 INSTANTIATE_TEST_SUITE_P(PortAssignment, ListenerPortTest, ::testing::Values(0, 12345));
 
-class ListenerIpAddressTest : public ListenerTestBase, public ::testing::Test {
+class ListenerHostTest : public ListenerTestBase, public ::testing::Test {
  protected:
   virtual void SetUp() { _worker = _context->createWorker(); }
 };
 
-TEST_F(ListenerIpAddressTest, BindToIpAddress)
+TEST_F(ListenerHostTest, BindToHost)
 {
   auto listenerContainer = createListenerContainer();
   auto listener          = _worker->listenerBuilder(0, listenerCallback, listenerContainer.get())
-                    .ipAddress("127.0.0.1")
+                    .host("127.0.0.1")
                     .build();
   listenerContainer->listener = listener;
   auto progress               = getProgressFunction(_worker, ProgressMode::Polling);
@@ -348,11 +348,11 @@ TEST_F(ListenerIpAddressTest, BindToIpAddress)
   ASSERT_EQ(server_buf[0], client_buf[0]);
 }
 
-TEST_F(ListenerIpAddressTest, BindToInvalidIpAddress)
+TEST_F(ListenerHostTest, BindToInvalidHost)
 {
   auto listenerContainer = createListenerContainer();
   EXPECT_THROW(std::ignore = _worker->listenerBuilder(0, listenerCallback, listenerContainer.get())
-                               .ipAddress("invalid-address!")
+                               .host("invalid-address!")
                                .build(),
                ucxx::Error);
 }

--- a/cpp/tests/listener.cpp
+++ b/cpp/tests/listener.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>


### PR DESCRIPTION
Resolves #299 

## Description

Until now `ucxx::Listener` always bound to the wildcard address (all interfaces): the private `Listener` constructor called `ucxx::utils::get_addrinfo(NULL, port)` with a hardcoded `NULL` address, even though `get_addrinfo()` fully supports resolving a hostname or IP address.

This PR adds an optional `ipAddress` option to `ListenerBuilder`, allowing the listener to be restricted to a specific interface:

```cpp
auto listener = worker->listenerBuilder(port, callback, callbackArgs)
                  .ipAddress("127.0.0.1")
                  .build();
```

An empty address (the default) preserves the existing wildcard behavior, so this is fully backward compatible. Invalid addresses throw `ucxx::Error` (raised by the existing `get_addrinfo` error path).

Motivation: services embedding ucxx (e.g. NVIDIA Isaac Sim's UCX bridge) need a secure-by-default loopback-only listener. Without this option, the only alternative is bypassing ucxx and managing raw `ucp_listener_h` / `ucp_ep_h` handles directly, which loses ucxx's endpoint lifetime management.

Changes:
- `ListenerBuilder::ipAddress(std::string)` builder option.
- `detail::createListener` / private `Listener` constructor take the address and pass it to `get_addrinfo`.
- Deprecated non-builder `createListener` APIs are unchanged (wildcard).
- Tests: end-to-end bind-to-loopback send/recv, `getIp()` verification, invalid-address throw, and builder-chaining static checks.

The async/`_lib` Python APIs could expose the same option; left out of scope here to keep the change small, happy to do a follow-up PR if there is interest.
