### PR TITLE
fix Limited API compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ python/ucxx/ucxx/_lib/*.h
 wheels/
 *.egg-info/
 _skbuild/
+*.tar.gz
+*.whl
 
 ## Doxygen
 cpp/doxygen/html

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -euo pipefail
@@ -33,10 +33,23 @@ rapids-logger "validate packages with 'pydistcheck'"
 
 pydistcheck \
     --inspect \
-    "$(echo "${wheel_dir_relative_path}"/*.whl)"
+    "${wheel_dir_relative_path}"/*.whl
 
 rapids-logger "validate packages with 'twine'"
 
 twine check \
     --strict \
-    "$(echo "${wheel_dir_relative_path}"/*.whl)"
+    "${wheel_dir_relative_path}"/*.whl
+
+rapids-logger "validate packages with 'abi3audit'"
+
+# TODO: remove once https://github.com/rapidsai/ci-imgs/pull/454 is merged
+pip install abi3audit
+
+# 'abi3audit' fails on wheels that contain DSOs but don't have an ABI tag (like 'libucxx').
+# This '-name' filtering avoids trying those.
+find \
+    "${wheel_dir_relative_path}" \
+    -type f \
+    -name '*abi*' \
+    -exec abi3audit --strict --summary --verbose '{}' \+

--- a/cpp/cmake/py_limited_api.cmake
+++ b/cpp/cmake/py_limited_api.cmake
@@ -40,14 +40,11 @@ function(rapids_target_set_py_limited_api target)
   string(REPLACE "." ";" _sabi_parts "${SKBUILD_SABI_VERSION}")
   list(GET _sabi_parts 0 _sabi_major)
   list(GET _sabi_parts 1 _sabi_minor)
-  if(_sabi_minor LESS 16)
-    set(_sabi_minor_pad "0")
-  else()
-    set(_sabi_minor_pad "")
-  endif()
-  math(EXPR _sabi_minor_hex "${_sabi_minor}" OUTPUT_FORMAT HEXADECIMAL)
-  string(REGEX REPLACE "^0x" "" _sabi_minor_hex "${_sabi_minor_hex}")
-  target_compile_definitions(
-    ${target} PRIVATE "Py_LIMITED_API=0x0${_sabi_major}${_sabi_minor_pad}${_sabi_minor_hex}0000"
+  math(EXPR _sabi_major_minor_hex "${_sabi_major} * 256 * 65536 + ${_sabi_minor} * 65536"
+       OUTPUT_FORMAT HEXADECIMAL
   )
+
+  # CPython source code pads '3' to '03' so all version components use 2 digits. Mirror that.
+  string(REGEX REPLACE "^0x" "0x0" _sabi_major_minor_hex "${_sabi_major_minor_hex}")
+  target_compile_definitions(${target} PRIVATE "Py_LIMITED_API=${_sabi_major_minor_hex}")
 endfunction()

--- a/cpp/cmake/py_limited_api.cmake
+++ b/cpp/cmake/py_limited_api.cmake
@@ -1,0 +1,53 @@
+# =================================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# cmake-format: on
+# =================================================================================
+
+# Sets Py_LIMITED_API=<hex> on <target> when SKBUILD_SABI_VERSION is defined, matching the version
+# encoding used by Python's C API headers.
+#
+# This ensures a compile-time error if anything in libpython that isn't part of the Limited API is
+# used.
+#
+# 'scikit-build-core' sets that variable based on 'skbuild.wheel.py-api'.
+function(rapids_target_set_py_limited_api target)
+  if(NOT DEFINED SKBUILD_SABI_VERSION OR "${SKBUILD_SABI_VERSION}" STREQUAL "")
+    message(
+      STATUS
+        "rapids_target_set_py_limited_api: SKBUILD_SABI_VERSION not set (not using scikit-build-core or 'skbuild.wheel.py-api' not set)"
+    )
+    return()
+  endif()
+  message(
+    STATUS
+      "rapids_target_set_py_limited_api: SKBUILD_SABI_VERSION=${SKBUILD_SABI_VERSION}, setting Py_LIMITED_API on '${target}'"
+  )
+
+  # SKBUILD_SABI_VERSION is usually a Python major.minor, e.g. '3.11'.
+  #
+  # CPython's Limited API guards expect a hexadecimal like '0x030b0000', where:
+  #
+  # * '0x'   = prefix for a hex literal
+  # * '03'   = major version: 3
+  # * '0b'   = minor version (0x0b = 11)
+  # * '0000' = other version components that can be ignored (limited API is versioned by Python
+  #   major.minor)
+  #
+  # docs: https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API
+  #
+  string(REPLACE "." ";" _sabi_parts "${SKBUILD_SABI_VERSION}")
+  list(GET _sabi_parts 0 _sabi_major)
+  list(GET _sabi_parts 1 _sabi_minor)
+  if(_sabi_minor LESS 16)
+    set(_sabi_minor_pad "0")
+  else()
+    set(_sabi_minor_pad "")
+  endif()
+  math(EXPR _sabi_minor_hex "${_sabi_minor}" OUTPUT_FORMAT HEXADECIMAL)
+  string(REGEX REPLACE "^0x" "" _sabi_minor_hex "${_sabi_minor_hex}")
+  target_compile_definitions(
+    ${target} PRIVATE "Py_LIMITED_API=0x0${_sabi_major}${_sabi_minor_pad}${_sabi_minor_hex}0000"
+  )
+endfunction()

--- a/cpp/python/CMakeLists.txt
+++ b/cpp/python/CMakeLists.txt
@@ -82,6 +82,10 @@ set_target_properties(
 
 target_compile_options(ucxx_python PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${UCXX_CXX_FLAGS}>")
 
+# ensure the outputs only use CPython's Limited API
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/py_limited_api.cmake)
+rapids_target_set_py_limited_api(ucxx_python)
+
 get_filename_component(ucxx_dir "${CMAKE_CURRENT_SOURCE_DIR}" DIRECTORY)
 
 # Specify include paths for the current target and dependents

--- a/cpp/python/src/future.cpp
+++ b/cpp/python/src/future.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <ucxx/log.h>
@@ -113,7 +113,8 @@ PyObject* check_future_state(PyObject* future)
 
   PyGILState_STATE state = PyGILState_Ensure();
 
-  result = PyObject_CallMethodNoArgs(future, cancelled_str);
+  // TODO: replace with PyObject_CallMethodNoArgs() when minimum Python version moves to 3.12
+  result = PyObject_CallMethodObjArgs(future, cancelled_str, NULL);
   if (PyErr_Occurred()) {
     ucxx_error("ucxx::python::%s, error calling `cancelled()` from `asyncio.Future` object",
                __func__);
@@ -122,7 +123,8 @@ PyObject* check_future_state(PyObject* future)
     goto finish;
   }
 
-  result = PyObject_CallMethodNoArgs(future, done_str);
+  // TODO: replace with PyObject_CallMethodNoArgs() when minimum Python version moves to 3.12
+  result = PyObject_CallMethodObjArgs(future, done_str, NULL);
   if (PyErr_Occurred()) {
     ucxx_error("ucxx::python::%s, error calling `done()` from `asyncio.Future` object", __func__);
   } else if (PyObject_IsTrue(result)) {
@@ -150,7 +152,8 @@ PyObject* future_set_result(PyObject* future, PyObject* value)
     goto finish;
   }
 
-  result = PyObject_CallMethodOneArg(future, set_result_str, value);
+  // TODO: replace with PyObject_CallMethodOneArg() when minimum Python version moves to 3.12
+  result = PyObject_CallMethodObjArgs(future, set_result_str, value, NULL);
   if (PyErr_Occurred()) {
     ucxx_error("ucxx::python::%s, error calling `set_result()` from `asyncio.Future` object",
                __func__);
@@ -187,7 +190,8 @@ PyObject* future_set_exception(PyObject* future, PyObject* exception, const char
   formed_exception = PyObject_Call(exception, message_tuple, NULL);
   if (formed_exception == NULL) goto err;
 
-  result = PyObject_CallMethodOneArg(future, set_exception_str, formed_exception);
+  // TODO: replace with PyObject_CallMethodOneArg() when minimum Python version moves to 3.12
+  result = PyObject_CallMethodObjArgs(future, set_exception_str, formed_exception, NULL);
 
   goto finish;
 


### PR DESCRIPTION
Fixes #723 

Contributes to https://github.com/rapidsai/build-planning/issues/315

* fixes some usage of functions outside the CPython 3.11 Limited API, so we can again publish `cp311-abi3` wheels
* adds CMake code to make future mistakes like this compile-time errors
* adds `abi3audit` in CI as another layer of protection against this class of bug

## Notes for Reviewers

### Rollout plan

1. merge this to `hotfix/0.51.01`
2. no-squash admin merge `hotfix/0.51.01` to `release/0.51`
3. push a new `v0.51.01` tag to `release/0.51` and do a `0.51.1` release
4. cherry-pick this onto `main`

### What is this `hotfix/0.51.01` branch?

It was cut from `release/0.51`, 1 commit prior to the `v0.51.00` tag.

### We built wheels with Python 3.11, how could they not follow the `cp311` Limited API?

```console
$ abi3audit --strict --verbose ./ucxx_*.whl
[16:27:09] 👎 ucxx_cu12-0.51.0-cp311-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl: libucxx_python.so uses the Python 3.12 ABI, but is tagged for the Python 3.11 ABI
           ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
           ┃ Symbol                    ┃ Version ┃
           ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
           │ PyObject_VectorcallMethod │ 3.12    │
           └───────────────────────────┴─────────┘
           💁 ucxx_cu12-0.51.0-cp311-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl: 4 extensions scanned; 1 ABI version mismatches and 0 ABI violations found
```

That symbol snuck in like this:

1. `PyObject_VectorcallMethod` was available as a public API since Python 3.9 (https://peps.python.org/pep-0590/).
6. in Python 3.11, it wasn't in the Limited API but could sneak in because `PyObject_CallMethodNoArgs` and `PyObject_CallMethodOneArg` are `static inline` functions that reference it (https://github.com/python/cpython/blob/3.11/Include/cpython/abstract.h#L103-L117)

And we missed it because:

1. `skbuild.wheel.py-api` (set at https://github.com/rapidsai/ucxx/blob/2764534dd8cdf977914b3d546c8f8b19eff4d313/ci/build_wheel.sh#L49-L52), only affects extension modules ... `ucxx_python.so` is just a regular DSO that links to `libpython.so`
2. we don't run `abi3audit` to check these things
7. CI wouldn't break with runtime errors, because `PyObject_VectorcallMethod` was available in Python 3.11, just not part of the Limited API until 3.12 (https://docs.python.org/3/whatsnew/3.12.html#c-api-changes)

### How I tested this

Did local wheel builds and checked them with `abi3audit`.

<details><summary>code for that (click me)</summary>

Small tweak to `ci/build_wheel_ucxx.sh` to re-use the local `libucxx` wheels.

```diff
diff --git a/ci/build_wheel_ucxx.sh b/ci/build_wheel_ucxx.sh
index d0d61d7..9ff2553 100755
--- a/ci/build_wheel_ucxx.sh
+++ b/ci/build_wheel_ucxx.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -euo pipefail
@@ -16,8 +16,13 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 #
 # env variable 'PIP_CONSTRAINT' is set up by rapids-init-pip. It constrains all subsequent
 # 'pip install', 'pip download', etc. calls (except those used in 'pip wheel', handled separately in build scripts)
-LIBUCXX_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libucxx ucxx --cuda "$RAPIDS_CUDA_VERSION")")
-echo "libucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBUCXX_WHEELHOUSE}"/libucxx_*.whl)" >> "${PIP_CONSTRAINT}"
+# TODO: remove before merging
+if [[ "${CI:-}" != "true" ]]; then
+    echo "libucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"/libucxx_*.whl)" >> "${PIP_CONSTRAINT}"
+else
+    LIBUCXX_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libucxx ucxx --cuda "$RAPIDS_CUDA_VERSION")")
+    echo "libucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBUCXX_WHEELHOUSE}"/libucxx_*.whl)" >> "${PIP_CONSTRAINT}"
+fi
 
 export SKBUILD_CMAKE_ARGS="-DFIND_UCXX_CPP=ON;-DCMAKE_INSTALL_LIBDIR=ucxx/lib64;-DCMAKE_INSTALL_INCLUDEDIR=ucxx/include"
```

Then:

```shell
docker run \
  --rm \
  -v $(pwd):/opt/work \
  -w /opt/work \
  -it rapidsai/ci-wheel:26.10-cuda13.3.0-rockylinux8-py3.11 \
  bash

rm -rf ./python/{libucxx,ucxx}/{build,dist}
rm -rf /tmp/wheelhouse/*
./ci/build_wheel_libucxx.sh && ./ci/build_wheel_ucxx.sh
```

</details>

Added `abi3audit` in CI here, and saw it fail before the C++ changes.

Checked locally that setting `Py_LIMITED_API` causes a compiler error on `main` without the C++ changes here.