### PR TITLE
Prevent delayed requests from being submitted after cancelation

### DIFF
--- a/cpp/include/ucxx/request.h
+++ b/cpp/include/ucxx/request.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -207,9 +207,12 @@ class Request : public Component {
    * to either execute (submit) it immediately or delay for the next iteration of its
    * progress loop, depending on the progress mode in use by the worker.
    *
+   * Submission is serialized with cancellation. If the request has already completed,
+   * the request-specific submission implementation is not invoked.
+   *
    * See `ucxx::DelayedSubmission::DelayedSubmission()` for more details.
    */
-  virtual void populateDelayedSubmission() = 0;
+  void populateDelayedSubmission();
 
   /**
    * @brief Get formatted string with owner type and handle address.
@@ -274,6 +277,14 @@ class Request : public Component {
   [[nodiscard]] Attributes queryAttributes();
 
  protected:
+  /**
+   * @brief Submit the request-specific UCX operation.
+   *
+   * Implemented by each concrete request and invoked only by
+   * `populateDelayedSubmission()` while holding the request mutex.
+   */
+  virtual void populateDelayedSubmissionImpl() = 0;
+
   /**
    * @brief Publish the UCP request handle and capture its attributes.
    *

--- a/cpp/include/ucxx/request_am.h
+++ b/cpp/include/ucxx/request_am.h
@@ -70,6 +70,8 @@ class RequestAm : public Request {
             RequestCallbackUserFunction callbackFunction = nullptr,
             RequestCallbackUserData callbackData         = nullptr);
 
+  void populateDelayedSubmissionImpl() override;
+
  public:
   // Allow internal construction without exposing factory functions.
   friend class detail::ConstructorFactory;
@@ -81,8 +83,6 @@ class RequestAm : public Request {
    * destructor but may be called by the user to cancel the request as well.
    */
   void cancel() override;
-
-  void populateDelayedSubmission() override;
 
   /**
    * @brief Create and submit an active message send request.

--- a/cpp/include/ucxx/request_endpoint_close.h
+++ b/cpp/include/ucxx/request_endpoint_close.h
@@ -54,11 +54,11 @@ class RequestEndpointClose : public Request {
                        RequestCallbackUserFunction callbackFunction = nullptr,
                        RequestCallbackUserData callbackData         = nullptr);
 
+  void populateDelayedSubmissionImpl() override;
+
  public:
   // Allow internal construction without exposing factory functions.
   friend class detail::ConstructorFactory;
-
-  virtual void populateDelayedSubmission();
 
   /**
    * @brief Create and submit an endpoint close request.

--- a/cpp/include/ucxx/request_flush.h
+++ b/cpp/include/ucxx/request_flush.h
@@ -60,11 +60,11 @@ class RequestFlush : public Request {
                RequestCallbackUserFunction callbackFunction = nullptr,
                RequestCallbackUserData callbackData         = nullptr);
 
+  void populateDelayedSubmissionImpl() override;
+
  public:
   // Allow internal construction without exposing factory functions.
   friend class detail::ConstructorFactory;
-
-  virtual void populateDelayedSubmission();
 
   /**
    * @brief Create and submit a flush request.

--- a/cpp/include/ucxx/request_mem.h
+++ b/cpp/include/ucxx/request_mem.h
@@ -68,11 +68,11 @@ class RequestMem : public Request {
              RequestCallbackUserFunction callbackFunction = nullptr,
              RequestCallbackUserData callbackData         = nullptr);
 
+  void populateDelayedSubmissionImpl() override;
+
  public:
   // Allow internal construction without exposing factory functions.
   friend class detail::ConstructorFactory;
-
-  virtual void populateDelayedSubmission();
 
   /**
    * @brief Callback executed by UCX when a memory put request is completed.

--- a/cpp/include/ucxx/request_stream.h
+++ b/cpp/include/ucxx/request_stream.h
@@ -50,11 +50,11 @@ class RequestStream : public Request {
                 std::string operationName,
                 const bool enablePythonFuture = false);
 
+  void populateDelayedSubmissionImpl() override;
+
  public:
   // Allow internal construction without exposing factory functions.
   friend class detail::ConstructorFactory;
-
-  virtual void populateDelayedSubmission();
 
   /**
    * @brief Create and submit a stream request.

--- a/cpp/include/ucxx/request_tag.h
+++ b/cpp/include/ucxx/request_tag.h
@@ -63,11 +63,11 @@ class RequestTag : public Request {
     RequestCallbackUserFunction callbackFunction = nullptr,
     RequestCallbackUserData callbackData         = nullptr);
 
+  void populateDelayedSubmissionImpl() override;
+
  public:
   // Allow internal construction without exposing factory functions.
   friend class detail::ConstructorFactory;
-
-  virtual void populateDelayedSubmission();
 
   /**
    * @brief Cancel the tag request.

--- a/cpp/include/ucxx/request_tag_multi.h
+++ b/cpp/include/ucxx/request_tag_multi.h
@@ -108,6 +108,8 @@ class RequestTagMulti : public Request {
                   std::string operationName,
                   const bool enablePythonFuture);
 
+  void populateDelayedSubmissionImpl() override;
+
   /**
    * @brief Receive all frames.
    *
@@ -187,8 +189,6 @@ class RequestTagMulti : public Request {
    * @throws std::runtime_error if called by a send request.
    */
   void recvCallback(ucs_status_t status);
-
-  void populateDelayedSubmission() override;
 
   void cancel() override;
 };

