### PR TITLE
Unpin CMake from < 4.4

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - automake
 - c-compiler
 - cloudpickle
-- cmake>=4.0,<4.4
+- cmake>=4.0
 - cuda-core>=0.5.1
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - automake
 - c-compiler
 - cloudpickle
-- cmake>=4.0,<4.4
+- cmake>=4.0
 - cuda-core>=0.5.1
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - automake
 - c-compiler
 - cloudpickle
-- cmake>=4.0,<4.4
+- cmake>=4.0
 - cuda-core>=0.5.1
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - automake
 - c-compiler
 - cloudpickle
-- cmake>=4.0,<4.4
+- cmake>=4.0
 - cuda-core>=0.5.1
 - cuda-cudart-dev
 - cuda-nvcc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Dependency list for https://github.com/rapidsai/dependency-file-generator
@@ -180,7 +180,7 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - &cmake_ver cmake>=4.0,<4.4
+          - &cmake_ver cmake>=4.0
           - librmm==26.8.*,>=0.0.0a0
           - ninja
       - output_types: [requirements, pyproject]

--- a/python/libucxx/pyproject.toml
+++ b/python/libucxx/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 [build-system]
@@ -60,7 +60,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
-    "cmake>=4.0,<4.4",
+    "cmake>=4.0",
     "librmm==26.8.*,>=0.0.0a0",
     "libucx>=1.19.0,<1.19.1",
     "ninja",

--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 [build-system]
@@ -60,7 +60,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
-    "cmake>=4.0,<4.4",
+    "cmake>=4.0",
     "cython>=3.2.2",
     "librmm==26.8.*,>=0.0.0a0",
     "libucxx==0.51.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

The issues with CMake 4.4 in rapids-cmake have been fixed, so remove the pin.

Issue: https://github.com/rapidsai/build-planning/issues/302
