### PR TITLE
Only disable CUDA IPC in CI when UCX 1.21.* is present

### DIFF
--- a/ci/run_cpp.sh
+++ b/ci/run_cpp.sh
@@ -5,12 +5,11 @@
 
 set -euo pipefail
 
-# See https://github.com/rapidsai/ucxx/issues/733
-export UCX_TLS=^cuda_ipc
-
 TIMEOUT_TOOL_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/timeout_with_stack.py
 
 source "$(dirname "$0")/test_common.sh"
+
+configure_ucx_tls
 
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../

--- a/ci/run_cpp_benchmarks.sh
+++ b/ci/run_cpp_benchmarks.sh
@@ -5,12 +5,11 @@
 
 set -euo pipefail
 
-# See https://github.com/rapidsai/ucxx/issues/733
-export UCX_TLS=^cuda_ipc
-
 TIMEOUT_TOOL_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/timeout_with_stack.py
 
 source "$(dirname "$0")/test_common.sh"
+
+configure_ucx_tls
 
 # Support invoking run_cpp_benchmarks.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../

--- a/ci/run_python.sh
+++ b/ci/run_python.sh
@@ -5,12 +5,11 @@
 
 set -euo pipefail
 
-# See https://github.com/rapidsai/ucxx/issues/733
-export UCX_TLS=^cuda_ipc
-
 TIMEOUT_TOOL_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/timeout_with_stack.py
 
 source "$(dirname "$0")/test_common.sh"
+
+configure_ucx_tls
 
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../

--- a/ci/run_python_distributed.sh
+++ b/ci/run_python_distributed.sh
@@ -5,12 +5,11 @@
 
 set -euo pipefail
 
-# See https://github.com/rapidsai/ucxx/issues/733
-export UCX_TLS=^cuda_ipc
-
 TIMEOUT_TOOL_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/timeout_with_stack.py
 
 source "$(dirname "$0")/test_common.sh"
+
+configure_ucx_tls
 
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../

--- a/ci/test_common.sh
+++ b/ci/test_common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -euo pipefail
@@ -37,6 +37,18 @@ print_ucx_config() {
   rapids-logger "UCX Version and Build Configuration"
 
   ucx_info -v
+}
+
+configure_ucx_tls() {
+  local ucx_version
+
+  ucx_version="$(ucx_info -v | sed -nE 's/^# Library version: ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -n 1)"
+
+  # See https://github.com/rapidsai/ucxx/issues/733
+  # TODO: Remove when UCX 1.23 or higher becomes minimum supported.
+  if [[ "${ucx_version}" == 1.21.* ]]; then
+    export UCX_TLS=^cuda_ipc
+  fi
 }
 
 run_port_retry() {

--- a/ci/test_common.sh
+++ b/ci/test_common.sh
@@ -42,7 +42,13 @@ print_ucx_config() {
 configure_ucx_tls() {
   local ucx_version
 
-  ucx_version="$(ucx_info -v | sed -nE 's/^# Library version: ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -n 1)"
+  if command -v ucx_info > /dev/null; then
+    ucx_version="$(ucx_info -v | sed -nE 's/^# Library version: ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -n 1)"
+  else
+    # ucx_info is not always available (wheels do not ship executables). Rely on
+    # Python to determine UCX version as a fallback.
+    ucx_version="$(python -c 'import ucxx; print(ucxx.__ucx_version__)')"
+  fi
 
   # See https://github.com/rapidsai/ucxx/issues/733
   # TODO: Remove when UCX 1.23 or higher becomes minimum supported.


### PR DESCRIPTION
An issue in UCX v1.21 has forced us to disable CUDA IPC, see #733 . The issue is confirmed to have already been resolved in v1.22 and above, therefore we can only disable CUDA IPC for the one bad version.

Closes #733 .