### PR TITLE
test: isolate library wheel smoke test

### DIFF
--- a/ci/test_wheel_ucxx.sh
+++ b/ci/test_wheel_ucxx.sh
@@ -28,7 +28,7 @@ rapids-pip-retry install \
     --prefer-binary \
     --constraint "${PIP_CONSTRAINT}" \
     "$(echo "${LIBUCXX_WHEELHOUSE}"/libucxx_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)"
-python -c "import libucxx; libucxx.load_library()"
+python -c "import libucxx; assert libucxx.load_library() is not None"
 deactivate
 
 # notes:

--- a/ci/test_wheel_ucxx.sh
+++ b/ci/test_wheel_ucxx.sh
@@ -20,6 +20,17 @@ UCXX_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_pyth
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"
 
+python -m venv libucxx-env
+. libucxx-env/bin/activate
+
+rapids-pip-retry install \
+    -v \
+    --prefer-binary \
+    --constraint "${PIP_CONSTRAINT}" \
+    "$(echo "${LIBUCXX_WHEELHOUSE}"/libucxx_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)"
+python -c "import libucxx; libucxx.load_library()"
+deactivate
+
 # notes:
 #
 #   * echo to expand wildcard before adding `[test]` requires for pip

--- a/ci/test_wheel_ucxx.sh
+++ b/ci/test_wheel_ucxx.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -euo pipefail


### PR DESCRIPTION
## Description

Install the library wheel in a clean virtual environment and call its `load_library()` entry point before installing the high-level wheel or test extras. This exposes missing library-wheel runtime dependencies that the full test environment can otherwise mask.

xref: https://github.com/rapidsai/build-planning/issues/307
