### PR TITLE
Migrate stream APIs from rmm::cuda_stream_view to cuda::stream_ref

### DIFF
--- a/cpp/benchmarks/include/buffer_interface.hpp
+++ b/cpp/benchmarks/include/buffer_interface.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -740,9 +740,9 @@ inline void initialize_send_pattern(rmm::device_buffer& send, std::size_t messag
                                      pattern.data(),
                                      messageSize,
                                      cudaMemcpyHostToDevice,
-                                     send.stream()),
+                                     send.stream().get()),
                      "RMM send buffer initialization");
-  CUDA_EXIT_ON_ERROR(cudaStreamSynchronize(send.stream()), "RMM stream synchronization");
+  CUDA_EXIT_ON_ERROR(cudaStreamSynchronize(send.stream().get()), "RMM stream synchronization");
 }
 
 inline void verify_device_buffers(rmm::device_buffer& send,
@@ -755,17 +755,17 @@ inline void verify_device_buffers(rmm::device_buffer& send,
                                      send.data(),
                                      messageSize,
                                      cudaMemcpyDeviceToHost,
-                                     send.stream()),
+                                     send.stream().get()),
                      "RMM send data copy for verification");
   CUDA_EXIT_ON_ERROR(cudaMemcpyAsync(recvData.data(),
                                      recv.data(),
                                      messageSize,
                                      cudaMemcpyDeviceToHost,
-                                     recv.stream()),
+                                     recv.stream().get()),
                      "RMM recv data copy for verification");