--- a/cpp/src/request.cpp
+++ b/cpp/src/request.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <chrono>
@@ -87,7 +87,10 @@ void Request::cancel()
                        ucs_status_string(status));
     } else {
       ucxx_trace_req_f(_ownerString.c_str(), this, _request, _operationName.c_str(), "canceling");
-      if (_request != nullptr) ucp_request_cancel(_worker->getHandle(), _request);
+      if (_request != nullptr)
+        ucp_request_cancel(_worker->getHandle(), _request);
+      else
+        setStatus(UCS_ERR_CANCELED);
     }
   } else {
     ucxx_trace_req_f(_ownerString.c_str(),
@@ -98,6 +101,13 @@ void Request::cancel()
                      _status,
                      ucs_status_string(_status));
   }
+}
+
+void Request::populateDelayedSubmission()
+{
+  std::lock_guard<std::recursive_mutex> lock(_mutex);
+  if (_status != UCS_INPROGRESS) return;
+  populateDelayedSubmissionImpl();
 }
 
 ucs_status_t Request::getStatus()

--- a/cpp/src/request.cpp
+++ b/cpp/src/request.cpp
@@ -87,10 +87,11 @@ void Request::cancel()
                        ucs_status_string(status));
     } else {
       ucxx_trace_req_f(_ownerString.c_str(), this, _request, _operationName.c_str(), "canceling");
-      if (_request != nullptr)
+      if (_request != nullptr) {
         ucp_request_cancel(_worker->getHandle(), _request);
-      else
+      } else {
         setStatus(UCS_ERR_CANCELED);
+      }
     }
   } else {
     ucxx_trace_req_f(_ownerString.c_str(),

--- a/cpp/src/request_am.cpp
+++ b/cpp/src/request_am.cpp
@@ -478,7 +478,7 @@ void RequestAm::request()
     _requestData);
 }
 
