### PR TITLE
put a <2 ceiling on cuda-core dependency

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=4.0
-- cuda-core>=0.5.1
+- cuda-core>=0.5.1,<2
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=4.0
-- cuda-core>=0.5.1
+- cuda-core>=0.5.1,<2
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=4.0
-- cuda-core>=0.5.1
+- cuda-core>=0.5.1,<2
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.3

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - cloudpickle
 - cmake>=4.0
-- cuda-core>=0.5.1
+- cuda-core>=0.5.1,<2
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.3

--- a/conda/recipes/ucxx/recipe.yaml
+++ b/conda/recipes/ucxx/recipe.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 context:
@@ -98,7 +98,7 @@ outputs:
         - libucxx =${{ version }}
         - cuda-cudart-dev
       run:
-        - cuda-core >=0.5.1
+        - cuda-core >=0.5.1,<2
         - numpy >=2.0,<3.0
         # 'nvidia-ml-py' provides the 'pynvml' module
         - nvidia-ml-py>=12

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -377,7 +377,7 @@ dependencies:
           - &numpy numpy>=2.0,<3.0
           # 'nvidia-ml-py' provides the 'pynvml' module
           - nvidia-ml-py>=12
-          - cuda-core>=0.5.1
+          - cuda-core>=0.5.1,<2
   run_python_distributed_ucxx:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/ucxx/pyproject.toml
+++ b/python/ucxx/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 license = "BSD-3-Clause"
 requires-python = ">=3.11"
 dependencies = [
-    "cuda-core>=0.5.1",
+    "cuda-core>=0.5.1,<2",
     "libucxx==0.51.*,>=0.0.0a0",
     "numpy>=2.0,<3.0",
     "nvidia-ml-py>=12",


### PR DESCRIPTION
## Description

Follow-up to #701

Puts a ceiling of `<2` on the project's `cuda-core` dependency.

Starting with the 1.x series, `cuda-core` is following strict semantic versioning, and some folks working on the project recommended doing this defensively: https://github.com/rapidsai/build-planning/issues/285#issuecomment-5027243158

There isn't yet a 2.x release, this is just defensive to protect CI and users if there eventually is one.