### PR TITLE
pre-commit: update to cython-lint 0.21.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.15.0
+    rev: v0.21.1
     hooks:
       - id: cython-lint
   - repo: https://github.com/pre-commit/mirrors-clang-format


### PR DESCRIPTION
The latest Cython release caused some compatibility issues for older `cython-lint` versions: https://github.com/MarcoGorelli/cython-lint/issues/201

This updates to the latest `cython-lint`, which contains a fix.