### PR TITLE
Receive queued tag messages after endpoint closure

### DIFF
--- a/cpp/include/ucxx/request_data.h
+++ b/cpp/include/ucxx/request_data.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -302,7 +302,8 @@ class TagReceive {
  */
 class TagReceiveWithHandle {
  public:
-  void* _buffer{nullptr};  ///< The raw pointer where received data should be stored.
+  void* _buffer{nullptr};   ///< The raw pointer where received data should be stored.
+  const size_t _length{0};  ///< The size in bytes of the receive buffer.
   const std::shared_ptr<TagProbeInfo> _probeInfo{
     nullptr};  ///< TagProbeInfo containing message length and handle
 
@@ -311,12 +312,13 @@ class TagReceiveWithHandle {
    *
    * Construct an object containing tag receive with handle-specific data.
    *
-   * @param[out] buffer      a raw pointer to the received data. The buffer must be large
-   *                         enough to hold the message data, otherwise the behavior is
-   *                         undefined. The buffer must be pre-allocated.
+   * @param[out] buffer      a raw pointer to the received data. The buffer must be pre-allocated.
+   * @param[in]  length      the size in bytes of the receive buffer.
    * @param[in]  probeInfo   the TagProbeInfo object containing message length and handle.
    */
-  explicit TagReceiveWithHandle(decltype(_buffer) buffer, std::shared_ptr<TagProbeInfo> probeInfo);
+  explicit TagReceiveWithHandle(decltype(_buffer) buffer,
+                                decltype(_length) length,
+                                std::shared_ptr<TagProbeInfo> probeInfo);
 
   TagReceiveWithHandle() = delete;
 };

--- a/cpp/include/ucxx/request_tag.h
+++ b/cpp/include/ucxx/request_tag.h
@@ -24,6 +24,8 @@ namespace ucxx {
  */
 class RequestTag : public Request {
  private:
+  bool _cancelRequested{false};  ///< Whether to cancel immediately after delayed submission.
+
   /**
    * @brief Private constructor of `ucxx::RequestTag`.
    *
@@ -106,8 +108,8 @@ class RequestTag : public Request {
    * @brief Cancel the tag request.
    *
    * A receive created from a probed message handle must consume that handle before it can
-   * be canceled. If delayed submission has not occurred yet, submit it first and then use
-   * normal request cancelation.
+   * be canceled. If delayed submission has not occurred yet, defer cancelation until the
+   * progress context has submitted and processed the receive.
    */
   void cancel() override;
 

--- a/cpp/include/ucxx/request_tag.h
+++ b/cpp/include/ucxx/request_tag.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -101,6 +101,15 @@ class RequestTag : public Request {
     RequestCallbackUserData callbackData);
 
   virtual void populateDelayedSubmission();
+
+  /**
+   * @brief Cancel the tag request.
+   *
+   * A receive created from a probed message handle must consume that handle before it can
+   * be canceled. If delayed submission has not occurred yet, submit it first and then use
+   * normal request cancelation.
+   */
+  void cancel() override;
 
   /**
    * @brief Create and submit a tag request.

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -883,6 +883,19 @@ class Worker : public Component {
    * @returns Builder to configure optional parameters and submit the request.
    */
   [[nodiscard]] RequestTagBuilder tagRecvWithHandleBuilder(void* buffer,
+                                                           std::shared_ptr<TagProbeInfo> probeInfo);
+
+  /**
+   * @brief Create a builder for a bounded tag receive using a message handle.
+   *
+   * @param[in] buffer     a raw pointer to pre-allocated receive memory.
+   * @param[in] length     the size in bytes of the receive buffer.
+   * @param[in] probeInfo  the TagProbeInfo object containing message length and handle.
+   *
+   * @returns Builder to configure optional parameters and submit the request.
+   */
+  [[nodiscard]] RequestTagBuilder tagRecvWithHandleBuilder(void* buffer,
+                                                           size_t length,
                                                            std::shared_ptr<TagProbeInfo> probeInfo);
 
   /**

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -886,7 +886,11 @@ class Worker : public Component {
                                                            std::shared_ptr<TagProbeInfo> probeInfo);
 
   /**
-   * @brief Create a builder for a bounded tag receive using a message handle.
+   * @brief Create a builder for a tag receive operation using a message handle.
+   *
+   * If the message does not fit in the receive buffer, the resulting request completes
+   * with `UCS_ERR_MESSAGE_TRUNCATED`. Calling `Request::checkError()` then raises
+   * `ucxx::MessageTruncatedError`.
    *
    * @param[in] buffer     a raw pointer to pre-allocated receive memory.
    * @param[in] length     the size in bytes of the receive buffer.

--- a/cpp/src/request_data.cpp
+++ b/cpp/src/request_data.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -114,10 +114,13 @@ TagReceive::TagReceive(void* buffer,
 {
 }
 
-TagReceiveWithHandle::TagReceiveWithHandle(void* buffer, std::shared_ptr<TagProbeInfo> probeInfo)
-  : _buffer(buffer), _probeInfo(std::move(probeInfo))
+TagReceiveWithHandle::TagReceiveWithHandle(void* buffer,
+                                           size_t length,
+                                           std::shared_ptr<TagProbeInfo> probeInfo)
+  : _buffer(buffer), _length(length), _probeInfo(std::move(probeInfo))
 {
-  if (_buffer == nullptr) throw std::runtime_error("Buffer cannot be a nullptr.");
+  if (_buffer == nullptr && _length > 0)
+    throw std::runtime_error("Buffer cannot be a nullptr when length is > 0.");
   if (!_probeInfo->isMatched()) throw std::runtime_error("TagProbeInfo must be matched.");
   // getInfo() and getHandle() will throw runtime_error if invalid, so we can just call them
   try {

--- a/cpp/src/request_tag.cpp
+++ b/cpp/src/request_tag.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -121,6 +121,19 @@ void RequestTag::tagRecvCallback(void* request,
   return req->callback(request, status, info);
 }
 
+void RequestTag::cancel()
+{
+  std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+  if (_status == UCS_INPROGRESS && _request == nullptr &&
+      std::holds_alternative<data::TagReceiveWithHandle>(_requestData)) {
+    request();
+    process();
+  }
+
+  Request::cancel();
+}
+
 void RequestTag::request()
 {
   ucp_request_param_t param = {.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
@@ -150,7 +163,7 @@ void RequestTag::request()
                  auto handle   = tagReceiveWithHandle._probeInfo->getHandle();
                  request       = ucp_tag_msg_recv_nbx(_worker->getHandle(),
                                                 tagReceiveWithHandle._buffer,
-                                                tagReceiveWithHandle._probeInfo->getInfo().length,
+                                                tagReceiveWithHandle._length,
                                                 handle,
                                                 &param);
 
@@ -166,6 +179,10 @@ void RequestTag::request()
 
 void RequestTag::populateDelayedSubmission()
 {
+  std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+  if (_status != UCS_INPROGRESS || _request != nullptr) return;
+
   bool terminate =
     std::visit(data::dispatch{
                  [this](data::TagSend) {

--- a/cpp/src/request_tag.cpp
+++ b/cpp/src/request_tag.cpp
@@ -123,12 +123,15 @@ void RequestTag::tagRecvCallback(void* request,
 
 void RequestTag::cancel()
 {
-  std::lock_guard<std::recursive_mutex> lock(_mutex);
+  std::unique_lock<std::recursive_mutex> lock(_mutex);
 
   if (_status == UCS_INPROGRESS && _request == nullptr &&
-      std::holds_alternative<data::TagReceiveWithHandle>(_requestData)) {
-    request();
-    process();
+      std::holds_alternative<data::TagReceiveWithHandle>(_requestData) &&
+      _worker->isDelayedRequestSubmissionEnabled()) {
+    _cancelRequested = true;
+    lock.unlock();
+    _worker->signal();
+    return;
   }
 
   Request::cancel();
@@ -261,6 +264,7 @@ void RequestTag::populateDelayedSubmission()
              _requestData);
 
   process();
+  if (_cancelRequested) Request::cancel();
 }
 
 }  // namespace ucxx

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -675,14 +675,24 @@ std::shared_ptr<Request> Worker::tagRecvWithHandle(void* buffer,
   }
 
   auto worker = std::static_pointer_cast<Worker>(shared_from_this());
-  return registerInflightRequest(createRequestTag(worker,
-                                                  data::TagReceiveWithHandle(buffer, probeInfo),
-                                                  enableFuture,
-                                                  std::move(callbackFunction),
-                                                  std::move(callbackData)));
+  return registerInflightRequest(
+    createRequestTag(worker,
+                     data::TagReceiveWithHandle(buffer, probeInfo->getInfo().length, probeInfo),
+                     enableFuture,
+                     std::move(callbackFunction),
+                     std::move(callbackData)));
 }
 
 RequestTagBuilder Worker::tagRecvWithHandleBuilder(void* buffer,
+                                                   std::shared_ptr<TagProbeInfo> probeInfo)
+{
+  if (!probeInfo->isMatched()) { throw std::invalid_argument("TagProbeInfo must be matched"); }
+  const auto length = probeInfo->getInfo().length;
+  return tagRecvWithHandleBuilder(buffer, length, std::move(probeInfo));
+}
+
+RequestTagBuilder Worker::tagRecvWithHandleBuilder(void* buffer,
+                                                   size_t length,
                                                    std::shared_ptr<TagProbeInfo> probeInfo)
 {
   if (!probeInfo->isMatched()) { throw std::invalid_argument("TagProbeInfo must be matched"); }
@@ -695,7 +705,8 @@ RequestTagBuilder Worker::tagRecvWithHandleBuilder(void* buffer,
   }
 
   auto worker = std::static_pointer_cast<Worker>(shared_from_this());
-  return RequestTagBuilder(std::move(worker), data::TagReceiveWithHandle(buffer, probeInfo));
+  return RequestTagBuilder(std::move(worker),
+                           data::TagReceiveWithHandle(buffer, length, probeInfo));
 }
 
 std::shared_ptr<Address> Worker::getAddress()

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <chrono>
@@ -37,6 +37,62 @@ struct ExtraParams {
   GenericCallbackType genericCallbackType{GenericCallbackType::None};
 };
 
+struct ProgressThreadStartBarrier {
+  std::mutex mutex{};
+  std::condition_variable condition{};
+  bool started{false};
+  bool released{false};
+};
+
+void waitForProgressThreadRelease(void* arg)
+{
+  auto& barrier = *static_cast<ProgressThreadStartBarrier*>(arg);
+  std::unique_lock<std::mutex> lock(barrier.mutex);
+  barrier.started = true;
+  barrier.condition.notify_one();
+  barrier.condition.wait(lock, [&barrier]() { return barrier.released; });
+}
+
+class PausedProgressThread {
+ public:
+  explicit PausedProgressThread(std::shared_ptr<ucxx::Worker> worker) : _worker(worker)
+  {
+    _worker->setProgressThreadStartCallback(waitForProgressThreadRelease, &_barrier);
+    _worker->startProgressThread(true);
+
+    std::unique_lock<std::mutex> lock(_barrier.mutex);
+    _barrier.condition.wait(lock, [this]() { return _barrier.started; });
+  }
+
+  ~PausedProgressThread()
+  {
+    resume();
+    if (_worker->isProgressThreadRunning()) _worker->stopProgressThread();
+  }
+
+  void resume()
+  {
+    {
+      std::lock_guard<std::mutex> lock(_barrier.mutex);
+      if (_barrier.released) return;
+      _barrier.released = true;
+    }
+    _barrier.condition.notify_one();
+  }
+
+ private:
+  std::shared_ptr<ucxx::Worker> _worker;
+  ProgressThreadStartBarrier _barrier{};
+};
+
+struct ProbedTagTransfer {
+  std::shared_ptr<ucxx::Worker> recvWorker;
+  std::shared_ptr<ucxx::Worker> sendWorker;
+  std::shared_ptr<ucxx::Endpoint> endpoint;
+  std::shared_ptr<ucxx::Request> sendRequest;
+  std::shared_ptr<ucxx::TagProbeInfo> probe;
+};
+
 class WorkerTest : public ::testing::Test {
  protected:
   std::shared_ptr<ucxx::Context> _context{
@@ -53,6 +109,39 @@ class WorkerTest : public ::testing::Test {
       ucp_tag_msg_recv_nbx(_worker->getHandle(), recv_buf->data(), length, handle, &param);
     EXPECT_FALSE(UCS_PTR_IS_ERR(request));
     EXPECT_FALSE(UCS_PTR_IS_PTR(request));
+  }
+
+  ProbedTagTransfer makeProbedTagTransfer(const void* buffer,
+                                          size_t length,
+                                          bool delayedSubmission,
+                                          bool waitForSendCompletion = false)
+  {
+    ProbedTagTransfer transfer{_context->createWorker(delayedSubmission),
+                               _context->createWorker(false)};
+    transfer.endpoint =
+      transfer.sendWorker->createEndpointFromWorkerAddress(transfer.recvWorker->getAddress());
+    transfer.sendRequest = transfer.endpoint->tagSend(buffer, length, ucxx::Tag{0});
+
+    loopWithTimeout(std::chrono::milliseconds(5000), [&]() {
+      transfer.sendWorker->progress();
+      transfer.recvWorker->progress();
+      return (!waitForSendCompletion || transfer.sendRequest->isCompleted()) &&
+             transfer.recvWorker->tagProbe(ucxx::Tag{0})->isMatched();
+    });
+
+    transfer.probe = transfer.recvWorker->tagProbe(ucxx::Tag{0}, ucxx::TagMaskFull, true);
+    return transfer;
+  }
+
+  void progressUntilCompleted(const ProbedTagTransfer& transfer,
+                              const std::shared_ptr<ucxx::Request>& request,
+                              bool progressReceiver = true)
+  {
+    loopWithTimeout(std::chrono::milliseconds(5000), [&]() {
+      transfer.sendWorker->progress();
+      if (progressReceiver) transfer.recvWorker->progress();
+      return request->isCompleted();
+    });
   }
 };
 
@@ -274,6 +363,104 @@ TEST_F(WorkerTest, TagProbeRemoveWithMessage)
   }
 
   EXPECT_EQ(recv_buf, buf);
+}
+
+TEST_F(WorkerTest, CancelTagRecvWithHandleBeforeDelayedSubmissionConsumesHandle)
+{
+  // Keep the transfer in progress after the rendezvous header is matched so cancel() submits
+  // a real UCP request while the delayed callback remains queued.
+  std::vector<int> sendBuf(1 << 20, 123);
+  auto transfer = makeProbedTagTransfer(sendBuf.data(), sendBuf.size() * sizeof(int), true);
+  ASSERT_TRUE(transfer.probe->isMatched());
+  ASSERT_NO_THROW(transfer.probe->getHandle());
+
+  PausedProgressThread progressThread{transfer.recvWorker};
+
+  std::vector<int> recvBuf(sendBuf.size());
+  auto recvReq =
+    transfer.recvWorker
+      ->tagRecvWithHandleBuilder(recvBuf.data(), recvBuf.size() * sizeof(int), transfer.probe)
+      .build();
+  recvReq->cancel();
+
+  EXPECT_THROW(transfer.probe->getHandle(), std::runtime_error);
+  EXPECT_FALSE(recvReq->isCompleted());
+
+  progressThread.resume();
+  progressUntilCompleted(transfer, recvReq, false);
+}
+
+TEST_F(WorkerTest, TagRecvWithHandleHonorsReceiveBufferLength)
+{
+  std::vector<int> sendBuf{123, 456};
+  auto transfer = makeProbedTagTransfer(sendBuf.data(), sendBuf.size() * sizeof(int), false);
+  ASSERT_TRUE(transfer.probe->isMatched());
+
+  std::vector<int> recvBuf(1);
+  auto recvReq =
+    transfer.recvWorker
+      ->tagRecvWithHandleBuilder(recvBuf.data(), recvBuf.size() * sizeof(int), transfer.probe)
+      .build();
+  progressUntilCompleted(transfer, recvReq);
+
+  EXPECT_EQ(recvReq->getStatus(), UCS_ERR_MESSAGE_TRUNCATED);
+  progressUntilCompleted(transfer, transfer.sendRequest);
+}
+
+TEST_F(WorkerTest, CancelTagRecvWithHandleProcessesImmediateTruncation)
+{
+  std::vector<int> sendBuf{123, 456};
+  auto transfer = makeProbedTagTransfer(sendBuf.data(), sendBuf.size() * sizeof(int), true);
+  ASSERT_TRUE(transfer.probe->isMatched());
+
+  {
+    PausedProgressThread progressThread{transfer.recvWorker};
+    std::vector<int> recvBuf(1);
+    auto recvReq =
+      transfer.recvWorker
+        ->tagRecvWithHandleBuilder(recvBuf.data(), recvBuf.size() * sizeof(int), transfer.probe)
+        .build();
+    recvReq->cancel();
+
+    EXPECT_TRUE(recvReq->isCompleted());
+    EXPECT_EQ(recvReq->getStatus(), UCS_ERR_MESSAGE_TRUNCATED);
+    EXPECT_THROW(transfer.probe->getHandle(), std::runtime_error);
+  }
+
+  progressUntilCompleted(transfer, transfer.sendRequest);
+}
+
+TEST_F(WorkerTest, CancelTagRecvWithHandlePreservesImmediateCompletion)
+{
+  int sendBuf{123};
+  auto transfer = makeProbedTagTransfer(&sendBuf, sizeof(sendBuf), true, true);
+  ASSERT_TRUE(transfer.probe->isMatched());
+
+  PausedProgressThread progressThread{transfer.recvWorker};
+  int recvBuf{};
+  auto recvReq =
+    transfer.recvWorker->tagRecvWithHandleBuilder(&recvBuf, sizeof(recvBuf), transfer.probe)
+      .build();
+  recvReq->cancel();
+
+  EXPECT_TRUE(recvReq->isCompleted());
+  EXPECT_EQ(recvReq->getStatus(), UCS_OK);
+  EXPECT_EQ(recvBuf, sendBuf);
+  EXPECT_THROW(transfer.probe->getHandle(), std::runtime_error);
+}
+
+TEST_F(WorkerTest, TagRecvWithHandleConsumesMessageWithZeroLengthBuffer)
+{
+  int sendBuf{123};
+  auto transfer = makeProbedTagTransfer(&sendBuf, sizeof(sendBuf), false);
+  ASSERT_TRUE(transfer.probe->isMatched());
+
+  auto recvReq = transfer.recvWorker->tagRecvWithHandleBuilder(nullptr, 0, transfer.probe).build();
+  EXPECT_THROW(transfer.probe->getHandle(), std::runtime_error);
+  progressUntilCompleted(transfer, recvReq);
+
+  EXPECT_EQ(recvReq->getStatus(), UCS_ERR_MESSAGE_TRUNCATED);
+  progressUntilCompleted(transfer, transfer.sendRequest);
 }
 
 TEST_F(WorkerTest, TagProbeUnconsumedWarning)

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -365,10 +365,10 @@ TEST_F(WorkerTest, TagProbeRemoveWithMessage)
   EXPECT_EQ(recv_buf, buf);
 }
 
-TEST_F(WorkerTest, CancelTagRecvWithHandleBeforeDelayedSubmissionConsumesHandle)
+TEST_F(WorkerTest, CancelTagRecvWithHandleDefersSubmissionToProgressThread)
 {
-  // Keep the transfer in progress after the rendezvous header is matched so cancel() submits
-  // a real UCP request while the delayed callback remains queued.
+  // Keep the transfer in progress after the rendezvous header is matched so delayed submission
+  // produces a real UCP request that must subsequently be canceled.
   std::vector<int> sendBuf(1 << 20, 123);
   auto transfer = makeProbedTagTransfer(sendBuf.data(), sendBuf.size() * sizeof(int), true);
   ASSERT_TRUE(transfer.probe->isMatched());
@@ -383,11 +383,12 @@ TEST_F(WorkerTest, CancelTagRecvWithHandleBeforeDelayedSubmissionConsumesHandle)
       .build();
   recvReq->cancel();
 
-  EXPECT_THROW(transfer.probe->getHandle(), std::runtime_error);
+  EXPECT_NO_THROW(transfer.probe->getHandle());
   EXPECT_FALSE(recvReq->isCompleted());
 
   progressThread.resume();
   progressUntilCompleted(transfer, recvReq, false);
+  EXPECT_THROW(transfer.probe->getHandle(), std::runtime_error);
 }
 
 TEST_F(WorkerTest, TagRecvWithHandleHonorsReceiveBufferLength)
@@ -422,7 +423,11 @@ TEST_F(WorkerTest, CancelTagRecvWithHandleProcessesImmediateTruncation)
         .build();
     recvReq->cancel();
 
-    EXPECT_TRUE(recvReq->isCompleted());
+    EXPECT_FALSE(recvReq->isCompleted());
+    EXPECT_NO_THROW(transfer.probe->getHandle());
+
+    progressThread.resume();
+    progressUntilCompleted(transfer, recvReq, false);
     EXPECT_EQ(recvReq->getStatus(), UCS_ERR_MESSAGE_TRUNCATED);
     EXPECT_THROW(transfer.probe->getHandle(), std::runtime_error);
   }
@@ -443,7 +448,11 @@ TEST_F(WorkerTest, CancelTagRecvWithHandlePreservesImmediateCompletion)
       .build();
   recvReq->cancel();
 
-  EXPECT_TRUE(recvReq->isCompleted());
+  EXPECT_FALSE(recvReq->isCompleted());
+  EXPECT_NO_THROW(transfer.probe->getHandle());
+
+  progressThread.resume();
+  progressUntilCompleted(transfer, recvReq, false);
   EXPECT_EQ(recvReq->getStatus(), UCS_OK);
   EXPECT_EQ(recvBuf, sendBuf);
   EXPECT_THROW(transfer.probe->getHandle(), std::runtime_error);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 [tool.ruff]
 line-length = 88
+
+[tool.cython-lint]
+max-line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "W"]

--- a/python/ucxx/ucxx/_lib/libucxx.pyx
+++ b/python/ucxx/ucxx/_lib/libucxx.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -927,6 +927,7 @@ cdef class UCXWorker():
         the message matching queue again.
         """
         cdef void* buf = <void*>arr.ptr
+        cdef size_t nbytes = arr.nbytes
         cdef shared_ptr[Request] req
         cdef unique_ptr[RequestTagBuilder] builder
 
@@ -939,7 +940,7 @@ cdef class UCXWorker():
         with nogil:
             builder = make_unique[RequestTagBuilder](
                 self._worker.get().tagRecvWithHandleBuilder(
-                    buf, probe_result._probe_info_ptr
+                    buf, nbytes, probe_result._probe_info_ptr
                 )
             )
             builder.get().pythonFuture(self._enable_python_future)
@@ -1541,6 +1542,7 @@ cdef class UCXEndpoint():
         the message matching queue again.
         """
         cdef void* buf = <void*>arr.ptr
+        cdef size_t nbytes = arr.nbytes
         cdef shared_ptr[Request] req
         cdef shared_ptr[Worker] worker
         cdef unique_ptr[RequestTagBuilder] builder
@@ -1555,7 +1557,7 @@ cdef class UCXEndpoint():
             worker = self._endpoint.get().getWorker()
             builder = make_unique[RequestTagBuilder](
                 worker.get().tagRecvWithHandleBuilder(
-                    buf, probe_result._probe_info_ptr
+                    buf, nbytes, probe_result._probe_info_ptr
                 )
             )
             builder.get().pythonFuture(self._enable_python_future)

--- a/python/ucxx/ucxx/_lib/ucxx_api.pxd
+++ b/python/ucxx/ucxx/_lib/ucxx_api.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -326,6 +326,7 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
         )
         RequestTagBuilder tagRecvWithHandleBuilder(
             void* buffer,
+            size_t length,
             shared_ptr[TagProbeInfo] probe_info
         )
         bint isDelayedRequestSubmissionEnabled() const

--- a/python/ucxx/ucxx/_lib_async/endpoint.py
+++ b/python/ucxx/ucxx/_lib_async/endpoint.py
@@ -450,8 +450,8 @@ class Endpoint:
         except Exception:
             # Only probe the worker as last resort. To be reliable, probing for the tag
             # requires progressing the worker, thus prevent that happening too often.
-            ctx = self._ctx
-            if ctx is None or not ctx.worker.tag_probe(tag).matched:
+            worker = None if self._ctx is None else self._ctx.worker
+            if worker is None or not worker.tag_probe(tag).matched:
                 raise
 
             if not isinstance(buffer, Array):
@@ -460,7 +460,7 @@ class Endpoint:
             # Reserve the matched message and receive it directly on the worker. A tag
             # receive submitted on an endpoint that has already closed would immediately
             # be scheduled for cancelation.
-            probe_info = ctx.worker.tag_probe(tag, remove=True)
+            probe_info = worker.tag_probe(tag, remove=True)
             if not probe_info.matched:
                 raise
 
@@ -484,7 +484,7 @@ class Endpoint:
         if probe_info is None:
             req = self._ep.tag_recv(buffer, tag, TagMaskFull)
         else:
-            req = ctx.worker.tag_recv_with_handle(buffer, probe_info)
+            req = worker.tag_recv_with_handle(buffer, probe_info)
 
         try:
             ret = await req.wait()
@@ -495,13 +495,13 @@ class Endpoint:
             # worker-owned receive cancelation must always propagate.
             if probe_info is not None:
                 raise
-            ctx = self._ctx
-            if ctx is None:
+            worker = None if self._ctx is None else self._ctx.worker
+            if worker is None:
                 raise
-            probe_info = ctx.worker.tag_probe(tag, remove=True)
+            probe_info = worker.tag_probe(tag, remove=True)
             if not probe_info.matched:
                 raise
-            req = ctx.worker.tag_recv_with_handle(buffer, probe_info)
+            req = worker.tag_recv_with_handle(buffer, probe_info)
             ret = await req.wait()
 
         self._finished_recv_count += 1

--- a/python/ucxx/ucxx/_lib_async/endpoint.py
+++ b/python/ucxx/ucxx/_lib_async/endpoint.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -442,15 +442,27 @@ class Endpoint:
         if not isinstance(tag, Tag):
             tag = Tag(tag)
 
+        probe_info = None
         try:
             self._ep.raise_on_error()
             if self.closed:
                 raise UCXCloseError("Endpoint closed")
-        except Exception as e:
+        except Exception:
             # Only probe the worker as last resort. To be reliable, probing for the tag
             # requires progressing the worker, thus prevent that happening too often.
-            if not self._ctx.worker.tag_probe(tag).matched:
-                raise e
+            ctx = self._ctx
+            if ctx is None or not ctx.worker.tag_probe(tag).matched:
+                raise
+
+            if not isinstance(buffer, Array):
+                buffer = Array(buffer)
+
+            # Reserve the matched message and receive it directly on the worker. A tag
+            # receive submitted on an endpoint that has already closed would immediately
+            # be scheduled for cancelation.
+            probe_info = ctx.worker.tag_probe(tag, remove=True)
+            if not probe_info.matched:
+                raise
 
         if not isinstance(buffer, Array):
             buffer = Array(buffer)
@@ -469,8 +481,28 @@ class Endpoint:
 
         self._recv_count += 1
 
-        req = self._ep.tag_recv(buffer, tag, TagMaskFull)
-        ret = await req.wait()
+        if probe_info is None:
+            req = self._ep.tag_recv(buffer, tag, TagMaskFull)
+        else:
+            req = ctx.worker.tag_recv_with_handle(buffer, probe_info)
+
+        try:
+            ret = await req.wait()
+        except UCXCanceled:
+            # The endpoint may close after the initial status check but before a delayed
+            # receive is submitted. If its message is already queued on the worker,
+            # reserve and receive it there; otherwise preserve the cancelation. A
+            # worker-owned receive cancelation must always propagate.
+            if probe_info is not None:
+                raise
+            ctx = self._ctx
+            if ctx is None:
+                raise
+            probe_info = ctx.worker.tag_probe(tag, remove=True)
+            if not probe_info.matched:
+                raise
+            req = ctx.worker.tag_recv_with_handle(buffer, probe_info)
+            ret = await req.wait()
 
         self._finished_recv_count += 1
         if (

--- a/python/ucxx/ucxx/_lib_async/tests/test_endpoint.py
+++ b/python/ucxx/ucxx/_lib_async/tests/test_endpoint.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import asyncio
@@ -7,7 +7,158 @@ from queue import Empty, Queue
 import pytest
 
 import ucxx
+from ucxx._lib.libucxx import UCXCanceled, UCXCloseError, UCXMessageTruncatedError
+from ucxx._lib_async.endpoint import Endpoint
 from ucxx._lib_async.utils_test import wait_listener_client_handlers
+from ucxx.types import Tag
+
+
+class _MatchedProbe:
+    def __init__(self, tag, message, remove):
+        self.matched = True
+        self.sender_tag = tag
+        self.length = len(message)
+        self.handle = object() if remove else None
+        self.message = message
+
+
+class _UnmatchedProbe:
+    matched = False
+    sender_tag = None
+    length = 0
+    handle = None
+
+
+class _CompletedReceive:
+    def __init__(self, buffer, message):
+        self._buffer = buffer
+        self._message = message
+
+    async def wait(self):
+        self._buffer.obj[:] = self._message
+
+
+class _CanceledReceive:
+    async def wait(self):
+        raise UCXCanceled("Request canceled")
+
+
+class _TruncatedReceive:
+    async def wait(self):
+        raise UCXMessageTruncatedError("Message truncated")
+
+
+class _WorkerWithMatchedMessage:
+    def __init__(self, message):
+        self.message = message
+
+    def tag_probe(self, tag, remove=False):
+        if self.message is None:
+            return _UnmatchedProbe()
+        probe = _MatchedProbe(tag, self.message, remove)
+        if remove:
+            self.message = None
+        return probe
+
+    def tag_recv_with_handle(self, buffer, probe_result):
+        if probe_result.handle is None:
+            raise ValueError("TagProbeResult does not own the matched message")
+        if buffer.nbytes < probe_result.length:
+            return _TruncatedReceive()
+        return _CompletedReceive(buffer, probe_result.message)
+
+
+class _WorkerCancelingMatchedReceive(_WorkerWithMatchedMessage):
+    def __init__(self, message):
+        super().__init__(message)
+        self._receive_attempts = 0
+
+    def tag_recv_with_handle(self, buffer, probe_result):
+        self._receive_attempts += 1
+        if self._receive_attempts == 1:
+            return _CanceledReceive()
+        return super().tag_recv_with_handle(buffer, probe_result)
+
+
+class _ContextWithMatchedMessage:
+    def __init__(self, worker):
+        self.worker = worker
+
+
+class _ClosedEndpoint:
+    alive = False
+    handle = 1
+
+    def raise_on_error(self):
+        raise UCXCloseError("Endpoint closed")
+
+    def tag_recv(self, buffer, tag, tag_mask):
+        raise AssertionError("receive was submitted on a closed endpoint")
+
+
+class _EndpointClosingDuringReceive(_ClosedEndpoint):
+    alive = True
+
+    def raise_on_error(self):
+        pass
+
+    def tag_recv(self, buffer, tag, tag_mask):
+        return _CanceledReceive()
+
+
+def _endpoint_with_matched_message(low_level_endpoint, worker):
+    endpoint = Endpoint.__new__(Endpoint)
+    endpoint._ep = low_level_endpoint
+    endpoint._ctx = _ContextWithMatchedMessage(worker)
+    endpoint._tags = {"msg_recv": Tag(1)}
+    endpoint._recv_count = 0
+    endpoint._finished_recv_count = 0
+    endpoint._close_after_n_recv = None
+    return endpoint
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "low_level_endpoint",
+    [_ClosedEndpoint(), _EndpointClosingDuringReceive()],
+    ids=["already-closed", "closes-during-submission"],
+)
+async def test_recv_matched_message_after_endpoint_closes(low_level_endpoint):
+    message = b"message received before endpoint closed"
+    worker = _WorkerWithMatchedMessage(message)
+    endpoint = _endpoint_with_matched_message(low_level_endpoint, worker)
+    received = bytearray(len(message))
+
+    await endpoint.recv(received)
+
+    assert received == message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "low_level_endpoint",
+    [_ClosedEndpoint(), _EndpointClosingDuringReceive()],
+    ids=["already-closed", "closes-during-submission"],
+)
+async def test_recv_matched_message_after_endpoint_closes_buffer_too_small(
+    low_level_endpoint,
+):
+    message = b"message received before endpoint closed"
+    worker = _WorkerWithMatchedMessage(message)
+    endpoint = _endpoint_with_matched_message(low_level_endpoint, worker)
+
+    with pytest.raises(UCXMessageTruncatedError):
+        await endpoint.recv(bytearray(len(message) - 1))
+
+
+@pytest.mark.asyncio
+async def test_recv_worker_cancelation_is_not_retried():
+    message = b"message received before endpoint closed"
+    worker = _WorkerCancelingMatchedReceive(message)
+    endpoint = _endpoint_with_matched_message(_ClosedEndpoint(), worker)
+
+    with pytest.raises(UCXCanceled):
+        await endpoint.recv(bytearray(len(message)))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Allow `Endpoint.recv()` to recover a matching message already queued on the UCX worker when the endpoint closes or its receive is canceled.

The change reserves the queued message and receives it directly through the worker. It also:

- Uses the destination buffer length for handle-based receives.
- Safely consumes reserved message handles during cancellation.
- Synchronizes delayed submission to prevent duplicate request submission.

## Problem

A peer may close its endpoint after sending, leaving the message queued on the receiving worker. Previously, `Endpoint.recv()` could raise `UCXCloseError` or `UCXCanceled` even though the requested payload was available.

This change preserves that queued message and delivers it, while retaining cancellation when no matching message exists. Tests cover endpoint closure, undersized buffers, immediate completion, and cancellation behavior.

This is expected to resolve a problem exposed by #729 , therefore should be merged before that PR.