-void RequestAm::populateDelayedSubmission()
+void RequestAm::populateDelayedSubmissionImpl()
 {
   bool terminate =
     std::visit(data::dispatch{

--- a/cpp/src/request_endpoint_close.cpp
+++ b/cpp/src/request_endpoint_close.cpp
@@ -82,7 +82,7 @@ void RequestEndpointClose::request()
   publishRequest(request);
 }
 
-void RequestEndpointClose::populateDelayedSubmission()
+void RequestEndpointClose::populateDelayedSubmissionImpl()
 {
   if (_endpoint != nullptr && _endpoint->getHandle() == nullptr) {
     ucxx_warn("Endpoint is already closed");

--- a/cpp/src/request_flush.cpp
+++ b/cpp/src/request_flush.cpp
@@ -81,7 +81,7 @@ void RequestFlush::request()
   publishRequest(request);
 }
 
-void RequestFlush::populateDelayedSubmission()
+void RequestFlush::populateDelayedSubmissionImpl()
 {
   if (_endpoint != nullptr && _endpoint->getHandle() == nullptr) {
     ucxx_warn("Endpoint was closed before it could be flushed");

--- a/cpp/src/request_mem.cpp
+++ b/cpp/src/request_mem.cpp
@@ -131,7 +131,7 @@ void RequestMem::request()
   publishRequest(request);
 }
 
-void RequestMem::populateDelayedSubmission()
+void RequestMem::populateDelayedSubmissionImpl()
 {
   bool terminate =
     std::visit(data::dispatch{

--- a/cpp/src/request_stream.cpp
+++ b/cpp/src/request_stream.cpp
@@ -95,7 +95,7 @@ void RequestStream::request()
   publishRequest(request);
 }
 
-void RequestStream::populateDelayedSubmission()
+void RequestStream::populateDelayedSubmissionImpl()
 {
   bool terminate =
     std::visit(data::dispatch{

--- a/cpp/src/request_tag.cpp
+++ b/cpp/src/request_tag.cpp
@@ -181,7 +181,7 @@ void RequestTag::request()
   publishRequest(request);
 }
 
-void RequestTag::populateDelayedSubmission()
+void RequestTag::populateDelayedSubmissionImpl()
 {
   std::lock_guard<std::recursive_mutex> lock(_mutex);
 

--- a/cpp/src/request_tag_multi.cpp
+++ b/cpp/src/request_tag_multi.cpp
@@ -367,7 +367,7 @@ void RequestTagMulti::send()
     _requestData);
 }
 
-void RequestTagMulti::populateDelayedSubmission() {}
+void RequestTagMulti::populateDelayedSubmissionImpl() {}
 
 void RequestTagMulti::cancel()
 {

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>
+#include <condition_variable>
 #include <memory>
 #include <numeric>
 #include <stdexcept>
@@ -41,6 +42,22 @@ using ::testing::ContainerEq;
 using ::testing::Values;
 
 typedef std::vector<int> DataContainerType;
+
+struct ProgressThreadStartBarrier {
+  std::mutex mutex{};
+  std::condition_variable condition{};
+  bool started{false};
+  bool released{false};
+};
+
+void waitForProgressThreadRelease(void* arg)
+{
+  auto& barrier = *static_cast<ProgressThreadStartBarrier*>(arg);
+  std::unique_lock<std::mutex> lock(barrier.mutex);
+  barrier.started = true;
+  barrier.condition.notify_one();
+  barrier.condition.wait(lock, [&barrier]() { return barrier.released; });
+}
 
 enum class TestBufferType {
   Host,
@@ -244,6 +261,45 @@ class RequestTest
     }
   }
 };
+
+TEST(RequestCancellationTest, CancelBeforeDelayedSubmission)
+{
+  auto context = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
+  auto worker  = ucxx::workerBuilder(context).delayedSubmission(true).build();
+  auto ep      = worker->createEndpointFromWorkerAddress(worker->getAddress());
+
+  ProgressThreadStartBarrier barrier{};
+  worker->setProgressThreadStartCallback(waitForProgressThreadRelease, &barrier);
+  worker->startProgressThread(true);
+
+  {
+    std::unique_lock<std::mutex> lock(barrier.mutex);
+    barrier.condition.wait(lock, [&barrier]() { return barrier.started; });
+  }
+
+  int recvBuffer{};
+  auto request = ep->tagRecv(&recvBuffer, sizeof(recvBuffer), ucxx::Tag{0}, ucxx::TagMaskFull);
+  request->cancel();
+
+  const bool completedBeforeSubmission = request->isCompleted();
+  const auto statusBeforeSubmission    = request->getStatus();
+
+  {
+    std::lock_guard<std::mutex> lock(barrier.mutex);
+    barrier.released = true;
+  }
+  barrier.condition.notify_one();
+
+  // Wait until the delayed-submission iteration has completed before cleaning up.
+  EXPECT_TRUE(worker->registerGenericPost([]() {}));
+  if (!request->isCompleted()) request->cancel();
+  while (!request->isCompleted())
+    std::this_thread::yield();
+  worker->stopProgressThread();
+
+  EXPECT_TRUE(completedBeforeSubmission);
+  EXPECT_EQ(statusBeforeSubmission, UCS_ERR_CANCELED);
+}
 
 TEST_P(RequestTest, ProgressAm)
 {

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -264,9 +264,9 @@ class RequestTest
 
 TEST(RequestCancellationTest, CancelBeforeDelayedSubmission)
 {
-  auto context = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
+  auto context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build();
   auto worker  = ucxx::workerBuilder(context).delayedSubmission(true).build();
-  auto ep      = worker->createEndpointFromWorkerAddress(worker->getAddress());
+  auto ep      = worker->endpointBuilder(worker->addressBuilder().build()).build();
 
   ProgressThreadStartBarrier barrier{};
   worker->setProgressThreadStartCallback(waitForProgressThreadRelease, &barrier);
@@ -278,7 +278,8 @@ TEST(RequestCancellationTest, CancelBeforeDelayedSubmission)
   }
 
   int recvBuffer{};
-  auto request = ep->tagRecv(&recvBuffer, sizeof(recvBuffer), ucxx::Tag{0}, ucxx::TagMaskFull);
+  auto request =
+    ep->tagRecvBuilder(&recvBuffer, sizeof(recvBuffer), ucxx::Tag{0}, ucxx::TagMaskFull).build();
   request->cancel();
 
   const bool completedBeforeSubmission = request->isCompleted();


### PR DESCRIPTION
## Summary

Prevent a delayed UCXX request from being submitted after it has already been canceled.

This addresses intermittent hangs in `ucxx/_lib_async/tests/test_shutdown.py::test_client_shutdown[tag]`.

## Problem

During endpoint shutdown, a request can be canceled before its delayed-submission callback runs. At that point no UCP request exists, so the previous cancelation path did nothing. A later progress iteration could then submit the request after shutdown, leaving its Python future waiting indefinitely.

## Fix

Cancelation and submission are now serialized using the request mutex:

- Canceling before submission completes the request with `UCS_ERR_CANCELED`;
- `Request::populateDelayedSubmission()` skips submission for completed requests;
- Request-specific submission remains in private `populateDelayedSubmissionImpl()` overrides.

This ensures that either cancelation prevents submission or submission completes before normal UCP cancelation occurs.


Depends on #731 