### PR TITLE
Enable public docs features in CI

### DIFF
--- a/docs/ucxx/source/conf.py
+++ b/docs/ucxx/source/conf.py
@@ -6,6 +6,7 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import datetime
+import os
 
 import ucxx
 from packaging.version import Version
@@ -72,6 +73,7 @@ exclude_patterns = []
 pygments_style = "sphinx"
 
 html_theme_options = {
+    "public_docs_features": os.environ.get("CI") == "true",
     "external_links": [],
     # https://github.com/pydata/pydata-sphinx-theme/issues/1220
     "icon_links": [],


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/319

Enable the Sphinx theme's `public_docs_features` option when `CI=true`, while leaving local documentation builds unchanged.
