### PR TITLE
update most pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,18 +3,18 @@
 
 repos:
       - repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v5.0.0
+        rev: v6.0.0
         hooks:
               - id: trailing-whitespace
               - id: end-of-file-fixer
       - repo: https://github.com/astral-sh/ruff-pre-commit
-        rev: v0.14.3
+        rev: v0.15.22
         hooks:
               - id: ruff-check
                 args: [--fix]
               - id: ruff-format
       - repo: https://github.com/MarcoGorelli/cython-lint
-        rev: v0.15.0
+        rev: v0.21.0
         hooks:
               - id: cython-lint
       - repo: https://github.com/pre-commit/mirrors-clang-format
@@ -25,7 +25,7 @@ repos:
                 types_or: [file]
                 args: ['-fallback-style=none', '-style=file', '-i']
       - repo: https://github.com/cpplint/cpplint
-        rev: 2.0.0
+        rev: 2.0.2
         hooks:
               - id: cpplint
                 name: cpplint
@@ -35,7 +35,7 @@ repos:
                 files: \.(h|cpp)$
                 # exclude: path/to/myfile.h
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v1.6.0
+        rev: v1.6.1
         hooks:
             - id: verify-copyright
               args: [--fix, --spdx, --spdx-license-identifier=BSD-3-Clause]
@@ -88,7 +88,7 @@ repos:
                 (?x)
                   ^pyproject[.]toml$
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.20.0
+        rev: v1.21.0
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean", "--warn-all", "--strict"]
@@ -125,7 +125,7 @@ repos:
               pass_filenames: false
               verbose: true
       - repo: https://github.com/codespell-project/codespell
-        rev: v2.4.1
+        rev: v2.4.3
         hooks:
             - id: codespell
               additional_dependencies: [tomli]
@@ -136,11 +136,11 @@ repos:
                   ^CHANGELOG.md$
                 )
       - repo: https://github.com/shellcheck-py/shellcheck-py
-        rev: v0.10.0.1
+        rev: v0.11.0.1
         hooks:
           - id: shellcheck
       - repo: https://github.com/zizmorcore/zizmor-pre-commit
-        rev: v1.24.1
+        rev: v1.28.0
         hooks:
           - id: zizmor
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -325,9 +325,9 @@ dependencies:
           - dask-cuda==26.8.*,>=0.0.0a0
           - dask-cudf==26.8.*,>=0.0.0a0
           # UCX Build
-          - libtool
-          - automake
           - autoconf
+          - automake
+          - libtool
           # UCXX Build
           - pkg-config
           # Docs Build


### PR DESCRIPTION
Updates most `pre-commit` hooks to their latest versions (skipped `clang-format` because it changes many files).

This is helpful on its own, but mainly opening this to test whether a CI failure I'm observing in https://github.com/rapidsai/ucxx/pull/710#issuecomment-5060226224 affects all PRs.