-  CUDA_EXIT_ON_ERROR(cudaStreamSynchronize(send.stream()),
+  CUDA_EXIT_ON_ERROR(cudaStreamSynchronize(send.stream().get()),
                      "RMM send stream synchronization for verification");
-  CUDA_EXIT_ON_ERROR(cudaStreamSynchronize(recv.stream()),
+  CUDA_EXIT_ON_ERROR(cudaStreamSynchronize(recv.stream().get()),
                      "RMM recv stream synchronization for verification");
   for (std::size_t j = 0; j < messageSize; ++j)
     if (recvData[j] != sendData[j])

--- a/cpp/benchmarks/include/buffer_interface.hpp
+++ b/cpp/benchmarks/include/buffer_interface.hpp
@@ -19,8 +19,8 @@
 #endif
 
 #ifdef UCXX_BENCHMARKS_ENABLE_RMM
+#include <cuda/stream>
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_async_managed_memory_resource.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
@@ -780,8 +780,8 @@ struct RmmDeviceMrBuffers {
   static std::shared_ptr<RmmDeviceMrBuffers> allocate(std::size_t messageSize)
   {
     auto p    = std::make_shared<RmmDeviceMrBuffers>();
-    p->send   = std::make_unique<rmm::device_buffer>(messageSize, rmm::cuda_stream_default, p->mr);
-    p->recv   = std::make_unique<rmm::device_buffer>(messageSize, rmm::cuda_stream_default, p->mr);
+    p->send   = std::make_unique<rmm::device_buffer>(messageSize, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, p->mr);
+    p->recv   = std::make_unique<rmm::device_buffer>(messageSize, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, p->mr);
     initialize_send_pattern(*p->send, messageSize);
     return p;
   }
@@ -795,8 +795,8 @@ struct RmmPoolBuffers {
   explicit RmmPoolBuffers(std::size_t messageSize)
     : pool(rmm::mr::cuda_memory_resource{}, rmm_benchmark_detail::initial_pool_size(messageSize))
   {
-    send     = std::make_unique<rmm::device_buffer>(messageSize, rmm::cuda_stream_default, pool);
-    recv     = std::make_unique<rmm::device_buffer>(messageSize, rmm::cuda_stream_default, pool);
+    send     = std::make_unique<rmm::device_buffer>(messageSize, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, pool);
+    recv     = std::make_unique<rmm::device_buffer>(messageSize, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, pool);
     rmm_benchmark_detail::initialize_send_pattern(*send, messageSize);
   }
 
@@ -814,8 +814,8 @@ struct RmmCudaAsyncMrBuffers {
   static std::shared_ptr<RmmCudaAsyncMrBuffers> allocate(std::size_t messageSize)
   {
     auto p   = std::make_shared<RmmCudaAsyncMrBuffers>();
-    p->send  = std::make_unique<rmm::device_buffer>(messageSize, rmm::cuda_stream_default, p->mr);
-    p->recv  = std::make_unique<rmm::device_buffer>(messageSize, rmm::cuda_stream_default, p->mr);
+    p->send  = std::make_unique<rmm::device_buffer>(messageSize, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, p->mr);
+    p->recv  = std::make_unique<rmm::device_buffer>(messageSize, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, p->mr);
     initialize_send_pattern(*p->send, messageSize);
     return p;
   }
@@ -829,8 +829,8 @@ struct RmmCudaAsyncManagedMrBuffers {
   static std::shared_ptr<RmmCudaAsyncManagedMrBuffers> allocate(std::size_t messageSize)
   {
     auto p   = std::make_shared<RmmCudaAsyncManagedMrBuffers>();
-    p->send  = std::make_unique<rmm::device_buffer>(messageSize, rmm::cuda_stream_default, p->mr);
-    p->recv  = std::make_unique<rmm::device_buffer>(messageSize, rmm::cuda_stream_default, p->mr);
+    p->send  = std::make_unique<rmm::device_buffer>(messageSize, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, p->mr);
+    p->recv  = std::make_unique<rmm::device_buffer>(messageSize, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, p->mr);
     initialize_send_pattern(*p->send, messageSize);
     return p;
   }

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>
@@ -27,6 +27,7 @@
 #endif
 
 #if UCXX_TESTS_ENABLE_RMM
+#include <cuda/stream>
 #include <rmm/device_buffer.hpp>
 #endif
 
@@ -58,7 +59,8 @@ class RMMTestBuffer : public ucxx::Buffer {
  public:
   explicit RMMTestBuffer(size_t size)
     : ucxx::Buffer(ucxx::BufferType::Invalid, size),
-      _buffer{std::make_unique<rmm::device_buffer>(size, rmm::cuda_stream_default)}
+      _buffer{std::make_unique<rmm::device_buffer>(
+        size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}})}
   {
   }
 
@@ -205,7 +207,10 @@ class RequestTest
       if (allocateRecvBuffer) _recvPtr[i] = _recvBuffer[i]->data();
     }
 #if UCXX_TESTS_ENABLE_RMM
-    if (_bufferType == TestBufferType::RMM) { rmm::cuda_stream_default.synchronize(); }
+    if (_bufferType == TestBufferType::RMM) {
+      auto stream = cuda::stream_ref{cudaStream_t { cudaStreamDefault }};
+      stream.sync();
+    }
 #endif
     if (_bufferType == TestBufferType::CCCL) { cudaStreamSynchronize(nullptr); }
   }
@@ -215,7 +220,10 @@ class RequestTest
     for (size_t i = 0; i < _numBuffers; ++i)
       copyMemoryTypeAware(_recv[i].data(), _recvPtr[i], _messageSize, false);
 #if UCXX_TESTS_ENABLE_RMM
-    if (_bufferType == TestBufferType::RMM) { rmm::cuda_stream_default.synchronize(); }
+    if (_bufferType == TestBufferType::RMM) {
+      auto stream = cuda::stream_ref{cudaStream_t { cudaStreamDefault }};
+      stream.sync();
+    }
 #endif
     if (_bufferType == TestBufferType::CCCL) { cudaStreamSynchronize(nullptr); }
   }
@@ -226,9 +234,9 @@ class RequestTest
       memcpy(dst, src, size);
 #if UCXX_TESTS_ENABLE_RMM
     } else if (_memoryType == UCS_MEMORY_TYPE_CUDA && _bufferType == TestBufferType::RMM) {
-      RMM_CUDA_TRY(
-        cudaMemcpyAsync(dst, src, size, cudaMemcpyDefault, rmm::cuda_stream_default.value()));
-      if (synchronize) rmm::cuda_stream_default.synchronize();
+      auto stream = cuda::stream_ref{cudaStream_t { cudaStreamDefault }};
+      RMM_CUDA_TRY(cudaMemcpyAsync(dst, src, size, cudaMemcpyDefault, stream.get()));
+      if (synchronize) { stream.sync(); }
 #endif
     } else if (_memoryType == UCS_MEMORY_TYPE_CUDA) {
       cudaMemcpyAsync(dst, src, size, cudaMemcpyDefault, nullptr);


### PR DESCRIPTION
## Summary

Track the coordinated migration of stream APIs and call sites from `rmm::cuda_stream_view` to CCCL's `cuda::stream_ref`. This propagates `cuda::stream_ref` through RMM containers and memory resources, RAFT resource and handle APIs, downstream C++ interfaces, Python/Cython bindings, benchmarks, tests, and documentation.

This updates UCXX RMM-backed tests and benchmarks to construct CUDA Core default stream references, synchronize them with `.sync()`, and extract raw handles for CUDA runtime calls.

Depends on rapidsai/rmm#2372.

Tracked in rapidsai/build-planning#318.

## Migrations

- Pass `cuda::stream_ref` through stream pools, resource accessors, conditionals, and downstream APIs without converting to `rmm::cuda_stream_view`
- Use `cuda::stream_ref` constructions for default/legacy/per-thread streams
  - `rmm::cuda_stream_default` ➡️ `cuda::stream_ref{cudaStream_t{cudaStreamDefault}}`
  - `rmm::cuda_stream_legacy` ➡️ `cuda::stream_ref{cudaStreamLegacy}`
  - `rmm::cuda_stream_per_thread` ➡️ `cuda::stream_ref{cudaStreamPerThread}`
- Use `.get()` when calling an API that requires a raw `cudaStream_t`, including CUDA runtime, library, CUB, and legacy API boundaries (previously `rmm::cuda_stream_view` used `value()`)
- Use `.sync()` when synchronizing a `cuda::stream_ref` (previously `rmm::cuda_stream_view` used `synchronize()`)
- Update Cython declarations and call sites to pass stream references directly where supported
