### PR TITLE
fix Limited API compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ python/ucxx/ucxx/_lib/*.h
 wheels/
 *.egg-info/
 _skbuild/
+*.tar.gz
+*.whl
 
 ## Doxygen
 cpp/doxygen/html

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -euo pipefail
@@ -33,10 +33,23 @@ rapids-logger "validate packages with 'pydistcheck'"
 
 pydistcheck \
     --inspect \
-    "$(echo "${wheel_dir_relative_path}"/*.whl)"
+    "${wheel_dir_relative_path}"/*.whl
 
 rapids-logger "validate packages with 'twine'"
 
 twine check \
     --strict \
-    "$(echo "${wheel_dir_relative_path}"/*.whl)"
+    "${wheel_dir_relative_path}"/*.whl
+
+rapids-logger "validate packages with 'abi3audit'"
+
+# TODO: remove once https://github.com/rapidsai/ci-imgs/pull/454 is merged
+pip install abi3audit
+
+# 'abi3audit' fails on wheels that contain DSOs but don't have an ABI tag (like 'libucxx').
+# This '-name' filtering avoids trying those.
+find \
+    "${wheel_dir_relative_path}" \
+    -type f \
+    -name '*abi*' \
+    -exec abi3audit --strict --summary --verbose '{}' \+

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -43,9 +43,6 @@ twine check \
 
 rapids-logger "validate packages with 'abi3audit'"
 
-# TODO: remove once https://github.com/rapidsai/ci-imgs/pull/454 is merged
-pip install abi3audit
-
 # 'abi3audit' fails on wheels that contain DSOs but don't have an ABI tag (like 'libucxx').
 # This '-name' filtering avoids trying those.
 find \

--- a/cpp/cmake/py_limited_api.cmake
+++ b/cpp/cmake/py_limited_api.cmake
@@ -1,0 +1,50 @@
+# =================================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# cmake-format: on
+# =================================================================================
+
+# Sets Py_LIMITED_API=<hex> on <target> when SKBUILD_SABI_VERSION is defined, matching the version
+# encoding used by Python's C API headers.
+#
+# This ensures a compile-time error if anything in libpython that isn't part of the Limited API is
+# used.
+#
+# 'scikit-build-core' sets that variable based on 'skbuild.wheel.py-api'.
+function(rapids_target_set_py_limited_api target)
+  if(NOT DEFINED SKBUILD_SABI_VERSION OR "${SKBUILD_SABI_VERSION}" STREQUAL "")
+    message(
+      STATUS
+        "rapids_target_set_py_limited_api: SKBUILD_SABI_VERSION not set (not using scikit-build-core or 'skbuild.wheel.py-api' not set)"
+    )
+    return()
+  endif()
+  message(
+    STATUS
+      "rapids_target_set_py_limited_api: SKBUILD_SABI_VERSION=${SKBUILD_SABI_VERSION}, setting Py_LIMITED_API on '${target}'"
+  )
+
+  # SKBUILD_SABI_VERSION is usually a Python major.minor, e.g. '3.11'.
+  #
+  # CPython's Limited API guards expect a hexadecimal like '0x030b0000', where:
+  #
+  # * '0x'   = prefix for a hex literal
+  # * '03'   = major version: 3
+  # * '0b'   = minor version (0x0b = 11)
+  # * '0000' = other version components that can be ignored (limited API is versioned by Python
+  #   major.minor)
+  #
+  # docs: https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API
+  #
+  string(REPLACE "." ";" _sabi_parts "${SKBUILD_SABI_VERSION}")
+  list(GET _sabi_parts 0 _sabi_major)
+  list(GET _sabi_parts 1 _sabi_minor)
+  math(EXPR _sabi_major_minor_hex "${_sabi_major} * 256 * 65536 + ${_sabi_minor} * 65536"
+       OUTPUT_FORMAT HEXADECIMAL
+  )
+
+  # CPython source code pads '3' to '03' so all version components use 2 digits. Mirror that.
+  string(REGEX REPLACE "^0x" "0x0" _sabi_major_minor_hex "${_sabi_major_minor_hex}")
+  target_compile_definitions(${target} PRIVATE "Py_LIMITED_API=${_sabi_major_minor_hex}")
+endfunction()

--- a/cpp/python/CMakeLists.txt
+++ b/cpp/python/CMakeLists.txt
@@ -82,6 +82,10 @@ set_target_properties(
 
 target_compile_options(ucxx_python PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${UCXX_CXX_FLAGS}>")
 
+# ensure the outputs only use CPython's Limited API
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/py_limited_api.cmake)
+rapids_target_set_py_limited_api(ucxx_python)
+
 get_filename_component(ucxx_dir "${CMAKE_CURRENT_SOURCE_DIR}" DIRECTORY)
 
 # Specify include paths for the current target and dependents

--- a/cpp/python/src/future.cpp
+++ b/cpp/python/src/future.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <ucxx/log.h>
@@ -113,7 +113,8 @@ PyObject* check_future_state(PyObject* future)
 
   PyGILState_STATE state = PyGILState_Ensure();
 
-  result = PyObject_CallMethodNoArgs(future, cancelled_str);
+  // TODO: replace with PyObject_CallMethodNoArgs() when minimum Python version moves to 3.12
+  result = PyObject_CallMethodObjArgs(future, cancelled_str, NULL);
   if (PyErr_Occurred()) {
     ucxx_error("ucxx::python::%s, error calling `cancelled()` from `asyncio.Future` object",
                __func__);
@@ -122,7 +123,8 @@ PyObject* check_future_state(PyObject* future)
     goto finish;
   }
 
-  result = PyObject_CallMethodNoArgs(future, done_str);
+  // TODO: replace with PyObject_CallMethodNoArgs() when minimum Python version moves to 3.12
+  result = PyObject_CallMethodObjArgs(future, done_str, NULL);
   if (PyErr_Occurred()) {
     ucxx_error("ucxx::python::%s, error calling `done()` from `asyncio.Future` object", __func__);
   } else if (PyObject_IsTrue(result)) {
@@ -150,7 +152,8 @@ PyObject* future_set_result(PyObject* future, PyObject* value)
     goto finish;
   }
 
-  result = PyObject_CallMethodOneArg(future, set_result_str, value);
+  // TODO: replace with PyObject_CallMethodOneArg() when minimum Python version moves to 3.12
+  result = PyObject_CallMethodObjArgs(future, set_result_str, value, NULL);
   if (PyErr_Occurred()) {
     ucxx_error("ucxx::python::%s, error calling `set_result()` from `asyncio.Future` object",
                __func__);
@@ -187,7 +190,8 @@ PyObject* future_set_exception(PyObject* future, PyObject* exception, const char
   formed_exception = PyObject_Call(exception, message_tuple, NULL);
   if (formed_exception == NULL) goto err;
 
-  result = PyObject_CallMethodOneArg(future, set_exception_str, formed_exception);
+  // TODO: replace with PyObject_CallMethodOneArg() when minimum Python version moves to 3.12
+  result = PyObject_CallMethodObjArgs(future, set_exception_str, formed_exception, NULL);
 
   goto finish;
 


### PR DESCRIPTION
This forward-merges this hotfix from 0.51: https://github.com/rapidsai/ucxx/pull/724

And also switches from `pip install`-ing `abi3audit` to using the one in the CI container images, now that there are new builds containing https://github.com/rapidsai/ci-imgs/pull/454