### PR TITLE
Remove deprecated C++ constructors for v0.52

### DIFF
--- a/conda/recipes/libucxx/recipe.yaml
+++ b/conda/recipes/libucxx/recipe.yaml
@@ -121,7 +121,7 @@ outputs:
             - include/ucxx/buffer.h
             - include/ucxx/component.h
             - include/ucxx/config.h
-            - include/ucxx/constructors.h
+            - include/ucxx/detail/constructors.h
             - include/ucxx/context.h
             - include/ucxx/delayed_submission.h
             - include/ucxx/endpoint.h

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =================================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 # cmake-format: on
 # =================================================================================
@@ -183,7 +183,6 @@ set_target_properties(
 )
 
 target_compile_options(ucxx PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${UCXX_CXX_FLAGS}>")
-target_compile_definitions(ucxx PRIVATE UCXX_DISABLE_DEPRECATED_NON_BUILDER_CONSTRUCTOR_WARNINGS)
 
 # Specify include paths for the current target and dependents
 target_include_directories(

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -37,10 +37,6 @@ function(ConfigureBench CMAKE_BENCH_NAME)
                CXX_STANDARD_REQUIRED ON
   )
   target_link_libraries(${CMAKE_BENCH_NAME} PRIVATE ucxx $<TARGET_NAME_IF_EXISTS:conda_env>)
-  target_compile_definitions(
-    ${CMAKE_BENCH_NAME} PRIVATE UCXX_DISABLE_DEPRECATED_NON_BUILDER_CONSTRUCTOR_WARNINGS
-  )
-
   # Add CUDA support if enabled
   if(UCXX_BENCHMARKS_ENABLE_CUDA)
     target_compile_definitions(${CMAKE_BENCH_NAME} PRIVATE UCXX_BENCHMARKS_ENABLE_CUDA)

--- a/cpp/benchmarks/perftest.cpp
+++ b/cpp/benchmarks/perftest.cpp
@@ -801,13 +801,17 @@ class Application {
                                             {DirectionType::Recv, std::vector<char>(3, 0)}});
 
     // Schedule small wireup messages to let UCX identify capabilities between endpoints
-    requests.push_back(_endpoint->tagSend((*wireupBufferMap)[DirectionType::Send].data(),
+    requests.push_back(_endpoint
+                         ->tagSendBuilder((*wireupBufferMap)[DirectionType::Send].data(),
                                           (*wireupBufferMap)[DirectionType::Send].size(),
-                                          (*_tagMap)[DirectionType::Send]));
-    requests.push_back(_endpoint->tagRecv((*wireupBufferMap)[DirectionType::Recv].data(),
+                                          (*_tagMap)[DirectionType::Send])
+                         .build());
+    requests.push_back(_endpoint
+                         ->tagRecvBuilder((*wireupBufferMap)[DirectionType::Recv].data(),
                                           (*wireupBufferMap)[DirectionType::Recv].size(),
                                           (*_tagMap)[DirectionType::Recv],
-                                          ucxx::TagMaskFull));
+                                          ucxx::TagMaskFull)
+                         .build());
 
     // In loopback mode, also schedule the peer (server-side) wireup
     std::shared_ptr<BufferMap> peerWireupBufferMap;
@@ -816,13 +820,17 @@ class Application {
         std::make_shared<BufferMap>(BufferMap{{DirectionType::Send, std::vector<char>{1, 2, 3}},
                                               {DirectionType::Recv, std::vector<char>(3, 0)}});
 
-      requests.push_back(_peerEndpoint->tagSend((*peerWireupBufferMap)[DirectionType::Send].data(),
-                                                (*peerWireupBufferMap)[DirectionType::Send].size(),
-                                                (*_peerTagMap)[DirectionType::Send]));
-      requests.push_back(_peerEndpoint->tagRecv((*peerWireupBufferMap)[DirectionType::Recv].data(),
-                                                (*peerWireupBufferMap)[DirectionType::Recv].size(),
-                                                (*_peerTagMap)[DirectionType::Recv],
-                                                ucxx::TagMaskFull));
+      requests.push_back(_peerEndpoint
+                           ->tagSendBuilder((*peerWireupBufferMap)[DirectionType::Send].data(),
+                                            (*peerWireupBufferMap)[DirectionType::Send].size(),
+                                            (*_peerTagMap)[DirectionType::Send])
+                           .build());
+      requests.push_back(_peerEndpoint
+                           ->tagRecvBuilder((*peerWireupBufferMap)[DirectionType::Recv].data(),
+                                            (*peerWireupBufferMap)[DirectionType::Recv].size(),
+                                            (*_peerTagMap)[DirectionType::Recv],
+                                            ucxx::TagMaskFull)
+                           .build());
     }
 
     // Wait for wireup requests and clear requests
@@ -884,38 +892,55 @@ class Application {
     auto start = std::chrono::high_resolution_clock::now();
     if (_appContext.testAttributes->testType == TestType::PingPong) {
       requests = {
-        _endpoint->tagSend(
-          bufferInterface->getSendPtr(), _appContext.messageSize, (*_tagMap)[DirectionType::Send]),
-        _endpoint->tagRecv(bufferInterface->getRecvPtr(),
+        _endpoint
+          ->tagSendBuilder(
+            bufferInterface->getSendPtr(), _appContext.messageSize, (*_tagMap)[DirectionType::Send])
+          .build(),
+        _endpoint
+          ->tagRecvBuilder(bufferInterface->getRecvPtr(),
                            _appContext.messageSize,
                            (*_tagMap)[DirectionType::Recv],
-                           ucxx::TagMaskFull)};
+                           ucxx::TagMaskFull)
+          .build()};
       if (_appContext.loopback) {
-        requests.push_back(_peerEndpoint->tagSend(peerBufferInterface->getSendPtr(),
-                                                  _appContext.messageSize,
-                                                  (*_peerTagMap)[DirectionType::Send]));
-        requests.push_back(_peerEndpoint->tagRecv(peerBufferInterface->getRecvPtr(),
-                                                  _appContext.messageSize,
-                                                  (*_peerTagMap)[DirectionType::Recv],
-                                                  ucxx::TagMaskFull));
+        requests.push_back(_peerEndpoint
+                             ->tagSendBuilder(peerBufferInterface->getSendPtr(),
+                                              _appContext.messageSize,
+                                              (*_peerTagMap)[DirectionType::Send])
+                             .build());
+        requests.push_back(_peerEndpoint
+                             ->tagRecvBuilder(peerBufferInterface->getRecvPtr(),
+                                              _appContext.messageSize,
+                                              (*_peerTagMap)[DirectionType::Recv],
+                                              ucxx::TagMaskFull)
+                             .build());
       }
     } else {
       if (_appContext.loopback) {
-        requests = {_endpoint->tagSend(bufferInterface->getSendPtr(),
+        requests = {_endpoint
+                      ->tagSendBuilder(bufferInterface->getSendPtr(),
                                        _appContext.messageSize,
-                                       (*_tagMap)[DirectionType::Send]),
-                    _peerEndpoint->tagRecv(peerBufferInterface->getRecvPtr(),
-                                           _appContext.messageSize,
-                                           (*_peerTagMap)[DirectionType::Recv],
-                                           ucxx::TagMaskFull)};
+                                       (*_tagMap)[DirectionType::Send])
+                      .build(),
+                    _peerEndpoint
+                      ->tagRecvBuilder(peerBufferInterface->getRecvPtr(),
+                                       _appContext.messageSize,
+                                       (*_peerTagMap)[DirectionType::Recv],
+                                       ucxx::TagMaskFull)
+                      .build()};
       } else if (_isServer) {
-        requests = {_endpoint->tagRecv(bufferInterface->getRecvPtr(),
+        requests = {_endpoint
+                      ->tagRecvBuilder(bufferInterface->getRecvPtr(),
                                        _appContext.messageSize,
                                        (*_tagMap)[DirectionType::Recv],
-                                       ucxx::TagMaskFull)};
+                                       ucxx::TagMaskFull)
+                      .build()};
       } else {
-        requests = {_endpoint->tagSend(
-          bufferInterface->getSendPtr(), _appContext.messageSize, (*_tagMap)[DirectionType::Send])};
+        requests = {_endpoint
+                      ->tagSendBuilder(bufferInterface->getSendPtr(),
+                                       _appContext.messageSize,
+                                       (*_tagMap)[DirectionType::Send])
+                      .build()};
       }
     }
 

--- a/cpp/benchmarks/perftest.cpp
+++ b/cpp/benchmarks/perftest.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <sched.h>   // for cpu_set_t, CPU_SET, CPU_ZERO, sched_setaffinity
@@ -184,7 +184,8 @@ class ListenerContext {
   {
     if (!isAvailable()) throw std::runtime_error("Listener context already has an endpoint");
 
-    _endpoint    = _listener->createEndpointFromConnRequest(connRequest, _endpointErrorHandling);
+    _endpoint =
+      _listener->endpointBuilder(connRequest).endpointErrorHandling(_endpointErrorHandling).build();
     _isAvailable = false;
   }
 
@@ -1017,8 +1018,8 @@ class Application {
         appContext.progressMode == ProgressMode::Wait) {
       ucpFeatures |= UCP_FEATURE_WAKEUP;
     }
-    _context = UCXX_EXIT_ON_ERROR(ucxx::createContext({}, ucpFeatures), "Context creation");
-    _worker  = UCXX_EXIT_ON_ERROR(_context->createWorker(), "Worker creation");
+    _context = UCXX_EXIT_ON_ERROR(ucxx::contextBuilder(ucpFeatures).build(), "Context creation");
+    _worker  = UCXX_EXIT_ON_ERROR(_context->workerBuilder().build(), "Worker creation");
 
     if (_appContext.loopback) {
       // In loopback mode, _endpoint acts as the "client" side and
@@ -1042,7 +1043,8 @@ class Application {
       _listenerContext =
         std::make_unique<ListenerContext>(_worker, _appContext.endpointErrorHandling);
       _listener = UCXX_EXIT_ON_ERROR(
-        _worker->createListener(_appContext.listenerPort, listenerCallback, _listenerContext.get()),
+        _worker->listenerBuilder(_appContext.listenerPort, listenerCallback, _listenerContext.get())
+          .build(),
         "Listener creation");
       _listenerContext->setListener(_listener);
     }
@@ -1059,10 +1061,10 @@ class Application {
 
     if (_appContext.loopback) {
       // Connect to our own listener
-      _endpoint = UCXX_EXIT_ON_ERROR(
-        _worker->createEndpointFromHostname(
-          "127.0.0.1", _appContext.listenerPort, _appContext.endpointErrorHandling),
-        "Self-endpoint creation");
+      _endpoint = UCXX_EXIT_ON_ERROR(_worker->endpointBuilder("127.0.0.1", _appContext.listenerPort)
+                                       .endpointErrorHandling(_appContext.endpointErrorHandling)
+                                       .build(),
+                                     "Self-endpoint creation");
 
       // Wait for the listener to accept our connection
       while (_listenerContext->isAvailable())
@@ -1085,8 +1087,9 @@ class Application {
         appContext.testAttributes->description, appContext.memoryType, appContext.memoryType);
     } else {
       _endpoint = UCXX_EXIT_ON_ERROR(
-        _worker->createEndpointFromHostname(
-          _appContext.serverAddress, _appContext.listenerPort, _appContext.endpointErrorHandling),
+        _worker->endpointBuilder(_appContext.serverAddress, _appContext.listenerPort)
+          .endpointErrorHandling(_appContext.endpointErrorHandling)
+          .build(),
         "Endpoint creation");
       printClientHeader(appContext.testAttributes->category);
     }

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =================================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 # cmake-format: on
 # =================================================================================
@@ -31,9 +31,6 @@ function(ConfigureBench CMAKE_BENCH_NAME)
                CXX_STANDARD_REQUIRED ON
   )
   target_link_libraries(${CMAKE_BENCH_NAME} PRIVATE ucxx $<TARGET_NAME_IF_EXISTS:conda_env>)
-  target_compile_definitions(
-    ${CMAKE_BENCH_NAME} PRIVATE UCXX_DISABLE_DEPRECATED_NON_BUILDER_CONSTRUCTOR_WARNINGS
-  )
   if(UCXX_ENABLE_CCCL)
     find_package(CUDAToolkit REQUIRED)
     target_link_libraries(${CMAKE_BENCH_NAME} PRIVATE CUDA::cudart_static)

--- a/cpp/examples/basic.cpp
+++ b/cpp/examples/basic.cpp
@@ -324,10 +324,15 @@ int main(int argc, char** argv)
     recvBuffers.push_back(allocateBuffer(args.recv_buf_type, v->getSize()));
 
   // Schedule small wireup messages to let UCX identify capabilities between endpoints
-  requests.push_back(listener_ctx->getEndpoint()->tagSend(
-    sendWireupBuffer->data(), sendWireupBuffer->getSize(), ucxx::Tag{0}));
-  requests.push_back(endpoint->tagRecv(
-    recvWireupBuffer->data(), sendWireupBuffer->getSize(), ucxx::Tag{0}, ucxx::TagMaskFull));
+  requests.push_back(
+    listener_ctx->getEndpoint()
+      ->tagSendBuilder(sendWireupBuffer->data(), sendWireupBuffer->getSize(), ucxx::Tag{0})
+      .build());
+  requests.push_back(
+    endpoint
+      ->tagRecvBuilder(
+        recvWireupBuffer->data(), sendWireupBuffer->getSize(), ucxx::Tag{0}, ucxx::TagMaskFull)
+      .build());
   ::waitRequests(args.progress_mode, worker, requests);
   requests.clear();
 
@@ -336,18 +341,32 @@ int main(int argc, char** argv)
   // tag 0: l_ctx_ep      ep
   // tag 1: ep            l_ctx_ep
   // tag 2: l_ctx_ep      ep
-  requests.push_back(listener_ctx->getEndpoint()->tagSend(
-    sendBuffers[0]->data(), sendBuffers[0]->getSize(), ucxx::Tag{0}));
-  requests.push_back(listener_ctx->getEndpoint()->tagRecv(
-    recvBuffers[1]->data(), recvBuffers[1]->getSize(), ucxx::Tag{1}, ucxx::TagMaskFull));
-  requests.push_back(listener_ctx->getEndpoint()->tagSend(
-    sendBuffers[2]->data(), sendBuffers[2]->getSize(), ucxx::Tag{2}, ucxx::TagMaskFull));
-  requests.push_back(endpoint->tagRecv(
-    recvBuffers[2]->data(), recvBuffers[2]->getSize(), ucxx::Tag{2}, ucxx::TagMaskFull));
   requests.push_back(
-    endpoint->tagSend(sendBuffers[1]->data(), sendBuffers[1]->getSize(), ucxx::Tag{1}));
-  requests.push_back(endpoint->tagRecv(
-    recvBuffers[0]->data(), recvBuffers[0]->getSize(), ucxx::Tag{0}, ucxx::TagMaskFull));
+    listener_ctx->getEndpoint()
+      ->tagSendBuilder(sendBuffers[0]->data(), sendBuffers[0]->getSize(), ucxx::Tag{0})
+      .build());
+  requests.push_back(
+    listener_ctx->getEndpoint()
+      ->tagRecvBuilder(
+        recvBuffers[1]->data(), recvBuffers[1]->getSize(), ucxx::Tag{1}, ucxx::TagMaskFull)
+      .build());
+  requests.push_back(
+    listener_ctx->getEndpoint()
+      ->tagSendBuilder(sendBuffers[2]->data(), sendBuffers[2]->getSize(), ucxx::Tag{2})
+      .build());
+  requests.push_back(
+    endpoint
+      ->tagRecvBuilder(
+        recvBuffers[2]->data(), recvBuffers[2]->getSize(), ucxx::Tag{2}, ucxx::TagMaskFull)
+      .build());
+  requests.push_back(
+    endpoint->tagSendBuilder(sendBuffers[1]->data(), sendBuffers[1]->getSize(), ucxx::Tag{1})
+      .build());
+  requests.push_back(
+    endpoint
+      ->tagRecvBuilder(
+        recvBuffers[0]->data(), recvBuffers[0]->getSize(), ucxx::Tag{0}, ucxx::TagMaskFull)
+      .build());
 
   // Wait for requests to be set, i.e., transfers complete
   ::waitRequests(args.progress_mode, worker, requests);

--- a/cpp/examples/basic.cpp
+++ b/cpp/examples/basic.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cassert>
@@ -46,7 +46,9 @@ class ListenerContext {
     if (!isAvailable()) throw std::runtime_error("Listener context already has an endpoint");
 
     static bool endpoint_error_handling = true;
-    _endpoint = _listener->createEndpointFromConnRequest(conn_request, endpoint_error_handling);
+    _endpoint                           = _listener->endpointBuilder(conn_request)
+                  .endpointErrorHandling(endpoint_error_handling)
+                  .build();
   }
 
   void releaseEndpoint() { _endpoint.reset(); }
@@ -274,12 +276,14 @@ int main(int argc, char** argv)
   if (args.parse(argc, argv) != UCS_OK) return -1;
 
   // Setup: create UCP context, worker, listener and client endpoint.
-  auto context      = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
-  auto worker       = context->createWorker();
+  auto context      = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build();
+  auto worker       = context->workerBuilder().build();
   auto listener_ctx = std::make_unique<ListenerContext>(worker);
-  auto listener     = worker->createListener(args.listener_port, listener_cb, listener_ctx.get());
+  auto listener =
+    worker->listenerBuilder(args.listener_port, listener_cb, listener_ctx.get()).build();
   listener_ctx->setListener(listener);
-  auto endpoint = worker->createEndpointFromHostname("127.0.0.1", args.listener_port, true);
+  auto endpoint =
+    worker->endpointBuilder("127.0.0.1", args.listener_port).endpointErrorHandling().build();
 
   // Initialize worker progress
   if (args.progress_mode == ProgressMode::Blocking)

--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -128,13 +128,9 @@ class Address : public Component {
 /**
  * @brief Deprecated constructor for `std::shared_ptr<ucxx::Address>` from a worker.
  */
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::AddressBuilder instead.")
-[[nodiscard]] std::shared_ptr<Address> createAddressFromWorker(std::shared_ptr<Worker> worker);
 
 /**
  * @brief Deprecated constructor for `std::shared_ptr<ucxx::Address>` from a string.
  */
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::AddressBuilder instead.")
-[[nodiscard]] std::shared_ptr<Address> createAddressFromString(std::string_view addressString);
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/address.h
+++ b/cpp/include/ucxx/address.h
@@ -125,12 +125,4 @@ class Address : public Component {
   [[nodiscard]] std::string_view getStringView() const;
 };
 
-/**
- * @brief Deprecated constructor for `std::shared_ptr<ucxx::Address>` from a worker.
- */
-
-/**
- * @brief Deprecated constructor for `std::shared_ptr<ucxx::Address>` from a string.
- */
-
 }  // namespace ucxx

--- a/cpp/include/ucxx/api.h
+++ b/cpp/include/ucxx/api.h
@@ -1,12 +1,11 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
 
 #include <ucxx/address.h>
 #include <ucxx/buffer.h>
-#include <ucxx/constructors.h>
 #include <ucxx/context.h>
 #include <ucxx/endpoint.h>
 #include <ucxx/header.h>

--- a/cpp/include/ucxx/constructors.h
+++ b/cpp/include/ucxx/constructors.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -56,117 +56,61 @@ namespace detail {
 [[nodiscard]] std::shared_ptr<TagProbeInfo> createTagProbeInfo(const ucp_tag_recv_info_t& info,
                                                                ucp_tag_message_h handle);
 
-}  // namespace detail
-
-// Components
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::AddressBuilder instead.")
-[[nodiscard]] std::shared_ptr<Address> createAddressFromWorker(std::shared_ptr<Worker> worker);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::AddressBuilder instead.")
-[[nodiscard]] std::shared_ptr<Address> createAddressFromString(std::string_view addressString);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::contextBuilder() instead.")
-[[nodiscard]] std::shared_ptr<Context> createContext(const ConfigMap ucxConfig,
-                                                     const uint64_t featureFlags);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::endpointBuilder() instead.")
+[[nodiscard]] std::shared_ptr<Context> createContext(ConfigMap ucxConfig, uint64_t featureFlags);
 [[nodiscard]] std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> worker,
                                                                    std::string ipAddress,
                                                                    uint16_t port,
                                                                    bool endpointErrorHandling);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::endpointBuilder() instead.")
 [[nodiscard]] std::shared_ptr<Endpoint> createEndpointFromConnRequest(
   std::shared_ptr<Listener> listener, ucp_conn_request_h connRequest, bool endpointErrorHandling);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::endpointBuilder() instead.")
 [[nodiscard]] std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(
   std::shared_ptr<Worker> worker, std::shared_ptr<Address> address, bool endpointErrorHandling);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::ListenerBuilder instead.")
-[[nodiscard]] std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
-                                                       uint16_t port,
-                                                       ucp_listener_conn_callback_t callback,
-                                                       void* callbackArgs);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::workerBuilder() instead.")
 [[nodiscard]] std::shared_ptr<Worker> createWorker(std::shared_ptr<Context> context,
-                                                   const bool enableDelayedSubmission,
-                                                   const bool enableFuture);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::MemoryHandleBuilder instead.")
-[[nodiscard]] std::shared_ptr<MemoryHandle> createMemoryHandle(
-  std::shared_ptr<Context> context,
-  const size_t size,
-  void* buffer                       = nullptr,
-  const ucs_memory_type_t memoryType = UCS_MEMORY_TYPE_HOST);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::RemoteKeyBuilder instead.")
-[[nodiscard]] std::shared_ptr<RemoteKey> createRemoteKeyFromMemoryHandle(
-  std::shared_ptr<MemoryHandle> memoryHandle);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::RemoteKeyBuilder instead.")
-[[nodiscard]] std::shared_ptr<RemoteKey> createRemoteKeyFromSerialized(
-  std::shared_ptr<Endpoint> endpoint, SerializedRemoteKey serializedRemoteKey);
-
-// Transfers
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::requestAmBuilder() instead.")
+                                                   bool enableDelayedSubmission,
+                                                   bool enableFuture);
+[[nodiscard]] std::shared_ptr<MemoryHandle> createMemoryHandle(std::shared_ptr<Context> context,
+                                                               size_t size,
+                                                               void* buffer,
+                                                               ucs_memory_type_t memoryType);
 [[nodiscard]] std::shared_ptr<RequestAm> createRequestAm(
   std::shared_ptr<Endpoint> endpoint,
-  const std::variant<data::AmSend, data::AmReceive> requestData,
-  const bool enablePythonFuture,
+  std::variant<data::AmSend, data::AmReceive> requestData,
+  bool enablePythonFuture,
   RequestCallbackUserFunction callbackFunction,
   RequestCallbackUserData callbackData);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::requestEndpointCloseBuilder() instead.")
 [[nodiscard]] std::shared_ptr<RequestEndpointClose> createRequestEndpointClose(
   std::shared_ptr<Endpoint> endpoint,
-  const data::EndpointClose requestData,
-  const bool enablePythonFuture,
+  data::EndpointClose requestData,
+  bool enablePythonFuture,
   RequestCallbackUserFunction callbackFunction,
   RequestCallbackUserData callbackData);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::requestFlushBuilder() instead.")
 [[nodiscard]] std::shared_ptr<RequestFlush> createRequestFlush(
   std::shared_ptr<Component> endpointOrWorker,
-  const data::Flush requestData,
-  const bool enablePythonFuture,
+  data::Flush requestData,
+  bool enablePythonFuture,
   RequestCallbackUserFunction callbackFunction,
   RequestCallbackUserData callbackData);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::requestStreamBuilder() instead.")
 [[nodiscard]] std::shared_ptr<RequestStream> createRequestStream(
   std::shared_ptr<Endpoint> endpoint,
-  const std::variant<data::StreamSend, data::StreamReceive> requestData,
-  const bool enablePythonFuture);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::requestTagBuilder() instead.")
+  std::variant<data::StreamSend, data::StreamReceive> requestData,
+  bool enablePythonFuture);
 [[nodiscard]] std::shared_ptr<RequestTag> createRequestTag(
   std::shared_ptr<Component> endpointOrWorker,
-  const std::variant<data::TagSend, data::TagReceive, data::TagReceiveWithHandle> requestData,
-  const bool enablePythonFuture,
+  std::variant<data::TagSend, data::TagReceive, data::TagReceiveWithHandle> requestData,
+  bool enablePythonFuture,
   RequestCallbackUserFunction callbackFunction,
   RequestCallbackUserData callbackData);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::requestMemBuilder() instead.")
 [[nodiscard]] std::shared_ptr<RequestMem> createRequestMem(
   std::shared_ptr<Endpoint> endpoint,
-  const std::variant<data::MemPut, data::MemGet> requestData,
-  const bool enablePythonFuture,
+  std::variant<data::MemPut, data::MemGet> requestData,
+  bool enablePythonFuture,
   RequestCallbackUserFunction callbackFunction,
   RequestCallbackUserData callbackData);
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::requestTagMultiBuilder() instead.")
 [[nodiscard]] std::shared_ptr<RequestTagMulti> createRequestTagMulti(
   std::shared_ptr<Endpoint> endpoint,
-  const std::variant<data::TagMultiSend, data::TagMultiReceive> requestData,
-  const bool enablePythonFuture);
+  std::variant<data::TagMultiSend, data::TagMultiReceive> requestData,
+  bool enablePythonFuture);
 
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::TagProbeInfoBuilder instead.")
-[[nodiscard]] std::shared_ptr<TagProbeInfo> createTagProbeInfo();
-
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::TagProbeInfoBuilder instead.")
-[[nodiscard]] std::shared_ptr<TagProbeInfo> createTagProbeInfo(const ucp_tag_recv_info_t& info,
-                                                               ucp_tag_message_h handle);
+}  // namespace detail
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/context.h
+++ b/cpp/include/ucxx/context.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -66,12 +66,13 @@ class Context : public Component {
   Context& operator=(Context&& o)    = delete;
 
   /**
-   * @brief Friend declaration for `ucxx::createContext` with parameters.
+   * @brief Allow the internal context factory to access the private constructor.
    *
-   * This friend declaration allows the standalone `ucxx::createContext` function to access
-   * the private constructor. See the public declaration for full documentation.
+   * This friend declaration allows `ucxx::detail::createContext` to access the private
+   * constructor.
    */
-  friend std::shared_ptr<Context> createContext(ConfigMap ucxConfig, const uint64_t featureFlags);
+  friend std::shared_ptr<Context> detail::createContext(ConfigMap ucxConfig,
+                                                        const uint64_t featureFlags);
 
   /**
    * @brief Allow ContextBuilder to access private constructor.
@@ -174,28 +175,6 @@ class Context : public Component {
   [[nodiscard]] WorkerBuilder workerBuilder();
 
   /**
-   * @brief Create a new `ucxx::Worker`.
-   *
-   * Create a new `ucxx::Worker` as a child of the current `ucxx::Context`.
-   * The `ucxx::Context` will retain ownership of the `ucxx::Worker` and will
-   * not be destroyed until all `ucxx::Worker` objects are destroyed first.
-   *
-   * @code{.cpp}
-   *   // context is `std::shared_ptr<ucxx::Context>`
-   *   auto worker = context->workerBuilder().delayedSubmission(true).build();
-   * @endcode
-   *
-   * @param[in] enableDelayedSubmission whether the worker should delay
-   *                                    transfer requests to the worker thread.
-   * @param[in] enableFuture if `true`, notifies the future associated with each
-   *                         `ucxx::Request`, currently used only by `ucxx::python::Worker`.
-   * @return Shared pointer to the `ucxx::Worker` object.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Context::workerBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Worker> createWorker(const bool enableDelayedSubmission = false,
-                                                     const bool enableFuture            = false);
-
-  /**
    * @brief Create a builder for a new `ucxx::MemoryHandle`.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -205,66 +184,6 @@ class Context : public Component {
    * @returns Builder to configure optional memory mapping parameters.
    */
   [[nodiscard]] MemoryHandleBuilder memoryHandleBuilder(size_t size);
-
-  /**
-   * @brief Create a new `std::shared_ptr<ucxx::memoryHandle>`.
-   *
-   * Create a new `std::shared_ptr<ucxx::MemoryHandle>` as a child of the current
-   * `ucxx::Context`.  The `ucxx::Context` will retain ownership of the underlying
-   * `ucxx::MemoryHandle` and will not be destroyed until all `ucxx::MemoryHandle`
-   * objects are destroyed first.
-   *
-   * The allocation requires a `size` and a `buffer`. The actual size of the allocation may
-   * be larger than requested, and can later be found calling the `getSize()` method. The
-   * `buffer` provided may be either a `nullptr`, in which case UCP will allocate a new
-   * memory region for it, or an already existing allocation, in which case UCP will only
-   * map it for RMA and it's the caller's responsibility to keep `buffer` alive until this
-   * object is destroyed.
-   *
-   * @code{.cpp}
-   * // `context` is `std::shared_ptr<ucxx::Context>`
-   * // Allocate a 128-byte buffer with UCP.
-   * auto memoryHandle = context->memoryHandleBuilder(128).build();
-   *
-   * // Map an existing 128-byte buffer with UCP.
-   * size_t allocationSize = 128;
-   * auto buffer = new uint8_t[allocationSize];
-   * auto memoryHandleFromBuffer = context->memoryHandleBuilder(allocationSize * sizeof(*buffer))
-   *                                  .buffer(buffer)
-   *                                  .build();
-   * @endcode
-   *
-   * @throws ucxx::Error if either `ucp_mem_map` or `ucp_mem_query` fail.
-   *
-   * @param[in] size        the minimum size of the memory allocation.
-   * @param[in] buffer      the pointer to an existing allocation or `nullptr` to allocate a
-   *                        new memory region.
-   * @param[in] memoryType  the type of memory the handle points to.
-   *
-   * @returns The `shared_ptr<ucxx::MemoryHandle>` object
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Context::memoryHandleBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<MemoryHandle> createMemoryHandle(
-    const size_t size, void* buffer, const ucs_memory_type_t memoryType = UCS_MEMORY_TYPE_HOST);
 };
-
-/**
- * @brief Constructor of `shared_ptr<ucxx::Context>` with parameters.
- *
- * The constructor for a `shared_ptr<ucxx::Context>` object. The default constructor is
- * made private to ensure all UCXX objects are shared pointers for correct lifetime
- * management.
- *
- * @code{.cpp}
- *   auto context = ucxx::contextBuilder(UCP_FEATURE_WAKEUP | UCP_FEATURE_TAG).build();
- * @endcode
- *
- * @param[in] ucxConfig configurations overriding `UCX_*` defaults and environment variables.
- * @param[in] featureFlags feature flags to be used at UCP context construction time.
- * @return The `shared_ptr<ucxx::Context>` object.
- */
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::contextBuilder() instead.")
-[[nodiscard]] std::shared_ptr<Context> createContext(ConfigMap ucxConfig,
-                                                     const uint64_t featureFlags);
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/context.h
+++ b/cpp/include/ucxx/context.h
@@ -13,8 +13,8 @@
 
 #include <ucxx/component.h>
 #include <ucxx/config.h>
-#include <ucxx/constructors.h>
 #include <ucxx/context_builder.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/memory_handle_builder.h>
 #include <ucxx/worker_builder.h>
 

--- a/cpp/include/ucxx/detail/constructors.h
+++ b/cpp/include/ucxx/detail/constructors.h
@@ -18,12 +18,9 @@ namespace ucxx {
 class Address;
 class Context;
 class Endpoint;
-class Future;
 class Listener;
 class MemoryHandle;
-class Notifier;
 class RemoteKey;
-class Request;
 class RequestAm;
 class RequestEndpointClose;
 class RequestFlush;
@@ -37,25 +34,18 @@ class Worker;
 namespace detail {
 
 [[nodiscard]] std::shared_ptr<Address> createAddressFromWorker(std::shared_ptr<Worker> worker);
-
 [[nodiscard]] std::shared_ptr<Address> createAddressFromString(std::string_view addressString);
-
 [[nodiscard]] std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
                                                        uint16_t port,
                                                        ucp_listener_conn_callback_t callback,
                                                        void* callbackArgs);
-
 [[nodiscard]] std::shared_ptr<RemoteKey> createRemoteKeyFromMemoryHandle(
   std::shared_ptr<MemoryHandle> memoryHandle);
-
 [[nodiscard]] std::shared_ptr<RemoteKey> createRemoteKeyFromSerialized(
   std::shared_ptr<Endpoint> endpoint, SerializedRemoteKey serializedRemoteKey);
-
 [[nodiscard]] std::shared_ptr<TagProbeInfo> createTagProbeInfo();
-
 [[nodiscard]] std::shared_ptr<TagProbeInfo> createTagProbeInfo(const ucp_tag_recv_info_t& info,
                                                                ucp_tag_message_h handle);
-
 [[nodiscard]] std::shared_ptr<Context> createContext(ConfigMap ucxConfig, uint64_t featureFlags);
 [[nodiscard]] std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> worker,
                                                                    std::string ipAddress,

--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -14,6 +14,7 @@
 
 #include <ucxx/address.h>
 #include <ucxx/component.h>
+#include <ucxx/constructors.h>
 #include <ucxx/endpoint_builder.h>
 #include <ucxx/exception.h>
 #include <ucxx/inflight_requests.h>
@@ -209,10 +210,11 @@ class Endpoint : public Component {
    *
    * @returns The `shared_ptr<ucxx::Endpoint>` object
    */
-  friend std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> worker,
-                                                              std::string ipAddress,
-                                                              uint16_t port,
-                                                              bool endpointErrorHandling);
+  friend std::shared_ptr<Endpoint> detail::createEndpointFromHostname(
+    std::shared_ptr<Worker> worker,
+    std::string ipAddress,
+    uint16_t port,
+    bool endpointErrorHandling);
 
   /**
    * @brief Constructor for `shared_ptr<ucxx::Endpoint>`.
@@ -240,9 +242,8 @@ class Endpoint : public Component {
    *
    * @returns The `shared_ptr<ucxx::Endpoint>` object
    */
-  friend std::shared_ptr<Endpoint> createEndpointFromConnRequest(std::shared_ptr<Listener> listener,
-                                                                 ucp_conn_request_h connRequest,
-                                                                 bool endpointErrorHandling);
+  friend std::shared_ptr<Endpoint> detail::createEndpointFromConnRequest(
+    std::shared_ptr<Listener> listener, ucp_conn_request_h connRequest, bool endpointErrorHandling);
 
   /**
    * @brief Constructor for `shared_ptr<ucxx::Endpoint>`.
@@ -267,9 +268,8 @@ class Endpoint : public Component {
    *
    * @returns The `shared_ptr<ucxx::Endpoint>` object
    */
-  friend std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(std::shared_ptr<Worker> worker,
-                                                                   std::shared_ptr<Address> address,
-                                                                   bool endpointErrorHandling);
+  friend std::shared_ptr<Endpoint> detail::createEndpointFromWorkerAddress(
+    std::shared_ptr<Worker> worker, std::shared_ptr<Address> address, bool endpointErrorHandling);
 
   /**
    * @brief Get the underlying `ucp_ep_h` handle.

--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -14,7 +14,7 @@
 
 #include <ucxx/address.h>
 #include <ucxx/component.h>
-#include <ucxx/constructors.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/endpoint_builder.h>
 #include <ucxx/exception.h>
 #include <ucxx/inflight_requests.h>

--- a/cpp/include/ucxx/endpoint.h
+++ b/cpp/include/ucxx/endpoint.h
@@ -390,54 +390,6 @@ class Endpoint : public Component {
                         EndpointCloseCallbackUserData closeCallbackArg);
 
   /**
-   * @brief Enqueue an active message send operation.
-   *
-   * Enqueue an active message send operation, returning a `std::shared_ptr<ucxx::Request>`
-   * that can be later awaited and checked for errors. This is a non-blocking operation, and
-   * the status of the transfer must be verified from the resulting request object before
-   * the data can be released.
-   *
-   * An optional `receiverCallbackInfo` may be specified, in which case the remote worker
-   * obligatorily needs to have registered a callback with the same `receiverCallbackInfo`
-   * in order to execute the callback when the active message is received. When this is
-   * specified, `amRecv()` will _NOT_ match this message, which is instead handled by the
-   * remote worker's callback.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] buffer                  a raw pointer to the data to be sent.
-   * @param[in] length                  the size in bytes of the tag message to be sent.
-   * @param[in] memoryType              the memory type of the buffer.
-   * @param[in] receiverCallbackInfo    the owner name and unique identifier of the receiver
-                                        callback.
-   * @param[in] enablePythonFuture      whether a python future should be created and
-   *                                    subsequently notified.
-   * @param[in] callbackFunction        user-defined callback function to call upon
-                                        completion.
-   * @param[in] callbackData            user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::amSendBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> amSend(
-    const void* const buffer,
-    const size_t length,
-    const ucs_memory_type_t memoryType,
-    const std::optional<AmReceiverCallbackInfo> receiverCallbackInfo = std::nullopt,
-    const bool enablePythonFuture                                    = false,
-    RequestCallbackUserFunction callbackFunction                     = nullptr,
-    RequestCallbackUserData callbackData                             = nullptr);
-
-  /**
    * @brief Create a builder for an active message send operation.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -452,31 +404,6 @@ class Endpoint : public Component {
   [[nodiscard]] RequestAmBuilder amSendBuilder(const void* const buffer,
                                                const size_t length,
                                                const ucs_memory_type_t memoryType);
-
-  /**
-   * @brief Enqueue an active message send operation with explicit policy parameters.
-   *
-   * This overload extends `amSend()` with explicit UCX datatype/flags controls and receive
-   * allocation policy metadata while keeping callback behavior identical to the legacy API.
-   *
-   * @param[in] buffer              a raw pointer to the data to be sent.
-   * @param[in] length              the size in bytes of the message to be sent.
-   * @param[in] params              active message send parameters.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::amSendBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> amSend(
-    const void* const buffer,
-    const size_t length,
-    const AmSendParams& params,
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Create a builder for an active message send operation with explicit policy parameters.
@@ -495,29 +422,6 @@ class Endpoint : public Component {
                                                const AmSendParams& params);
 
   /**
-   * @brief Enqueue an active message send operation with IOV datatype.
-   *
-   * This overload submits `UCP_DATATYPE_IOV` active message sends.
-   *
-   * @param[in] iov                 vector of IOV segments to be sent.
-   * @param[in] params              active message send parameters. Datatype must be
-   *                                `UCP_DATATYPE_IOV`.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::amSendBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> amSend(
-    std::vector<ucp_dt_iov_t> iov,
-    const AmSendParams& params,
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
-
-  /**
    * @brief Create a builder for an active message send operation with IOV datatype.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -533,40 +437,6 @@ class Endpoint : public Component {
                                                const AmSendParams& params);
 
   /**
-   * @brief Enqueue an active message receive operation.
-   *
-   * Enqueue an active message receive operation, returning a
-   * `std::shared_ptr<ucxx::Request>` that can be later awaited and checked for errors,
-   * making data available via the return value's `getRecvBuffer()` method once the
-   * operation completes successfully. This is a non-blocking operation, and the status of
-   * the transfer must be verified from the resulting request object before the data can be
-   * consumed.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::amRecvBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> amRecv(
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
-
-  /**
    * @brief Create a builder for an active message receive operation.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -577,47 +447,6 @@ class Endpoint : public Component {
   [[nodiscard]] RequestAmBuilder amRecvBuilder();
 
   /**
-   * @brief Enqueue a memory put operation.
-   *
-   * Enqueue a memory operation, returning a `std::shared<ucxx::Request>` that can be later
-   * awaited and checked for errors. This is a non-blocking operation, and the status of the
-   * transfer must be verified from the resulting request object before both local and
-   * remote data can be released and the remote data can be consumed.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] buffer              a raw pointer to the data to be sent.
-   * @param[in] length              the size in bytes of the tag message to be sent.
-   * @param[in] remoteAddr          the destination remote memory address to write to.
-   * @param[in] rkey                the remote memory key associated with the remote memory
-   *                                address.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::memPutBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> memPut(
-    const void* const buffer,
-    size_t length,
-    uint64_t remoteAddr,
-    ucp_rkey_h rkey,
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
-
-  /**
    * @brief Create a builder for a memory put operation.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -637,49 +466,6 @@ class Endpoint : public Component {
                                                 ucp_rkey_h rkey);
 
   /**
-   * @brief Enqueue a memory put operation.
-   *
-   * Enqueue a memory operation, returning a `std::shared<ucxx::Request>` that can be later
-   * awaited and checked for errors. This is a non-blocking operation, and the status of the
-   * transfer must be verified from the resulting request object before both local and
-   * remote data can be released and the remote data can be consumed.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] buffer              a raw pointer to the data to be sent.
-   * @param[in] length              the size in bytes of the tag message to be sent.
-   * @param[in] remoteKey           the remote memory key associated with the remote memory
-   *                                address.
-   * @param[in] remoteAddrOffset    the destination remote memory address offset where to
-   *                                start writing to, `0` means start writing from beginning
-   *                                of the base address.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::memPutBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> memPut(
-    const void* const buffer,
-    size_t length,
-    std::shared_ptr<ucxx::RemoteKey> remoteKey,
-    uint64_t remoteAddrOffset                    = 0,
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
-
-  /**
    * @brief Create a builder for a memory put operation.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -695,47 +481,6 @@ class Endpoint : public Component {
   [[nodiscard]] RequestMemBuilder memPutBuilder(const void* const buffer,
                                                 size_t length,
                                                 std::shared_ptr<ucxx::RemoteKey> remoteKey);
-
-  /**
-   * @brief Enqueue a memory get operation.
-   *
-   * Enqueue a memory operation, returning a `std::shared<ucxx::Request>` that can be later
-   * awaited and checked for errors. This is a non-blocking operation, and the status of the
-   * transfer must be verified from the resulting request object before both local and
-   * remote data can be released and the local data can be consumed.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] buffer              a raw pointer to the data to be sent.
-   * @param[in] length              the size in bytes of the tag message to be sent.
-   * @param[in] remoteAddr          the source remote memory address to read from.
-   * @param[in] rkey                the remote memory key associated with the remote memory
-   *                                address.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::memGetBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> memGet(
-    void* buffer,
-    size_t length,
-    uint64_t remoteAddr,
-    ucp_rkey_h rkey,
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Create a builder for a memory get operation.
@@ -757,49 +502,6 @@ class Endpoint : public Component {
                                                 ucp_rkey_h rkey);
 
   /**
-   * @brief Enqueue a memory get operation.
-   *
-   * Enqueue a memory operation, returning a `std::shared<ucxx::Request>` that can be later
-   * awaited and checked for errors. This is a non-blocking operation, and the status of the
-   * transfer must be verified from the resulting request object before both local and
-   * remote data can be released and the local data can be consumed.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] buffer              a raw pointer to the data to be sent.
-   * @param[in] length              the size in bytes of the tag message to be sent.
-   * @param[in] remoteKey           the remote memory key associated with the remote memory
-   *                                address.
-   * @param[in] remoteAddrOffset    the destination remote memory address offset where to
-   *                                start reading from, `0` means start writing from
-   *                                beginning of the base address.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::memGetBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> memGet(
-    void* buffer,
-    size_t length,
-    std::shared_ptr<ucxx::RemoteKey> remoteKey,
-    uint64_t remoteAddrOffset                    = 0,
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
-
-  /**
    * @brief Create a builder for a memory get operation.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -815,30 +517,6 @@ class Endpoint : public Component {
   [[nodiscard]] RequestMemBuilder memGetBuilder(void* buffer,
                                                 size_t length,
                                                 std::shared_ptr<ucxx::RemoteKey> remoteKey);
-
-  /**
-   * @brief Enqueue a stream send operation.
-   *
-   * Enqueue a stream send operation, returning a `std::shared<ucxx::Request>` that can
-   * be later awaited and checked for errors. This is a non-blocking operation, and the
-   * status of the transfer must be verified from the resulting request object before the
-   * data can be released.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @param[in] buffer              a raw pointer to the data to be sent.
-   * @param[in] length              the size in bytes of the tag message to be sent.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::streamSendBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> streamSend(const void* const buffer,
-                                                    size_t length,
-                                                    const bool enablePythonFuture);
 
   /**
    * @brief Create a builder for a stream send operation.
@@ -852,31 +530,6 @@ class Endpoint : public Component {
    * @returns Builder to configure optional parameters and submit the request.
    */
   [[nodiscard]] RequestStreamBuilder streamSendBuilder(const void* const buffer, size_t length);
-
-  /**
-   * @brief Enqueue a stream receive operation.
-   *
-   * Enqueue a stream receive operation, returning a `std::shared<ucxx::Request>` that can
-   * be later awaited and checked for errors. This is a non-blocking operation, and the
-   * status of the transfer must be verified from the resulting request object before the
-   * data can be consumed.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @param[in] buffer              a raw pointer to pre-allocated memory where resulting
-   *                                data will be stored.
-   * @param[in] length              the size in bytes of the tag message to be received.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::streamRecvBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> streamRecv(void* buffer,
-                                                    size_t length,
-                                                    const bool enablePythonFuture);
 
   /**
    * @brief Create a builder for a stream receive operation.
@@ -893,44 +546,6 @@ class Endpoint : public Component {
   [[nodiscard]] RequestStreamBuilder streamRecvBuilder(void* buffer, size_t length);
 
   /**
-   * @brief Enqueue a tag send operation.
-   *
-   * Enqueue a tag send operation, returning a `std::shared<ucxx::Request>` that can
-   * be later awaited and checked for errors. This is a non-blocking operation, and the
-   * status of the transfer must be verified from the resulting request object before the
-   * data can be released.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] buffer              a raw pointer to the data to be sent.
-   * @param[in] length              the size in bytes of the tag message to be sent.
-   * @param[in] tag                 the tag to match.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::tagSendBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> tagSend(
-    const void* const buffer,
-    size_t length,
-    Tag tag,
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
-
-  /**
    * @brief Create a builder for a tag send operation.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -943,47 +558,6 @@ class Endpoint : public Component {
    * @returns Builder to configure optional parameters and submit the request.
    */
   [[nodiscard]] RequestTagBuilder tagSendBuilder(const void* const buffer, size_t length, Tag tag);
-
-  /**
-   * @brief Enqueue a tag receive operation.
-   *
-   * Enqueue a tag receive operation, returning a `std::shared<ucxx::Request>` that can
-   * be later awaited and checked for errors. This is a non-blocking operation, and the
-   * status of the transfer must be verified from the resulting request object before the
-   * data can be consumed.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] buffer              a raw pointer to pre-allocated memory where resulting
-   *                                data will be stored.
-   * @param[in] length              the size in bytes of the tag message to be received.
-   * @param[in] tag                 the tag to match.
-   * @param[in] tagMask             the tag mask to use.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::tagRecvBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> tagRecv(
-    void* buffer,
-    size_t length,
-    Tag tag,
-    TagMask tagMask,
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Create a builder for a tag receive operation.
@@ -1005,46 +579,6 @@ class Endpoint : public Component {
                                                  TagMask tagMask);
 
   /**
-   * @brief Enqueue a multi-buffer tag send operation.
-   *
-   * Enqueue a multi-buffer tag send operation, returning a
-   * `std::shared<ucxx::RequestTagMulti>` that can be later awaited and checked for errors.
-   * This is a non-blocking operation, and the status of the transfer must be verified from
-   * the resulting request object before the data can be released.
-   *
-   * The primary use of multi-buffer transfers is in Python where we want to reduce the
-   * amount of futures needed to watch for, thus reducing Python overhead. However, this
-   * may be used as a convenience implementation for transfers that require multiple
-   * frames, internally this is implemented as one or more `tagSend` calls sending headers
-   * (depending on the number of frames being transferred), followed by one `tagSend` for
-   * each data frame.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @throws  std::runtime_error  if sizes of `buffer`, `size` and `isCUDA` do not match.
-   *
-   * @param[in] buffer              a vector of raw pointers to the data frames to be sent.
-   * @param[in] size                a vector of size in bytes of each frame to be sent.
-   * @param[in] isCUDA              a vector of booleans (integers to prevent incoherence
-   *                                with other vector types) indicating whether frame is
-   *                                CUDA, to ensure proper memory allocation by the
-   *                                receiver.
-   * @param[in] tag                 the tag to match.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::tagMultiSendBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> tagMultiSend(const std::vector<const void*>& buffer,
-                                                      const std::vector<size_t>& size,
-                                                      const std::vector<int>& isCUDA,
-                                                      const Tag tag,
-                                                      const bool enablePythonFuture);
-
-  /**
    * @brief Create a builder for a multi-buffer tag send operation.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -1063,32 +597,6 @@ class Endpoint : public Component {
                                                            const Tag tag);
 
   /**
-   * @brief Enqueue a multi-buffer tag receive operation.
-   *
-   * Enqueue a multi-buffer tag receive operation, returning a
-   * `std::shared<ucxx::RequestTagMulti>` that can be later awaited and checked for errors.
-   * This is a non-blocking operation, and because the receiver has no a priori knowledge
-   * of the data being received, memory allocations are automatically handled internally.
-   * Receiving CUDA frames requires UCXX to be compiled with CCCL support (`UCXX_ENABLE_CCCL`)
-   * and the receiving worker to be configured to allocate CCCL buffers for CUDA frames.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @param[in] tag                 the tag to match.
-   * @param[in] tagMask             the tag mask to use.
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::tagMultiRecvBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> tagMultiRecv(const Tag tag,
-                                                      const TagMask tagMask,
-                                                      const bool enablePythonFuture);
-
-  /**
    * @brief Create a builder for a multi-buffer tag receive operation.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -1100,39 +608,6 @@ class Endpoint : public Component {
    * @returns Builder to configure optional parameters and submit the request.
    */
   [[nodiscard]] RequestTagMultiBuilder tagMultiRecvBuilder(const Tag tag, const TagMask tagMask);
-
-  /**
-   * @brief Enqueue a flush operation.
-   *
-   * Enqueue request to flush outstanding AMO (Atomic Memory Operation) and RMA (Remote
-   * Memory Access) operations on the endpoint, returning a pointer to a request object that
-   * can be later awaited and checked for errors. This is a non-blocking operation, and its
-   * status must be verified from the resulting request object to confirm the flush
-   * operation has completed successfully.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::flushBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> flush(
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Create a builder for a flush operation.
@@ -1166,59 +641,6 @@ class Endpoint : public Component {
    * @returns Builder to create the remote key.
    */
   [[nodiscard]] RemoteKeyBuilder remoteKeyBuilder(SerializedRemoteKey serializedRemoteKey);
-
-  /**
-   * @brief Enqueue a non-blocking endpoint close operation.
-   *
-   * Enqueue a non-blocking endpoint close operation, which will close the endpoint without
-   * requiring to destroy the object. This may be useful when other
-   * `std::shared_ptr<ucxx::Request>` objects are still alive, such as inflight transfers.
-   *
-   * This method returns a `std::shared<ucxx::Request>` that can be later awaited and
-   * checked for errors. This is a non-blocking operation, and the status of closing the
-   * endpoint must be verified from the resulting request object before the
-   * `std::shared_ptr<ucxx::Endpoint>` can be safely destroyed and the UCP endpoint assumed
-   * inactive (closed). If the endpoint is already closed or in process of closing, `nullptr`
-   * is returned instead.
-   *
-   * If the endpoint was created with error handling support, the error callback will be
-   * executed, implying the user-defined callback will also be executed.
-   *
-   * If a user-defined callback is specified via the `callbackFunction` argument then that
-   * callback will be executed, if not then the callback registered with `setCloseCallback()`
-   * will be executed, if neither was specified then no user-defined callback will be
-   * executed.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the close operation has completed. Requires UCXX Python support.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @warning Unlike its `closeBlocking()` counterpart, this method does not cancel any
-   * inflight requests prior to submitting the UCP close request. Before scheduling the
-   * endpoint close request, the caller must first call `cancelInflightRequests()` and
-   * progress the worker until `getCancelingSize()` returns `0`.
-   *
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state, or
-   *          `nullptr` if the endpoint has already closed or is already in process of
-   *          closing.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Endpoint::closeBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> close(
-    const bool enablePythonFuture                      = false,
-    EndpointCloseCallbackUserFunction callbackFunction = nullptr,
-    EndpointCloseCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Create a builder for a non-blocking endpoint close operation.

--- a/cpp/include/ucxx/listener.h
+++ b/cpp/include/ucxx/listener.h
@@ -124,32 +124,6 @@ class Listener : public Component {
   [[nodiscard]] EndpointBuilder endpointBuilder(ucp_conn_request_h connRequest);
 
   /**
-   * @brief Constructor for `shared_ptr<ucxx::Endpoint>`.
-   *
-   * The constructor for a `shared_ptr<ucxx::Endpoint>` object from a `ucp_conn_request_h`,
-   * as delivered by a `ucxx::Listener` connection callback.
-   *
-   * @code{.cpp}
-   * // listener is `std::shared_ptr<ucxx::Listener>`, with a `ucp_conn_request_h` delivered
-   * // by a `ucxx::Listener` connection callback.
-   * auto endpoint = listener->endpointBuilder(connRequest)
-   *                   .endpointErrorHandling(true)
-   *                   .build();
-   *
-   * // Equivalent to line above
-   * // auto endpoint = ucxx::endpointBuilder(listener, connRequest)
-   * //                   .endpointErrorHandling(true)
-   * //                   .build();
-   * @endcode
-   *
-   * @param[in] connRequest           handle to connection request delivered by a
-   *                                  listener callback.
-   * @param[in] endpointErrorHandling whether to enable endpoint error handling.
-   *
-   * @returns The `shared_ptr<ucxx::Endpoint>` object.
-   */
-
-  /**
    * @brief Get the underlying `ucp_listener_h` handle.
    *
    * Lifetime of the `ucp_listener_h` handle is managed by the `ucxx::Listener` object and
@@ -184,9 +158,5 @@ class Listener : public Component {
    */
   [[nodiscard]] std::string getIp();
 };
-
-/**
- * @brief Deprecated constructor for `std::shared_ptr<ucxx::Listener>`.
- */
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/listener.h
+++ b/cpp/include/ucxx/listener.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -148,9 +148,6 @@ class Listener : public Component {
    *
    * @returns The `shared_ptr<ucxx::Endpoint>` object.
    */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use Listener::endpointBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Endpoint> createEndpointFromConnRequest(
-    ucp_conn_request_h connRequest, bool endpointErrorHandling = true);
 
   /**
    * @brief Get the underlying `ucp_listener_h` handle.
@@ -191,10 +188,5 @@ class Listener : public Component {
 /**
  * @brief Deprecated constructor for `std::shared_ptr<ucxx::Listener>`.
  */
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::ListenerBuilder instead.")
-[[nodiscard]] std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
-                                                       uint16_t port,
-                                                       ucp_listener_conn_callback_t callback,
-                                                       void* callbackArgs);
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/memory_handle.h
+++ b/cpp/include/ucxx/memory_handle.h
@@ -187,15 +187,6 @@ class MemoryHandle : public Component {
    * @returns Builder to create the remote key.
    */
   [[nodiscard]] RemoteKeyBuilder remoteKeyBuilder();
-
-  /**
-   * @brief Create a remote key for the memory allocation.
-   *
-   * Create a remote key that can be used by a remote endpoint to access this memory
-   * allocation. The remote key is required for remote memory access operations.
-   *
-   * @returns A shared pointer to the created remote key.
-   */
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/memory_handle.h
+++ b/cpp/include/ucxx/memory_handle.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -10,6 +10,7 @@
 #include <ucp/api/ucp.h>
 
 #include <ucxx/component.h>
+#include <ucxx/constructors.h>
 #include <ucxx/context.h>
 #include <ucxx/memory_handle_builder.h>
 #include <ucxx/remote_key_builder.h>
@@ -112,10 +113,10 @@ class MemoryHandle : public Component {
    *
    * @returns The `shared_ptr<ucxx::MemoryHandle>` object
    */
-  friend std::shared_ptr<MemoryHandle> createMemoryHandle(std::shared_ptr<Context> context,
-                                                          const size_t size,
-                                                          void* buffer,
-                                                          const ucs_memory_type_t memoryType);
+  friend std::shared_ptr<MemoryHandle> detail::createMemoryHandle(std::shared_ptr<Context> context,
+                                                                  size_t size,
+                                                                  void* buffer,
+                                                                  ucs_memory_type_t memoryType);
 
   ~MemoryHandle();
 
@@ -195,8 +196,6 @@ class MemoryHandle : public Component {
    *
    * @returns A shared pointer to the created remote key.
    */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::MemoryHandle::remoteKeyBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<RemoteKey> createRemoteKey();
 };
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/memory_handle.h
+++ b/cpp/include/ucxx/memory_handle.h
@@ -10,8 +10,8 @@
 #include <ucp/api/ucp.h>
 
 #include <ucxx/component.h>
-#include <ucxx/constructors.h>
 #include <ucxx/context.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/memory_handle_builder.h>
 #include <ucxx/remote_key_builder.h>
 

--- a/cpp/include/ucxx/remote_key.h
+++ b/cpp/include/ucxx/remote_key.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -229,15 +229,9 @@ class RemoteKey : public Component {
 /**
  * @brief Deprecated constructor for `std::shared_ptr<ucxx::RemoteKey>` from a memory handle.
  */
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::RemoteKeyBuilder instead.")
-[[nodiscard]] std::shared_ptr<RemoteKey> createRemoteKeyFromMemoryHandle(
-  std::shared_ptr<MemoryHandle> memoryHandle);
 
 /**
  * @brief Deprecated constructor for `std::shared_ptr<ucxx::RemoteKey>` from serialized data.
  */
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::RemoteKeyBuilder instead.")
-[[nodiscard]] std::shared_ptr<RemoteKey> createRemoteKeyFromSerialized(
-  std::shared_ptr<Endpoint> endpoint, SerializedRemoteKey serializedRemoteKey);
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/remote_key.h
+++ b/cpp/include/ucxx/remote_key.h
@@ -226,12 +226,4 @@ class RemoteKey : public Component {
   [[nodiscard]] SerializedRemoteKey serialize() const;
 };
 
-/**
- * @brief Deprecated constructor for `std::shared_ptr<ucxx::RemoteKey>` from a memory handle.
- */
-
-/**
- * @brief Deprecated constructor for `std::shared_ptr<ucxx::RemoteKey>` from serialized data.
- */
-
 }  // namespace ucxx

--- a/cpp/include/ucxx/request_am.h
+++ b/cpp/include/ucxx/request_am.h
@@ -11,8 +11,8 @@
 
 #include <ucp/api/ucp.h>
 
-#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/request.h>
 #include <ucxx/request_am_builder.h>
 #include <ucxx/typedefs.h>

--- a/cpp/include/ucxx/request_am.h
+++ b/cpp/include/ucxx/request_am.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -11,6 +11,7 @@
 
 #include <ucp/api/ucp.h>
 
+#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
 #include <ucxx/request.h>
 #include <ucxx/request_am_builder.h>
@@ -102,7 +103,7 @@ class RequestAm : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestAm>` object
    */
-  friend std::shared_ptr<RequestAm> createRequestAm(
+  friend std::shared_ptr<RequestAm> detail::createRequestAm(
     std::shared_ptr<Endpoint> endpoint,
     const std::variant<data::AmSend, data::AmReceive> requestData,
     const bool enablePythonFuture,

--- a/cpp/include/ucxx/request_endpoint_close.h
+++ b/cpp/include/ucxx/request_endpoint_close.h
@@ -9,8 +9,8 @@
 
 #include <ucp/api/ucp.h>
 
-#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/request.h>
 #include <ucxx/request_endpoint_close_builder.h>
 #include <ucxx/typedefs.h>

--- a/cpp/include/ucxx/request_endpoint_close.h
+++ b/cpp/include/ucxx/request_endpoint_close.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -9,6 +9,7 @@
 
 #include <ucp/api/ucp.h>
 
+#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
 #include <ucxx/request.h>
 #include <ucxx/request_endpoint_close_builder.h>
@@ -83,7 +84,7 @@ class RequestEndpointClose : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestEndpointClose>` object.
    */
-  friend std::shared_ptr<RequestEndpointClose> createRequestEndpointClose(
+  friend std::shared_ptr<RequestEndpointClose> detail::createRequestEndpointClose(
     std::shared_ptr<Endpoint> endpoint,
     const data::EndpointClose requestData,
     const bool enablePythonFuture,

--- a/cpp/include/ucxx/request_flush.h
+++ b/cpp/include/ucxx/request_flush.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -9,6 +9,7 @@
 
 #include <ucp/api/ucp.h>
 
+#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
 #include <ucxx/request.h>
 #include <ucxx/request_flush_builder.h>
@@ -94,7 +95,7 @@ class RequestFlush : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestFlush>` object
    */
-  friend std::shared_ptr<RequestFlush> createRequestFlush(
+  friend std::shared_ptr<RequestFlush> detail::createRequestFlush(
     std::shared_ptr<Component> endpointOrWorker,
     const data::Flush requestData,
     const bool enablePythonFuture,

--- a/cpp/include/ucxx/request_flush.h
+++ b/cpp/include/ucxx/request_flush.h
@@ -9,8 +9,8 @@
 
 #include <ucp/api/ucp.h>
 
-#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/request.h>
 #include <ucxx/request_flush_builder.h>
 #include <ucxx/typedefs.h>

--- a/cpp/include/ucxx/request_mem.h
+++ b/cpp/include/ucxx/request_mem.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -9,6 +9,7 @@
 
 #include <ucp/api/ucp.h>
 
+#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
 #include <ucxx/request.h>
 #include <ucxx/request_mem_builder.h>
@@ -100,7 +101,7 @@ class RequestMem : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestMem>` object
    */
-  friend std::shared_ptr<RequestMem> createRequestMem(
+  friend std::shared_ptr<RequestMem> detail::createRequestMem(
     std::shared_ptr<Endpoint> endpoint,
     const std::variant<data::MemPut, data::MemGet> requestData,
     const bool enablePythonFuture,

--- a/cpp/include/ucxx/request_mem.h
+++ b/cpp/include/ucxx/request_mem.h
@@ -9,8 +9,8 @@
 
 #include <ucp/api/ucp.h>
 
-#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/request.h>
 #include <ucxx/request_mem_builder.h>
 #include <ucxx/typedefs.h>

--- a/cpp/include/ucxx/request_stream.h
+++ b/cpp/include/ucxx/request_stream.h
@@ -8,8 +8,8 @@
 
 #include <ucp/api/ucp.h>
 
-#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/request.h>
 #include <ucxx/request_data.h>
 #include <ucxx/request_stream_builder.h>

--- a/cpp/include/ucxx/request_stream.h
+++ b/cpp/include/ucxx/request_stream.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -8,6 +8,7 @@
 
 #include <ucp/api/ucp.h>
 
+#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
 #include <ucxx/request.h>
 #include <ucxx/request_data.h>
@@ -68,7 +69,7 @@ class RequestStream : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestStream>` object
    */
-  friend std::shared_ptr<RequestStream> createRequestStream(
+  friend std::shared_ptr<RequestStream> detail::createRequestStream(
     std::shared_ptr<Endpoint> endpoint,
     const std::variant<data::StreamSend, data::StreamReceive> requestData,
     const bool enablePythonFuture);

--- a/cpp/include/ucxx/request_tag.h
+++ b/cpp/include/ucxx/request_tag.h
@@ -9,8 +9,8 @@
 
 #include <ucp/api/ucp.h>
 
-#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/request.h>
 #include <ucxx/request_tag_builder.h>
 #include <ucxx/typedefs.h>

--- a/cpp/include/ucxx/request_tag.h
+++ b/cpp/include/ucxx/request_tag.h
@@ -9,6 +9,7 @@
 
 #include <ucp/api/ucp.h>
 
+#include <ucxx/constructors.h>
 #include <ucxx/delayed_submission.h>
 #include <ucxx/request.h>
 #include <ucxx/request_tag_builder.h>
@@ -95,7 +96,7 @@ class RequestTag : public Request {
    *
    * @returns The `shared_ptr<ucxx::RequestTag>` object
    */
-  friend std::shared_ptr<RequestTag> createRequestTag(
+  friend std::shared_ptr<RequestTag> detail::createRequestTag(
     std::shared_ptr<Component> endpointOrWorker,
     const std::variant<data::TagSend, data::TagReceive, data::TagReceiveWithHandle> requestData,
     const bool enablePythonFuture,

--- a/cpp/include/ucxx/request_tag_multi.h
+++ b/cpp/include/ucxx/request_tag_multi.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -12,6 +12,7 @@
 #include <ucp/api/ucp.h>
 
 #include <ucxx/buffer.h>
+#include <ucxx/constructors.h>
 #include <ucxx/endpoint.h>
 #include <ucxx/future.h>
 #include <ucxx/request.h>
@@ -177,7 +178,7 @@ class RequestTagMulti : public Request {
    *
    * @returns Request to be subsequently checked for the completion and its state.
    */
-  friend std::shared_ptr<RequestTagMulti> createRequestTagMulti(
+  friend std::shared_ptr<RequestTagMulti> detail::createRequestTagMulti(
     std::shared_ptr<Endpoint> endpoint,
     const std::variant<data::TagMultiSend, data::TagMultiReceive> requestData,
     const bool enablePythonFuture);

--- a/cpp/include/ucxx/request_tag_multi.h
+++ b/cpp/include/ucxx/request_tag_multi.h
@@ -12,7 +12,7 @@
 #include <ucp/api/ucp.h>
 
 #include <ucxx/buffer.h>
-#include <ucxx/constructors.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/endpoint.h>
 #include <ucxx/future.h>
 #include <ucxx/request.h>

--- a/cpp/include/ucxx/tag_probe.h
+++ b/cpp/include/ucxx/tag_probe.h
@@ -196,12 +196,4 @@ class TagProbeInfo {
   friend class RequestTag;
 };
 
-/**
- * @brief Deprecated constructor for an unmatched `std::shared_ptr<ucxx::TagProbeInfo>`.
- */
-
-/**
- * @brief Deprecated constructor for a matched `std::shared_ptr<ucxx::TagProbeInfo>`.
- */
-
 }  // namespace ucxx

--- a/cpp/include/ucxx/tag_probe.h
+++ b/cpp/include/ucxx/tag_probe.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -199,14 +199,9 @@ class TagProbeInfo {
 /**
  * @brief Deprecated constructor for an unmatched `std::shared_ptr<ucxx::TagProbeInfo>`.
  */
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::TagProbeInfoBuilder instead.")
-[[nodiscard]] std::shared_ptr<TagProbeInfo> createTagProbeInfo();
 
 /**
  * @brief Deprecated constructor for a matched `std::shared_ptr<ucxx::TagProbeInfo>`.
  */
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::TagProbeInfoBuilder instead.")
-[[nodiscard]] std::shared_ptr<TagProbeInfo> createTagProbeInfo(const ucp_tag_recv_info_t& info,
-                                                               ucp_tag_message_h handle);
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/typedefs.h
+++ b/cpp/include/ucxx/typedefs.h
@@ -20,15 +20,6 @@
 
 #include <ucp/api/ucp.h>
 
-// rapids-pre-commit-hooks: disable[verify-hardcoded-version]
-#ifdef UCXX_DISABLE_DEPRECATED_NON_BUILDER_CONSTRUCTOR_WARNINGS
-#define UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR(message)
-#else
-#define UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR(message) \
-  [[deprecated(message " This non-builder constructor will be removed in UCXX 0.52.")]]
-#endif
-// rapids-pre-commit-hooks: enable[verify-hardcoded-version]
-
 namespace ucxx {
 
 class Buffer;

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -744,9 +744,9 @@ class Worker : public Component {
    * When `remove` is `false` (default), the message remains in the receive queue and
    * a normal tag receive operation must be posted to consume it. When `remove` is `true`,
    * the message is removed from the queue and a message handle is returned that can be
-   * passed directly to `tagRecvWithHandle` for efficient consumption, in this case the
-   * caller is required to call `tagRecvWithHandle`, otherwise a warning will be thrown
-   * during destruction of the returned object.
+   * passed directly to `tagRecvWithHandleBuilder` for efficient consumption, in this case
+   * the caller is required to build a `tagRecvWithHandleBuilder` request, otherwise a
+   * warning will be thrown during destruction of the returned object.
    *
    * Note this is a non-blocking call, if this is being used to actively check for an
    * incoming message the worker should be constantly progress until a valid probe is
@@ -758,7 +758,7 @@ class Worker : public Component {
    * assert(!probe->isMatched());
    *
    * // `ep` is a remote `std::shared_ptr<ucxx::Endpoint` to the local `worker`
-   * ep->tagSend(buffer, length, 0);
+   * ep->tagSendBuilder(buffer, length, 0).build();
    *
    * probe = worker->tagProbe(0);
    * assert(probe->isMatched());
@@ -950,14 +950,14 @@ class Worker : public Component {
    *
    * Checks the worker for any uncaught active messages. An uncaught active message is any
    * active message that has been fully or partially received by the worker, but not matched
-   * by a corresponding `createRequestAmRecv()` call.
+   * by a corresponding active-message receive request.
    *
    * @code{.cpp}
    * // `worker` is `std::shared_ptr<ucxx::Worker>`
    * // `ep` is a remote `std::shared_ptr<ucxx::Endpoint` to the local `worker`
    * assert(!worker->amProbe(ep->getHandle()));
    *
-   * ep->amSend(buffer, length);
+   * ep->amSendBuilder(buffer, length, UCS_MEMORY_TYPE_HOST).build();
    *
    * assert(worker->amProbe(0));
    * @endcode

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -19,9 +19,9 @@
 #include <ucxx/address_builder.h>
 #include <ucxx/buffer.h>
 #include <ucxx/component.h>
-#include <ucxx/constructors.h>
 #include <ucxx/context.h>
 #include <ucxx/delayed_submission.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/endpoint_builder.h>
 #include <ucxx/future.h>
 #include <ucxx/inflight_requests.h>

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -83,7 +83,7 @@ class Worker : public Component {
   std::shared_ptr<DelayedSubmissionCollection> _delayedSubmissionCollection{
     nullptr};  ///< Collection of enqueued delayed submissions
 
-  friend std::shared_ptr<RequestAm> createRequestAm(
+  friend std::shared_ptr<RequestAm> detail::createRequestAm(
     std::shared_ptr<Endpoint> endpoint,
     const std::variant<data::AmSend, data::AmReceive> requestData,
     const bool enablePythonFuture,
@@ -204,14 +204,14 @@ class Worker : public Component {
   Worker& operator=(Worker&& o)    = delete;
 
   /**
-   * @brief Friend declaration for `ucxx::createWorker` with parameters.
+   * @brief Allow the internal worker factory to access the protected constructor.
    *
-   * This friend declaration allows the standalone `ucxx::createWorker` function to access
-   * the protected constructor. See the public declaration for full documentation.
+   * This friend declaration allows `ucxx::detail::createWorker` to access the protected
+   * constructor.
    */
-  friend std::shared_ptr<Worker> createWorker(std::shared_ptr<Context> context,
-                                              const bool enableDelayedSubmission,
-                                              const bool enableFuture);
+  friend std::shared_ptr<Worker> detail::createWorker(std::shared_ptr<Context> context,
+                                                      const bool enableDelayedSubmission,
+                                                      const bool enableFuture);
 
   /**
    * @brief Allow WorkerBuilder to access protected/private constructor.
@@ -903,20 +903,6 @@ class Worker : public Component {
                                                            std::shared_ptr<TagProbeInfo> probeInfo);
 
   /**
-   * @brief Get the address of the UCX worker object.
-   *
-   * Gets the address of the underlying UCX worker object, which can then be passed
-   * to a remote worker, allowing creating a new endpoint to the local worker via
-   * `ucxx::Worker::endpointBuilder()`.
-   *
-   * @throws ucxx::Error if an error occurred while attempting to get the worker address.
-   *
-   * @returns The address of the local worker.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Worker::addressBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Address> getAddress();
-
-  /**
    * @brief Create a builder for this worker's address.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -939,34 +925,6 @@ class Worker : public Component {
   [[nodiscard]] EndpointBuilder endpointBuilder(std::string ipAddress, uint16_t port);
 
   /**
-   * @brief Create endpoint to worker listening on specific IP and port.
-   *
-   * Creates an endpoint to a remote worker listening on a specific IP address and port.
-   * The remote worker must have an active listener created with
-   * `ucxx::Worker::listenerBuilder()`.
-   *
-   * @code{.cpp}
-   * // `worker` is `std::shared_ptr<ucxx::Worker>`
-   * // Create endpoint to worker listening on `10.10.10.10:12345`.
-   * auto ep = worker->endpointBuilder("10.10.10.10", 12345).build();
-   * @endcode
-   *
-   * @throws std::invalid_argument if the IP address or hostname is invalid.
-   * @throws std::bad_alloc if there was an error allocating space to handle the address.
-   * @throws ucxx::Error if an error occurred while attempting to create the endpoint.
-   *
-   * @param[in] ipAddress string containing the IP address of the remote worker.
-   * @param[in] port port number where the remote worker is listening at.
-   * @param[in] endpointErrorHandling enable endpoint error handling if `true`,
-   *                                  disable otherwise.
-   *
-   * @returns The `shared_ptr<ucxx::Endpoint>` object
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use Worker::endpointBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Endpoint> createEndpointFromHostname(
-    std::string ipAddress, uint16_t port, bool endpointErrorHandling = true);
-
-  /**
    * @brief Create a builder for an endpoint to a worker located at a UCX address.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -976,38 +934,6 @@ class Worker : public Component {
    * @returns Builder to configure optional endpoint parameters.
    */
   [[nodiscard]] EndpointBuilder endpointBuilder(std::shared_ptr<Address> address);
-
-  /**
-   * @brief Create endpoint to worker located at UCX address.
-   *
-   * Creates an endpoint to a listener-independent remote worker. The worker location is
-   * identified by its UCX address, wrapped by a `std::shared_ptr<ucxx::Address>` object.
-   *
-   * @code{.cpp}
-   * // `worker` is `std::shared_ptr<ucxx::Worker>`
-   * auto localAddress = worker->addressBuilder().build();
-   *
-   * // pass address to remote process
-   * // ...
-   *
-   * // receive address received from remote process
-   * // ...
-   *
-   * // `remoteAddress` is `std::shared_ptr<ucxx::Address>`
-   * auto ep = worker->endpointBuilder(remoteAddress).build();
-   * @endcode
-   *
-   * @throws ucxx::Error if an error occurred while attempting to create the endpoint.
-   *
-   * @param[in] address address of the remote UCX worker.
-   * @param[in] endpointErrorHandling enable endpoint error handling if `true`,
-   *                                  disable otherwise.
-   *
-   * @returns The `shared_ptr<ucxx::Endpoint>` object
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use Worker::endpointBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(
-    std::shared_ptr<Address> address, bool endpointErrorHandling = true);
 
   /**
    * @brief Create a builder for a listener on this worker.
@@ -1023,28 +949,6 @@ class Worker : public Component {
   [[nodiscard]] ListenerBuilder listenerBuilder(uint16_t port,
                                                 ucp_listener_conn_callback_t callback,
                                                 void* callbackArgs);
-
-  /**
-   * @brief Listen for remote connections on given port.
-   *
-   * Starts a listener on given port. The listener allows remote processes to connect to
-   * the local worker via an IP and port pair. The connection is then handle via a
-   * callback specified by the user.
-   *
-   * @throws std::bad_alloc if there was an error allocating space to handle the address.
-   * @throws ucxx::Error if an error occurred while attempting to create the listener or
-   *                     to acquire its address.
-   *
-   * @param[in] port port number where to listen at.
-   * @param[in] callback to handle each incoming connection.
-   * @param[in] callbackArgs pointer to argument to pass to the callback.
-   *
-   * @returns The `shared_ptr<ucxx::Listener>` object
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Worker::listenerBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Listener> createListener(uint16_t port,
-                                                         ucp_listener_conn_callback_t callback,
-                                                         void* callbackArgs);
 
   /**
    * @brief Register allocator for active messages.
@@ -1225,9 +1129,5 @@ class Worker : public Component {
  *                         `ucxx::Request`, currently used only by `ucxx::python::Worker`.
  * @returns The `shared_ptr<ucxx::Worker>` object
  */
-UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::workerBuilder() instead.")
-[[nodiscard]] std::shared_ptr<Worker> createWorker(std::shared_ptr<Context> context,
-                                                   const bool enableDelayedSubmission,
-                                                   const bool enableFuture);
 
 }  // namespace ucxx

--- a/cpp/include/ucxx/worker.h
+++ b/cpp/include/ucxx/worker.h
@@ -780,47 +780,6 @@ class Worker : public Component {
                                                        const bool remove     = false) const;
 
   /**
-   * @brief Enqueue a tag receive operation.
-   *
-   * Enqueue a tag receive operation, returning a `std::shared<ucxx::Request>` that can
-   * be later awaited and checked for errors. This is a non-blocking operation, and the
-   * status of the transfer must be verified from the resulting request object before the
-   * data can be consumed.
-   *
-   * Using a future may be requested by specifying `enableFuture` if the worker
-   * implementation has support for it. If a future is requested, the application must then
-   * await on this future to ensure the transfer has completed.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] buffer            a raw pointer to pre-allocated memory where resulting
-   *                              data will be stored.
-   * @param[in] length            the size in bytes of the tag message to be received.
-   * @param[in] tag               the tag to match.
-   * @param[in] tagMask           the tag mask to use.
-   * @param[in] enableFuture      whether a future should be created and subsequently
-   *                              notified.
-   * @param[in] callbackFunction  user-defined callback function to call upon completion.
-   * @param[in] callbackData      user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Worker::tagRecvBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> tagRecv(
-    void* buffer,
-    size_t length,
-    Tag tag,
-    TagMask tagMask,
-    const bool enableFuture                      = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
-
-  /**
    * @brief Create a builder for a tag receive operation.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -838,37 +797,6 @@ class Worker : public Component {
                                                  size_t length,
                                                  Tag tag,
                                                  TagMask tagMask);
-
-  /**
-   * @brief Enqueue a tag receive operation using a message handle.
-   *
-   * Enqueue a tag receive operation using a message handle obtained from `tagProbe` with
-   * `remove=true`. This is more efficient than regular `tagRecv` as it doesn't need to
-   * go through the message matching queue again.
-   *
-   * Using a future may be requested by specifying `enableFuture` if the worker
-   * implementation has support for it. If a future is requested, the application must then
-   * await on this future to ensure the transfer has completed.
-   *
-   * @param[in] buffer            a raw pointer to pre-allocated memory where resulting
-   *                              data will be stored. The buffer must be large enough to
-   *                              hold the message data, otherwise the behavior is undefined.
-   *                              The buffer must be pre-allocated.
-   * @param[in] probeInfo         the TagProbeInfo object containing message length and handle.
-   * @param[in] enableFuture      whether a future should be created and subsequently
-   *                              notified.
-   * @param[in] callbackFunction  user-defined callback function to call upon completion.
-   * @param[in] callbackData      user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Worker::tagRecvWithHandleBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> tagRecvWithHandle(
-    void* buffer,
-    std::shared_ptr<TagProbeInfo> probeInfo,
-    const bool enableFuture                      = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
 
   /**
    * @brief Create a builder for a tag receive operation using a message handle.
@@ -1039,39 +967,6 @@ class Worker : public Component {
   [[nodiscard]] bool amProbe(const ucp_ep_h endpointHandle) const;
 
   /**
-   * @brief Enqueue a flush operation.
-   *
-   * Enqueue request to flush outstanding AMO (Atomic Memory Operation) and RMA (Remote
-   * Memory Access) operations on the worker, returning a pointer to a request object that
-   * can be later awaited and checked for errors. This is a non-blocking operation, and its
-   * status must be verified from the resulting request object to confirm the flush
-   * operation has completed successfully.
-   *
-   * Using a Python future may be requested by specifying `enablePythonFuture`. If a
-   * Python future is requested, the Python application must then await on this future to
-   * ensure the transfer has completed.
-   *
-   * @note If a `callbackFunction` is specified, the lifetime of `callbackData` and of any
-   * other objects used in the scope of `callbackFunction` must be guaranteed by the caller
-   * until it executes or `isCompleted()` becomes true. The `callbackFunction` executes in
-   * the thread progressing the `ucxx::Worker`, unless the request completes immediately,
-   * in which case the callback will also execute immediately within the calling thread and
-   * before the method returns.
-   *
-   * @param[in] enablePythonFuture  whether a python future should be created and
-   *                                subsequently notified.
-   * @param[in] callbackFunction    user-defined callback function to call upon completion.
-   * @param[in] callbackData        user-defined data to pass to the `callbackFunction`.
-   *
-   * @returns Request to be subsequently checked for the completion and its state.
-   */
-  UCXX_DEPRECATED_NON_BUILDER_CONSTRUCTOR("Use ucxx::Worker::flushBuilder() instead.")
-  [[nodiscard]] std::shared_ptr<Request> flush(
-    const bool enablePythonFuture                = false,
-    RequestCallbackUserFunction callbackFunction = nullptr,
-    RequestCallbackUserData callbackData         = nullptr);
-
-  /**
    * @brief Create a builder for a flush operation.
    *
    * Calling this method only creates the builder. Finalizing it with `.build()` or
@@ -1107,27 +1002,5 @@ class Worker : public Component {
    */
   [[nodiscard]] Attributes queryAttributes() const;
 };
-
-/**
- * @brief Constructor of `shared_ptr<ucxx::Worker>` with parameters.
- *
- * The constructor for a `shared_ptr<ucxx::Worker>` object. The default constructor is
- * made private to ensure all UCXX objects are shared pointers for correct lifetime
- * management.
- *
- * @code{.cpp}
- *   // context is `std::shared_ptr<ucxx::Context>`
- *   auto worker = ucxx::workerBuilder(context).build();
- * @endcode
- *
- * @param[in] context the context from which to create the worker.
- * @param[in] enableDelayedSubmission if `true`, each `ucxx::Request` will not be
- *                                    submitted immediately, but instead delayed to
- *                                    the progress thread. Requires use of the
- *                                    progress thread.
- * @param[in] enableFuture if `true`, notifies the future associated with each
- *                         `ucxx::Request`, currently used only by `ucxx::python::Worker`.
- * @returns The `shared_ptr<ucxx::Worker>` object
- */
 
 }  // namespace ucxx

--- a/cpp/python/include/ucxx/python/worker.h
+++ b/cpp/python/include/ucxx/python/worker.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
@@ -63,13 +63,13 @@ class Worker : public ::ucxx::Worker {
    *
    * @code{.cpp}
    * // context is `std::shared_ptr<ucxx::Context>`
-   * auto worker = ucxx::createWorker(context, false, false);
+   * auto worker = ucxx::python::createWorker(context, false, false);
    * @endcode
    *
    * @cond Doxygen_Suppress
    *
    * Note: this parameter list is suppressed due to a warning in doxygen 1.9.1.
-   * It appears to conflict with the ucxx::createWorker docstring.
+   * It appears to conflict with the ucxx::python::createWorker docstring.
    *
    * @param[in] context the context from which to create the worker.
    * @param[in] enableDelayedSubmission if `true`, each `ucxx::Request` will not be

--- a/cpp/src/address.cpp
+++ b/cpp/src/address.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstring>
@@ -54,16 +54,6 @@ std::shared_ptr<Address> createAddressFromString(std::string_view addressString)
 }
 
 }  // namespace detail
-
-std::shared_ptr<Address> createAddressFromWorker(std::shared_ptr<Worker> worker)
-{
-  return detail::createAddressFromWorker(std::move(worker));
-}
-
-std::shared_ptr<Address> createAddressFromString(std::string_view addressString)
-{
-  return detail::createAddressFromString(addressString);
-}
 
 ucp_address_t* Address::getHandle() const { return _handle; }
 

--- a/cpp/src/address_builder.cpp
+++ b/cpp/src/address_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -8,8 +8,8 @@
 #include <utility>
 
 #include <ucxx/address_builder.h>
-#include <ucxx/constructors.h>
 #include <ucxx/detail/builder_utils.h>
+#include <ucxx/detail/constructors.h>
 
 namespace ucxx {
 

--- a/cpp/src/context.cpp
+++ b/cpp/src/context.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <ucxx/context.h>
+
 #include <ucxx/log.h>
 #include <ucxx/utils/file_descriptor.h>
 #include <ucxx/utils/ucx.h>
@@ -68,7 +69,8 @@ Context::Context(const ConfigMap ucxConfig, const uint64_t featureFlags)
     ucxx_info("  %s: %s", kv.first.c_str(), kv.second.c_str());
 }
 
-std::shared_ptr<Context> createContext(const ConfigMap ucxConfig, const uint64_t featureFlags)
+std::shared_ptr<Context> detail::createContext(const ConfigMap ucxConfig,
+                                               const uint64_t featureFlags)
 {
   return std::shared_ptr<Context>(new Context(ucxConfig, featureFlags));
 }
@@ -99,25 +101,9 @@ WorkerBuilder Context::workerBuilder()
   return WorkerBuilder(std::static_pointer_cast<Context>(shared_from_this()));
 }
 
-std::shared_ptr<Worker> Context::createWorker(const bool enableDelayedSubmission,
-                                              const bool enableFuture)
-{
-  auto context = std::static_pointer_cast<Context>(shared_from_this());
-  auto worker  = ucxx::createWorker(context, enableDelayedSubmission, enableFuture);
-  return worker;
-}
-
 MemoryHandleBuilder Context::memoryHandleBuilder(size_t size)
 {
   return MemoryHandleBuilder(std::static_pointer_cast<Context>(shared_from_this()), size);
-}
-
-std::shared_ptr<MemoryHandle> Context::createMemoryHandle(const size_t size,
-                                                          void* buffer,
-                                                          const ucs_memory_type_t memoryType)
-{
-  auto context = std::static_pointer_cast<Context>(shared_from_this());
-  return ucxx::createMemoryHandle(context, size, buffer, memoryType);
 }
 
 }  // namespace ucxx

--- a/cpp/src/context_builder.cpp
+++ b/cpp/src/context_builder.cpp
@@ -1,10 +1,11 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
 #include <utility>
 
+#include <ucxx/constructors.h>
 #include <ucxx/context.h>
 #include <ucxx/context_builder.h>
 #include <ucxx/detail/builder_utils.h>
@@ -32,7 +33,7 @@ ContextBuilder& ContextBuilder::configMap(ConfigMap configMap)
 
 std::shared_ptr<Context> ContextBuilder::build()
 {
-  return ucxx::createContext(_impl->configMap, _impl->featureFlags);
+  return detail::createContext(_impl->configMap, _impl->featureFlags);
 }
 
 }  // namespace ucxx

--- a/cpp/src/context_builder.cpp
+++ b/cpp/src/context_builder.cpp
@@ -5,10 +5,10 @@
 #include <memory>
 #include <utility>
 
-#include <ucxx/constructors.h>
 #include <ucxx/context.h>
 #include <ucxx/context_builder.h>
 #include <ucxx/detail/builder_utils.h>
+#include <ucxx/detail/constructors.h>
 
 namespace ucxx {
 

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -246,16 +246,6 @@ Endpoint::~Endpoint()
   ucxx_trace("ucxx::Endpoint destroyed: %p, UCP handle: %p", this, _originalHandle);
 }
 
-std::shared_ptr<Request> Endpoint::close(const bool enablePythonFuture,
-                                         EndpointCloseCallbackUserFunction callbackFunction,
-                                         EndpointCloseCallbackUserData callbackData)
-{
-  return closeRequest(_endpointErrorHandling,
-                      enablePythonFuture,
-                      std::move(callbackFunction),
-                      std::move(callbackData));
-}
-
 RequestEndpointCloseBuilder Endpoint::closeBuilder()
 {
   return requestEndpointCloseBuilder(std::static_pointer_cast<Endpoint>(shared_from_this()),
@@ -485,27 +475,6 @@ size_t Endpoint::cancelInflightRequestsBlocking(uint64_t period, uint64_t maxAtt
 
 size_t Endpoint::getCancelingSize() const { return _inflightRequests->getCancelingSize(); }
 
-std::shared_ptr<Request> Endpoint::amSend(
-  const void* const buffer,
-  const size_t length,
-  const ucs_memory_type_t memoryType,
-  const std::optional<AmReceiverCallbackInfo> receiverCallbackInfo,
-  const bool enablePythonFuture,
-  RequestCallbackUserFunction callbackFunction,
-  RequestCallbackUserData callbackData)
-{
-  auto params                 = AmSendParams{};
-  params.memoryType           = memoryType;
-  params.receiverCallbackInfo = receiverCallbackInfo;
-
-  return amSend(buffer,
-                length,
-                params,
-                enablePythonFuture,
-                std::move(callbackFunction),
-                std::move(callbackData));
-}
-
 RequestAmBuilder Endpoint::amSendBuilder(const void* const buffer,
                                          const size_t length,
                                          const ucs_memory_type_t memoryType)
@@ -516,21 +485,6 @@ RequestAmBuilder Endpoint::amSendBuilder(const void* const buffer,
   return amSendBuilder(buffer, length, params);
 }
 
-std::shared_ptr<Request> Endpoint::amSend(const void* const buffer,
-                                          const size_t length,
-                                          const AmSendParams& params,
-                                          const bool enablePythonFuture,
-                                          RequestCallbackUserFunction callbackFunction,
-                                          RequestCallbackUserData callbackData)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(detail::createRequestAm(endpoint,
-                                                         data::AmSend(buffer, length, params),
-                                                         enablePythonFuture,
-                                                         std::move(callbackFunction),
-                                                         std::move(callbackData)));
-}
-
 RequestAmBuilder Endpoint::amSendBuilder(const void* const buffer,
                                          const size_t length,
                                          const AmSendParams& params)
@@ -539,59 +493,16 @@ RequestAmBuilder Endpoint::amSendBuilder(const void* const buffer,
   return RequestAmBuilder(std::move(endpoint), data::AmSend(buffer, length, params));
 }
 
-std::shared_ptr<Request> Endpoint::amSend(std::vector<ucp_dt_iov_t> iov,
-                                          const AmSendParams& params,
-                                          const bool enablePythonFuture,
-                                          RequestCallbackUserFunction callbackFunction,
-                                          RequestCallbackUserData callbackData)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(detail::createRequestAm(endpoint,
-                                                         data::AmSend(std::move(iov), params),
-                                                         enablePythonFuture,
-                                                         std::move(callbackFunction),
-                                                         std::move(callbackData)));
-}
-
 RequestAmBuilder Endpoint::amSendBuilder(std::vector<ucp_dt_iov_t> iov, const AmSendParams& params)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
   return RequestAmBuilder(std::move(endpoint), data::AmSend(std::move(iov), params));
 }
 
-std::shared_ptr<Request> Endpoint::amRecv(const bool enablePythonFuture,
-                                          RequestCallbackUserFunction callbackFunction,
-                                          RequestCallbackUserData callbackData)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(detail::createRequestAm(endpoint,
-                                                         data::AmReceive(),
-                                                         enablePythonFuture,
-                                                         std::move(callbackFunction),
-                                                         std::move(callbackData)));
-}
-
 RequestAmBuilder Endpoint::amRecvBuilder()
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
   return RequestAmBuilder(std::move(endpoint), data::AmReceive());
-}
-
-std::shared_ptr<Request> Endpoint::memGet(void* buffer,
-                                          size_t length,
-                                          uint64_t remoteAddr,
-                                          ucp_rkey_h rkey,
-                                          const bool enablePythonFuture,
-                                          RequestCallbackUserFunction callbackFunction,
-                                          RequestCallbackUserData callbackData)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(
-    detail::createRequestMem(endpoint,
-                             data::MemGet(buffer, length, remoteAddr, rkey),
-                             enablePythonFuture,
-                             std::move(callbackFunction),
-                             std::move(callbackData)));
 }
 
 RequestMemBuilder Endpoint::memGetBuilder(void* buffer,
@@ -603,45 +514,11 @@ RequestMemBuilder Endpoint::memGetBuilder(void* buffer,
   return RequestMemBuilder(std::move(endpoint), data::MemGet(buffer, length, remoteAddr, rkey));
 }
 
-std::shared_ptr<Request> Endpoint::memGet(void* buffer,
-                                          size_t length,
-                                          std::shared_ptr<RemoteKey> remoteKey,
-                                          uint64_t remoteAddressOffset,
-                                          const bool enablePythonFuture,
-                                          RequestCallbackUserFunction callbackFunction,
-                                          RequestCallbackUserData callbackData)
-{
-  return memGet(buffer,
-                length,
-                remoteKey->getBaseAddress() + remoteAddressOffset,
-                remoteKey->getHandle(),
-                enablePythonFuture,
-                std::move(callbackFunction),
-                std::move(callbackData));
-}
-
 RequestMemBuilder Endpoint::memGetBuilder(void* buffer,
                                           size_t length,
                                           std::shared_ptr<RemoteKey> remoteKey)
 {
   return memGetBuilder(buffer, length, remoteKey->getBaseAddress(), remoteKey->getHandle());
-}
-
-std::shared_ptr<Request> Endpoint::memPut(const void* const buffer,
-                                          size_t length,
-                                          uint64_t remoteAddr,
-                                          ucp_rkey_h rkey,
-                                          const bool enablePythonFuture,
-                                          RequestCallbackUserFunction callbackFunction,
-                                          RequestCallbackUserData callbackData)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(
-    detail::createRequestMem(endpoint,
-                             data::MemPut(buffer, length, remoteAddr, rkey),
-                             enablePythonFuture,
-                             std::move(callbackFunction),
-                             std::move(callbackData)));
 }
 
 RequestMemBuilder Endpoint::memPutBuilder(const void* const buffer,
@@ -653,37 +530,11 @@ RequestMemBuilder Endpoint::memPutBuilder(const void* const buffer,
   return RequestMemBuilder(std::move(endpoint), data::MemPut(buffer, length, remoteAddr, rkey));
 }
 
-std::shared_ptr<Request> Endpoint::memPut(const void* const buffer,
-                                          size_t length,
-                                          std::shared_ptr<RemoteKey> remoteKey,
-                                          uint64_t remoteAddressOffset,
-                                          const bool enablePythonFuture,
-                                          RequestCallbackUserFunction callbackFunction,
-                                          RequestCallbackUserData callbackData)
-{
-  return memPut(buffer,
-                length,
-                remoteKey->getBaseAddress() + remoteAddressOffset,
-                remoteKey->getHandle(),
-                enablePythonFuture,
-                std::move(callbackFunction),
-                std::move(callbackData));
-}
-
 RequestMemBuilder Endpoint::memPutBuilder(const void* const buffer,
                                           size_t length,
                                           std::shared_ptr<RemoteKey> remoteKey)
 {
   return memPutBuilder(buffer, length, remoteKey->getBaseAddress(), remoteKey->getHandle());
-}
-
-std::shared_ptr<Request> Endpoint::streamSend(const void* const buffer,
-                                              size_t length,
-                                              const bool enablePythonFuture)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(
-    detail::createRequestStream(endpoint, data::StreamSend(buffer, length), enablePythonFuture));
 }
 
 RequestStreamBuilder Endpoint::streamSendBuilder(const void* const buffer, size_t length)
@@ -692,34 +543,10 @@ RequestStreamBuilder Endpoint::streamSendBuilder(const void* const buffer, size_
   return RequestStreamBuilder(std::move(endpoint), data::StreamSend(buffer, length));
 }
 
-std::shared_ptr<Request> Endpoint::streamRecv(void* buffer,
-                                              size_t length,
-                                              const bool enablePythonFuture)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(
-    detail::createRequestStream(endpoint, data::StreamReceive(buffer, length), enablePythonFuture));
-}
-
 RequestStreamBuilder Endpoint::streamRecvBuilder(void* buffer, size_t length)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
   return RequestStreamBuilder(std::move(endpoint), data::StreamReceive(buffer, length));
-}
-
-std::shared_ptr<Request> Endpoint::tagSend(const void* const buffer,
-                                           size_t length,
-                                           Tag tag,
-                                           const bool enablePythonFuture,
-                                           RequestCallbackUserFunction callbackFunction,
-                                           RequestCallbackUserData callbackData)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(detail::createRequestTag(endpoint,
-                                                          data::TagSend(buffer, length, tag),
-                                                          enablePythonFuture,
-                                                          std::move(callbackFunction),
-                                                          std::move(callbackData)));
 }
 
 RequestTagBuilder Endpoint::tagSendBuilder(const void* const buffer, size_t length, Tag tag)
@@ -728,38 +555,10 @@ RequestTagBuilder Endpoint::tagSendBuilder(const void* const buffer, size_t leng
   return RequestTagBuilder(std::move(endpoint), data::TagSend(buffer, length, tag));
 }
 
-std::shared_ptr<Request> Endpoint::tagRecv(void* buffer,
-                                           size_t length,
-                                           Tag tag,
-                                           TagMask tagMask,
-                                           const bool enablePythonFuture,
-                                           RequestCallbackUserFunction callbackFunction,
-                                           RequestCallbackUserData callbackData)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(
-    detail::createRequestTag(endpoint,
-                             data::TagReceive(buffer, length, tag, tagMask),
-                             enablePythonFuture,
-                             std::move(callbackFunction),
-                             std::move(callbackData)));
-}
-
 RequestTagBuilder Endpoint::tagRecvBuilder(void* buffer, size_t length, Tag tag, TagMask tagMask)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
   return RequestTagBuilder(std::move(endpoint), data::TagReceive(buffer, length, tag, tagMask));
-}
-
-std::shared_ptr<Request> Endpoint::tagMultiSend(const std::vector<const void*>& buffer,
-                                                const std::vector<size_t>& size,
-                                                const std::vector<int>& isCUDA,
-                                                const Tag tag,
-                                                const bool enablePythonFuture)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(detail::createRequestTagMulti(
-    endpoint, data::TagMultiSend(buffer, size, isCUDA, tag), enablePythonFuture));
 }
 
 RequestTagMultiBuilder Endpoint::tagMultiSendBuilder(const std::vector<const void*>& buffer,
@@ -771,31 +570,10 @@ RequestTagMultiBuilder Endpoint::tagMultiSendBuilder(const std::vector<const voi
   return RequestTagMultiBuilder(std::move(endpoint), data::TagMultiSend(buffer, size, isCUDA, tag));
 }
 
-std::shared_ptr<Request> Endpoint::tagMultiRecv(const Tag tag,
-                                                const TagMask tagMask,
-                                                const bool enablePythonFuture)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(detail::createRequestTagMulti(
-    endpoint, data::TagMultiReceive(tag, tagMask), enablePythonFuture));
-}
-
 RequestTagMultiBuilder Endpoint::tagMultiRecvBuilder(const Tag tag, const TagMask tagMask)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
   return RequestTagMultiBuilder(std::move(endpoint), data::TagMultiReceive(tag, tagMask));
-}
-
-std::shared_ptr<Request> Endpoint::flush(const bool enablePythonFuture,
-                                         RequestCallbackUserFunction callbackFunction,
-                                         RequestCallbackUserData callbackData)
-{
-  auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(detail::createRequestFlush(endpoint,
-                                                            data::Flush(),
-                                                            enablePythonFuture,
-                                                            std::move(callbackFunction),
-                                                            std::move(callbackData)));
 }
 
 RequestFlushBuilder Endpoint::flushBuilder()

--- a/cpp/src/endpoint.cpp
+++ b/cpp/src/endpoint.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -16,6 +16,7 @@
 
 #include <ucxx/component.h>
 #include <ucxx/endpoint.h>
+
 #include <ucxx/exception.h>
 #include <ucxx/listener.h>
 #include <ucxx/remote_key.h>
@@ -180,10 +181,10 @@ void Endpoint::create(ucp_ep_params_t* params)
              _endpointErrorHandling);
 }
 
-std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> worker,
-                                                     std::string ipAddress,
-                                                     uint16_t port,
-                                                     bool endpointErrorHandling)
+std::shared_ptr<Endpoint> detail::createEndpointFromHostname(std::shared_ptr<Worker> worker,
+                                                             std::string ipAddress,
+                                                             uint16_t port,
+                                                             bool endpointErrorHandling)
 {
   if (worker == nullptr || worker->getHandle() == nullptr)
     throw ucxx::Error("Worker not initialized");
@@ -202,9 +203,9 @@ std::shared_ptr<Endpoint> createEndpointFromHostname(std::shared_ptr<Worker> wor
   return ep;
 }
 
-std::shared_ptr<Endpoint> createEndpointFromConnRequest(std::shared_ptr<Listener> listener,
-                                                        ucp_conn_request_h connRequest,
-                                                        bool endpointErrorHandling)
+std::shared_ptr<Endpoint> detail::createEndpointFromConnRequest(std::shared_ptr<Listener> listener,
+                                                                ucp_conn_request_h connRequest,
+                                                                bool endpointErrorHandling)
 {
   if (listener == nullptr || listener->getHandle() == nullptr)
     throw ucxx::Error("Worker not initialized");
@@ -220,9 +221,9 @@ std::shared_ptr<Endpoint> createEndpointFromConnRequest(std::shared_ptr<Listener
   return ep;
 }
 
-std::shared_ptr<Endpoint> createEndpointFromWorkerAddress(std::shared_ptr<Worker> worker,
-                                                          std::shared_ptr<Address> address,
-                                                          bool endpointErrorHandling)
+std::shared_ptr<Endpoint> detail::createEndpointFromWorkerAddress(std::shared_ptr<Worker> worker,
+                                                                  std::shared_ptr<Address> address,
+                                                                  bool endpointErrorHandling)
 {
   if (worker == nullptr || worker->getHandle() == nullptr)
     throw ucxx::Error("Worker not initialized");
@@ -286,7 +287,7 @@ std::shared_ptr<RequestEndpointClose> Endpoint::closeRequest(
     }
   };
 
-  auto req = createRequestEndpointClose(
+  auto req = detail::createRequestEndpointClose(
     endpoint, data::EndpointClose(force), enablePythonFuture, combineCallbacksFunction, nullptr);
   std::ignore = registerInflightRequest(req);
   return req;
@@ -523,11 +524,11 @@ std::shared_ptr<Request> Endpoint::amSend(const void* const buffer,
                                           RequestCallbackUserData callbackData)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestAm(endpoint,
-                                                 data::AmSend(buffer, length, params),
-                                                 enablePythonFuture,
-                                                 std::move(callbackFunction),
-                                                 std::move(callbackData)));
+  return registerInflightRequest(detail::createRequestAm(endpoint,
+                                                         data::AmSend(buffer, length, params),
+                                                         enablePythonFuture,
+                                                         std::move(callbackFunction),
+                                                         std::move(callbackData)));
 }
 
 RequestAmBuilder Endpoint::amSendBuilder(const void* const buffer,
@@ -545,11 +546,11 @@ std::shared_ptr<Request> Endpoint::amSend(std::vector<ucp_dt_iov_t> iov,
                                           RequestCallbackUserData callbackData)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestAm(endpoint,
-                                                 data::AmSend(std::move(iov), params),
-                                                 enablePythonFuture,
-                                                 std::move(callbackFunction),
-                                                 std::move(callbackData)));
+  return registerInflightRequest(detail::createRequestAm(endpoint,
+                                                         data::AmSend(std::move(iov), params),
+                                                         enablePythonFuture,
+                                                         std::move(callbackFunction),
+                                                         std::move(callbackData)));
 }
 
 RequestAmBuilder Endpoint::amSendBuilder(std::vector<ucp_dt_iov_t> iov, const AmSendParams& params)
@@ -563,11 +564,11 @@ std::shared_ptr<Request> Endpoint::amRecv(const bool enablePythonFuture,
                                           RequestCallbackUserData callbackData)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestAm(endpoint,
-                                                 data::AmReceive(),
-                                                 enablePythonFuture,
-                                                 std::move(callbackFunction),
-                                                 std::move(callbackData)));
+  return registerInflightRequest(detail::createRequestAm(endpoint,
+                                                         data::AmReceive(),
+                                                         enablePythonFuture,
+                                                         std::move(callbackFunction),
+                                                         std::move(callbackData)));
 }
 
 RequestAmBuilder Endpoint::amRecvBuilder()
@@ -585,11 +586,12 @@ std::shared_ptr<Request> Endpoint::memGet(void* buffer,
                                           RequestCallbackUserData callbackData)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestMem(endpoint,
-                                                  data::MemGet(buffer, length, remoteAddr, rkey),
-                                                  enablePythonFuture,
-                                                  std::move(callbackFunction),
-                                                  std::move(callbackData)));
+  return registerInflightRequest(
+    detail::createRequestMem(endpoint,
+                             data::MemGet(buffer, length, remoteAddr, rkey),
+                             enablePythonFuture,
+                             std::move(callbackFunction),
+                             std::move(callbackData)));
 }
 
 RequestMemBuilder Endpoint::memGetBuilder(void* buffer,
@@ -634,11 +636,12 @@ std::shared_ptr<Request> Endpoint::memPut(const void* const buffer,
                                           RequestCallbackUserData callbackData)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestMem(endpoint,
-                                                  data::MemPut(buffer, length, remoteAddr, rkey),
-                                                  enablePythonFuture,
-                                                  std::move(callbackFunction),
-                                                  std::move(callbackData)));
+  return registerInflightRequest(
+    detail::createRequestMem(endpoint,
+                             data::MemPut(buffer, length, remoteAddr, rkey),
+                             enablePythonFuture,
+                             std::move(callbackFunction),
+                             std::move(callbackData)));
 }
 
 RequestMemBuilder Endpoint::memPutBuilder(const void* const buffer,
@@ -680,7 +683,7 @@ std::shared_ptr<Request> Endpoint::streamSend(const void* const buffer,
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
   return registerInflightRequest(
-    createRequestStream(endpoint, data::StreamSend(buffer, length), enablePythonFuture));
+    detail::createRequestStream(endpoint, data::StreamSend(buffer, length), enablePythonFuture));
 }
 
 RequestStreamBuilder Endpoint::streamSendBuilder(const void* const buffer, size_t length)
@@ -695,7 +698,7 @@ std::shared_ptr<Request> Endpoint::streamRecv(void* buffer,
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
   return registerInflightRequest(
-    createRequestStream(endpoint, data::StreamReceive(buffer, length), enablePythonFuture));
+    detail::createRequestStream(endpoint, data::StreamReceive(buffer, length), enablePythonFuture));
 }
 
 RequestStreamBuilder Endpoint::streamRecvBuilder(void* buffer, size_t length)
@@ -712,11 +715,11 @@ std::shared_ptr<Request> Endpoint::tagSend(const void* const buffer,
                                            RequestCallbackUserData callbackData)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestTag(endpoint,
-                                                  data::TagSend(buffer, length, tag),
-                                                  enablePythonFuture,
-                                                  std::move(callbackFunction),
-                                                  std::move(callbackData)));
+  return registerInflightRequest(detail::createRequestTag(endpoint,
+                                                          data::TagSend(buffer, length, tag),
+                                                          enablePythonFuture,
+                                                          std::move(callbackFunction),
+                                                          std::move(callbackData)));
 }
 
 RequestTagBuilder Endpoint::tagSendBuilder(const void* const buffer, size_t length, Tag tag)
@@ -734,11 +737,12 @@ std::shared_ptr<Request> Endpoint::tagRecv(void* buffer,
                                            RequestCallbackUserData callbackData)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestTag(endpoint,
-                                                  data::TagReceive(buffer, length, tag, tagMask),
-                                                  enablePythonFuture,
-                                                  std::move(callbackFunction),
-                                                  std::move(callbackData)));
+  return registerInflightRequest(
+    detail::createRequestTag(endpoint,
+                             data::TagReceive(buffer, length, tag, tagMask),
+                             enablePythonFuture,
+                             std::move(callbackFunction),
+                             std::move(callbackData)));
 }
 
 RequestTagBuilder Endpoint::tagRecvBuilder(void* buffer, size_t length, Tag tag, TagMask tagMask)
@@ -754,7 +758,7 @@ std::shared_ptr<Request> Endpoint::tagMultiSend(const std::vector<const void*>& 
                                                 const bool enablePythonFuture)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestTagMulti(
+  return registerInflightRequest(detail::createRequestTagMulti(
     endpoint, data::TagMultiSend(buffer, size, isCUDA, tag), enablePythonFuture));
 }
 
@@ -772,8 +776,8 @@ std::shared_ptr<Request> Endpoint::tagMultiRecv(const Tag tag,
                                                 const bool enablePythonFuture)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(
-    createRequestTagMulti(endpoint, data::TagMultiReceive(tag, tagMask), enablePythonFuture));
+  return registerInflightRequest(detail::createRequestTagMulti(
+    endpoint, data::TagMultiReceive(tag, tagMask), enablePythonFuture));
 }
 
 RequestTagMultiBuilder Endpoint::tagMultiRecvBuilder(const Tag tag, const TagMask tagMask)
@@ -787,11 +791,11 @@ std::shared_ptr<Request> Endpoint::flush(const bool enablePythonFuture,
                                          RequestCallbackUserData callbackData)
 {
   auto endpoint = std::static_pointer_cast<Endpoint>(shared_from_this());
-  return registerInflightRequest(createRequestFlush(endpoint,
-                                                    data::Flush(),
-                                                    enablePythonFuture,
-                                                    std::move(callbackFunction),
-                                                    std::move(callbackData)));
+  return registerInflightRequest(detail::createRequestFlush(endpoint,
+                                                            data::Flush(),
+                                                            enablePythonFuture,
+                                                            std::move(callbackFunction),
+                                                            std::move(callbackData)));
 }
 
 RequestFlushBuilder Endpoint::flushBuilder()

--- a/cpp/src/endpoint_builder.cpp
+++ b/cpp/src/endpoint_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -73,13 +73,13 @@ std::shared_ptr<Endpoint> EndpointBuilder::build()
 {
   switch (_impl->source) {
     case EndpointBuilderSource::Hostname:
-      return ucxx::createEndpointFromHostname(
+      return detail::createEndpointFromHostname(
         _impl->worker, _impl->ipAddress, _impl->port, _impl->endpointErrorHandling);
     case EndpointBuilderSource::ConnRequest:
-      return ucxx::createEndpointFromConnRequest(
+      return detail::createEndpointFromConnRequest(
         _impl->listener, _impl->connRequest, _impl->endpointErrorHandling);
     case EndpointBuilderSource::WorkerAddress:
-      return ucxx::createEndpointFromWorkerAddress(
+      return detail::createEndpointFromWorkerAddress(
         _impl->worker, _impl->address, _impl->endpointErrorHandling);
   }
 

--- a/cpp/src/endpoint_builder.cpp
+++ b/cpp/src/endpoint_builder.cpp
@@ -7,8 +7,8 @@
 #include <string>
 #include <utility>
 
-#include <ucxx/constructors.h>
 #include <ucxx/detail/builder_utils.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/endpoint_builder.h>
 
 namespace ucxx {

--- a/cpp/src/listener.cpp
+++ b/cpp/src/listener.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -11,6 +11,7 @@
 
 #include <ucxx/exception.h>
 #include <ucxx/listener.h>
+
 #include <ucxx/utils/callback_notifier.h>
 #include <ucxx/utils/sockaddr.h>
 #include <ucxx/utils/ucx.h>
@@ -77,25 +78,9 @@ std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
 
 }  // namespace detail
 
-std::shared_ptr<Listener> createListener(std::shared_ptr<Worker> worker,
-                                         uint16_t port,
-                                         ucp_listener_conn_callback_t callback,
-                                         void* callbackArgs)
-{
-  return detail::createListener(std::move(worker), port, callback, callbackArgs);
-}
-
 EndpointBuilder Listener::endpointBuilder(ucp_conn_request_h connRequest)
 {
   return EndpointBuilder(std::static_pointer_cast<Listener>(shared_from_this()), connRequest);
-}
-
-std::shared_ptr<Endpoint> Listener::createEndpointFromConnRequest(ucp_conn_request_h connRequest,
-                                                                  bool endpointErrorHandling)
-{
-  auto listener = std::static_pointer_cast<Listener>(shared_from_this());
-  auto endpoint = ucxx::createEndpointFromConnRequest(listener, connRequest, endpointErrorHandling);
-  return endpoint;
 }
 
 ucp_listener_h Listener::getHandle() { return _handle; }

--- a/cpp/src/listener_builder.cpp
+++ b/cpp/src/listener_builder.cpp
@@ -1,12 +1,12 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
 #include <utility>
 
-#include <ucxx/constructors.h>
 #include <ucxx/detail/builder_utils.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/listener_builder.h>
 
 namespace ucxx {

--- a/cpp/src/memory_handle.cpp
+++ b/cpp/src/memory_handle.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -69,10 +69,10 @@ MemoryHandle::~MemoryHandle()
     _memoryType);
 }
 
-std::shared_ptr<MemoryHandle> createMemoryHandle(std::shared_ptr<Context> context,
-                                                 const size_t size,
-                                                 void* buffer,
-                                                 const ucs_memory_type_t memoryType)
+std::shared_ptr<MemoryHandle> detail::createMemoryHandle(std::shared_ptr<Context> context,
+                                                         const size_t size,
+                                                         void* buffer,
+                                                         const ucs_memory_type_t memoryType)
 {
   return std::shared_ptr<MemoryHandle>(new MemoryHandle(context, size, buffer, memoryType));
 }
@@ -88,12 +88,6 @@ ucs_memory_type_t MemoryHandle::getMemoryType() { return _memoryType; }
 RemoteKeyBuilder MemoryHandle::remoteKeyBuilder()
 {
   return RemoteKeyBuilder(std::static_pointer_cast<MemoryHandle>(shared_from_this()));
-}
-
-std::shared_ptr<RemoteKey> MemoryHandle::createRemoteKey()
-{
-  return detail::createRemoteKeyFromMemoryHandle(
-    std::static_pointer_cast<MemoryHandle>(shared_from_this()));
 }
 
 }  // namespace ucxx

--- a/cpp/src/memory_handle.cpp
+++ b/cpp/src/memory_handle.cpp
@@ -9,7 +9,7 @@
 #include <ucp/api/ucp.h>
 
 #include <ucs/memory/memory_type.h>
-#include <ucxx/constructors.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/log.h>
 #include <ucxx/memory_handle.h>
 #include <ucxx/utils/ucx.h>

--- a/cpp/src/memory_handle_builder.cpp
+++ b/cpp/src/memory_handle_builder.cpp
@@ -5,8 +5,8 @@
 #include <memory>
 #include <utility>
 
-#include <ucxx/constructors.h>
 #include <ucxx/detail/builder_utils.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/memory_handle_builder.h>
 
 namespace ucxx {

--- a/cpp/src/memory_handle_builder.cpp
+++ b/cpp/src/memory_handle_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -44,7 +44,7 @@ MemoryHandleBuilder& MemoryHandleBuilder::memoryType(ucs_memory_type_t memoryTyp
 
 std::shared_ptr<MemoryHandle> MemoryHandleBuilder::build()
 {
-  return ucxx::createMemoryHandle(_impl->context, _impl->size, _impl->buffer, _impl->memoryType);
+  return detail::createMemoryHandle(_impl->context, _impl->size, _impl->buffer, _impl->memoryType);
 }
 
 }  // namespace ucxx

--- a/cpp/src/remote_key.cpp
+++ b/cpp/src/remote_key.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -88,18 +88,6 @@ std::shared_ptr<RemoteKey> createRemoteKeyFromSerialized(std::shared_ptr<Endpoin
 }
 
 }  // namespace detail
-
-std::shared_ptr<RemoteKey> createRemoteKeyFromMemoryHandle(
-  std::shared_ptr<MemoryHandle> memoryHandle)
-{
-  return detail::createRemoteKeyFromMemoryHandle(std::move(memoryHandle));
-}
-
-std::shared_ptr<RemoteKey> createRemoteKeyFromSerialized(std::shared_ptr<Endpoint> endpoint,
-                                                         SerializedRemoteKey serializedRemoteKey)
-{
-  return detail::createRemoteKeyFromSerialized(std::move(endpoint), std::move(serializedRemoteKey));
-}
 
 size_t RemoteKey::getSize() const { return _memorySize; }
 

--- a/cpp/src/remote_key_builder.cpp
+++ b/cpp/src/remote_key_builder.cpp
@@ -1,13 +1,13 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
 #include <stdexcept>
 #include <utility>
 
-#include <ucxx/constructors.h>
 #include <ucxx/detail/builder_utils.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/remote_key_builder.h>
 
 namespace ucxx {

--- a/cpp/src/request_am.cpp
+++ b/cpp/src/request_am.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstring>
@@ -118,12 +118,12 @@ struct AmHeader {
   }
 };
 
-std::shared_ptr<RequestAm> createRequestAm(
+std::shared_ptr<RequestAm> detail::createRequestAm(
   std::shared_ptr<Endpoint> endpoint,
   const std::variant<data::AmSend, data::AmReceive> requestData,
-  const bool enablePythonFuture                = false,
-  RequestCallbackUserFunction callbackFunction = nullptr,
-  RequestCallbackUserData callbackData         = nullptr)
+  const bool enablePythonFuture,
+  RequestCallbackUserFunction callbackFunction,
+  RequestCallbackUserData callbackData)
 {
   std::shared_ptr<RequestAm> req = std::visit(
     data::dispatch{

--- a/cpp/src/request_am_builder.cpp
+++ b/cpp/src/request_am_builder.cpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <variant>
 
-#include <ucxx/constructors.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/detail/register_inflight_request.h>
 #include <ucxx/endpoint.h>
 #include <ucxx/request.h>

--- a/cpp/src/request_am_builder.cpp
+++ b/cpp/src/request_am_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -58,7 +58,7 @@ RequestAmBuilder&& RequestAmBuilder::receiverCallbackInfo(
 std::shared_ptr<RequestAm> RequestAmBuilder::build()
 {
   markBuilt();
-  auto req = ucxx::createRequestAm(
+  auto req = detail::createRequestAm(
     _endpoint, _requestData, _enablePythonFuture, _callbackFunction, _callbackData);
   detail::registerInflightRequest(_endpoint, req);
   return req;

--- a/cpp/src/request_endpoint_close.cpp
+++ b/cpp/src/request_endpoint_close.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ucxx/request_data.h"
@@ -16,12 +16,12 @@
 
 namespace ucxx {
 
-std::shared_ptr<RequestEndpointClose> createRequestEndpointClose(
+std::shared_ptr<RequestEndpointClose> detail::createRequestEndpointClose(
   std::shared_ptr<Endpoint> endpoint,
   const data::EndpointClose requestData,
-  const bool enablePythonFuture                = false,
-  RequestCallbackUserFunction callbackFunction = nullptr,
-  RequestCallbackUserData callbackData         = nullptr)
+  const bool enablePythonFuture,
+  RequestCallbackUserFunction callbackFunction,
+  RequestCallbackUserData callbackData)
 {
   std::shared_ptr<RequestEndpointClose> req =
     std::shared_ptr<RequestEndpointClose>(new RequestEndpointClose(endpoint,

--- a/cpp/src/request_endpoint_close_builder.cpp
+++ b/cpp/src/request_endpoint_close_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>

--- a/cpp/src/request_flush.cpp
+++ b/cpp/src/request_flush.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -15,12 +15,12 @@
 
 namespace ucxx {
 
-std::shared_ptr<RequestFlush> createRequestFlush(
+std::shared_ptr<RequestFlush> detail::createRequestFlush(
   std::shared_ptr<Component> endpointOrWorker,
   const data::Flush requestData,
-  const bool enablePythonFuture                = false,
-  RequestCallbackUserFunction callbackFunction = nullptr,
-  RequestCallbackUserData callbackData         = nullptr)
+  const bool enablePythonFuture,
+  RequestCallbackUserFunction callbackFunction,
+  RequestCallbackUserData callbackData)
 {
   auto req = std::shared_ptr<RequestFlush>(new RequestFlush(endpointOrWorker,
                                                             requestData,

--- a/cpp/src/request_flush_builder.cpp
+++ b/cpp/src/request_flush_builder.cpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <utility>
 
-#include <ucxx/constructors.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/detail/register_inflight_request.h>
 #include <ucxx/endpoint.h>
 #include <ucxx/request.h>

--- a/cpp/src/request_flush_builder.cpp
+++ b/cpp/src/request_flush_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -24,7 +24,7 @@ RequestFlushBuilder::RequestFlushBuilder(std::shared_ptr<Component> endpointOrWo
 std::shared_ptr<RequestFlush> RequestFlushBuilder::build()
 {
   markBuilt();
-  auto req = ucxx::createRequestFlush(
+  auto req = detail::createRequestFlush(
     _endpointOrWorker, _requestData, _enablePythonFuture, _callbackFunction, _callbackData);
   detail::registerInflightRequest(_endpointOrWorker, req);
   return req;

--- a/cpp/src/request_mem.cpp
+++ b/cpp/src/request_mem.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -15,12 +15,12 @@
 
 namespace ucxx {
 
-std::shared_ptr<RequestMem> createRequestMem(
+std::shared_ptr<RequestMem> detail::createRequestMem(
   std::shared_ptr<Endpoint> endpoint,
   const std::variant<data::MemPut, data::MemGet> requestData,
-  const bool enablePythonFuture                = false,
-  RequestCallbackUserFunction callbackFunction = nullptr,
-  RequestCallbackUserData callbackData         = nullptr)
+  const bool enablePythonFuture,
+  RequestCallbackUserFunction callbackFunction,
+  RequestCallbackUserData callbackData)
 {
   std::shared_ptr<RequestMem> req = std::visit(
     data::dispatch{

--- a/cpp/src/request_mem_builder.cpp
+++ b/cpp/src/request_mem_builder.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 #include <variant>
 
-#include <ucxx/constructors.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/detail/register_inflight_request.h>
 #include <ucxx/endpoint.h>
 #include <ucxx/request.h>

--- a/cpp/src/request_mem_builder.cpp
+++ b/cpp/src/request_mem_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -24,7 +24,7 @@ RequestMemBuilder::RequestMemBuilder(std::shared_ptr<Endpoint> endpoint,
 std::shared_ptr<RequestMem> RequestMemBuilder::build()
 {
   markBuilt();
-  auto req = ucxx::createRequestMem(
+  auto req = detail::createRequestMem(
     _endpoint, _requestData, _enablePythonFuture, _callbackFunction, _callbackData);
   detail::registerInflightRequest(_endpoint, req);
   return req;

--- a/cpp/src/request_stream.cpp
+++ b/cpp/src/request_stream.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdio>
@@ -34,10 +34,10 @@ RequestStream::RequestStream(std::shared_ptr<Endpoint> endpoint,
              requestData);
 }
 
-std::shared_ptr<RequestStream> createRequestStream(
+std::shared_ptr<RequestStream> detail::createRequestStream(
   std::shared_ptr<Endpoint> endpoint,
   const std::variant<data::StreamSend, data::StreamReceive> requestData,
-  const bool enablePythonFuture = false)
+  const bool enablePythonFuture)
 {
   std::shared_ptr<RequestStream> req =
     std::visit(data::dispatch{

--- a/cpp/src/request_stream_builder.cpp
+++ b/cpp/src/request_stream_builder.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 #include <variant>
 
-#include <ucxx/constructors.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/detail/register_inflight_request.h>
 #include <ucxx/endpoint.h>
 #include <ucxx/request.h>

--- a/cpp/src/request_stream_builder.cpp
+++ b/cpp/src/request_stream_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -25,7 +25,7 @@ RequestStreamBuilder::RequestStreamBuilder(
 std::shared_ptr<RequestStream> RequestStreamBuilder::build()
 {
   markBuilt();
-  auto req = ucxx::createRequestStream(_endpoint, _requestData, _enablePythonFuture);
+  auto req = detail::createRequestStream(_endpoint, _requestData, _enablePythonFuture);
   detail::registerInflightRequest(_endpoint, req);
   return req;
 }

--- a/cpp/src/request_tag.cpp
+++ b/cpp/src/request_tag.cpp
@@ -15,12 +15,12 @@
 
 namespace ucxx {
 
-std::shared_ptr<RequestTag> createRequestTag(
+std::shared_ptr<RequestTag> detail::createRequestTag(
   std::shared_ptr<Component> endpointOrWorker,
   const std::variant<data::TagSend, data::TagReceive, data::TagReceiveWithHandle> requestData,
-  const bool enablePythonFuture                = false,
-  RequestCallbackUserFunction callbackFunction = nullptr,
-  RequestCallbackUserData callbackData         = nullptr)
+  const bool enablePythonFuture,
+  RequestCallbackUserFunction callbackFunction,
+  RequestCallbackUserData callbackData)
 {
   std::shared_ptr<RequestTag> req =
     std::visit(data::dispatch{

--- a/cpp/src/request_tag_builder.cpp
+++ b/cpp/src/request_tag_builder.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 #include <variant>
 
-#include <ucxx/constructors.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/detail/register_inflight_request.h>
 #include <ucxx/endpoint.h>
 #include <ucxx/request.h>

--- a/cpp/src/request_tag_builder.cpp
+++ b/cpp/src/request_tag_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -26,7 +26,7 @@ RequestTagBuilder::RequestTagBuilder(
 std::shared_ptr<RequestTag> RequestTagBuilder::build()
 {
   markBuilt();
-  auto req = ucxx::createRequestTag(
+  auto req = detail::createRequestTag(
     _endpointOrWorker, _requestData, _enablePythonFuture, _callbackFunction, _callbackData);
   detail::registerInflightRequest(_endpointOrWorker, req);
   return req;

--- a/cpp/src/request_tag_multi.cpp
+++ b/cpp/src/request_tag_multi.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -59,7 +59,7 @@ RequestTagMulti::~RequestTagMulti()
   }
 }
 
-std::shared_ptr<RequestTagMulti> createRequestTagMulti(
+std::shared_ptr<RequestTagMulti> detail::createRequestTagMulti(
   std::shared_ptr<Endpoint> endpoint,
   const std::variant<data::TagMultiSend, data::TagMultiReceive> requestData,
   const bool enablePythonFuture)

--- a/cpp/src/request_tag_multi.cpp
+++ b/cpp/src/request_tag_multi.cpp
@@ -136,16 +136,11 @@ void RequestTagMulti::recvFrames()
       if (h.isCUDA[i] && bufferType == ucxx::BufferType::Invalid)
         throw std::runtime_error("CUDA buffer support not enabled, no buffer type configured");
       auto buf               = allocateBuffer(bufferType, h.size[i]);
-      bufferRequest->request = _endpoint->tagRecv(
-        buf->data(),
-        buf->getSize(),
-        tagPair.first,
-        tagPair.second,
-        false,
-        [this](ucs_status_t status, RequestCallbackUserData /* callbackData */) {
-          return this->markCompleted(status);
-        },
-        bufferRequest);
+      bufferRequest->request = static_cast<std::shared_ptr<Request>>(
+        _endpoint->tagRecvBuilder(buf->data(), buf->getSize(), tagPair.first, tagPair.second)
+          .callbackFunction(
+            [this](ucs_status_t status, RequestCallbackUserData) { return markCompleted(status); })
+          .callbackData(bufferRequest));
       bufferRequest->buffer = buf;
       ucxx_trace_req_f(_ownerString.c_str(),
                        this,
@@ -252,15 +247,14 @@ void RequestTagMulti::recvHeader()
   auto bufferRequest = std::make_shared<BufferRequest>();
   _bufferRequests.push_back(bufferRequest);
   bufferRequest->stringBuffer = std::make_shared<std::string>(Header::dataSize(), 0);
-  bufferRequest->request =
-    _endpoint->tagRecv(&bufferRequest->stringBuffer->front(),
+  bufferRequest->request      = static_cast<std::shared_ptr<Request>>(
+    _endpoint
+      ->tagRecvBuilder(&bufferRequest->stringBuffer->front(),
                        bufferRequest->stringBuffer->size(),
                        tagPair.first,
-                       tagPair.second,
-                       false,
-                       [this](ucs_status_t status, RequestCallbackUserData /* callbackData */) {
-                         return this->recvCallback(status);
-                       });
+                       tagPair.second)
+      .callbackFunction(
+        [this](ucs_status_t status, RequestCallbackUserData) { return recvCallback(status); }));
 
   if (bufferRequest->request->isCompleted()) {
     // TODO: Errors may not be raisable within callback
@@ -342,22 +336,20 @@ void RequestTagMulti::send()
           auto serializedHeader = std::make_shared<std::string>(std::move(header.serialize()));
           auto bufferRequest    = std::make_shared<BufferRequest>();
           _bufferRequests.push_back(bufferRequest);
-          bufferRequest->request = _endpoint->tagSend(
-            &serializedHeader->front(), serializedHeader->size(), tagMultiSend._tag, false);
+          bufferRequest->request = static_cast<std::shared_ptr<Request>>(_endpoint->tagSendBuilder(
+            &serializedHeader->front(), serializedHeader->size(), tagMultiSend._tag));
           bufferRequest->stringBuffer = std::move(serializedHeader);
         }
 
         for (size_t i = 0; i < _totalFrames; ++i) {
           auto bufferRequest = std::make_shared<BufferRequest>();
           _bufferRequests.push_back(bufferRequest);
-          bufferRequest->request = _endpoint->tagSend(
-            tagMultiSend._buffer[i],
-            tagMultiSend._length[i],
-            tagMultiSend._tag,
-            false,
-            [this](ucs_status_t status, RequestCallbackUserData /* callbackData */) {
-              return this->markCompleted(status);
-            });
+          bufferRequest->request = static_cast<std::shared_ptr<Request>>(
+            _endpoint
+              ->tagSendBuilder(tagMultiSend._buffer[i], tagMultiSend._length[i], tagMultiSend._tag)
+              .callbackFunction([this](ucs_status_t status, RequestCallbackUserData) {
+                return markCompleted(status);
+              }));
         }
 
         _isFilled = true;

--- a/cpp/src/request_tag_multi_builder.cpp
+++ b/cpp/src/request_tag_multi_builder.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -25,7 +25,7 @@ RequestTagMultiBuilder::RequestTagMultiBuilder(
 std::shared_ptr<RequestTagMulti> RequestTagMultiBuilder::build()
 {
   markBuilt();
-  auto req = ucxx::createRequestTagMulti(_endpoint, _requestData, _enablePythonFuture);
+  auto req = detail::createRequestTagMulti(_endpoint, _requestData, _enablePythonFuture);
   detail::registerInflightRequest(_endpoint, req);
   return req;
 }

--- a/cpp/src/request_tag_multi_builder.cpp
+++ b/cpp/src/request_tag_multi_builder.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 #include <variant>
 
-#include <ucxx/constructors.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/detail/register_inflight_request.h>
 #include <ucxx/endpoint.h>
 #include <ucxx/request.h>

--- a/cpp/src/tag_probe.cpp
+++ b/cpp/src/tag_probe.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -34,14 +34,6 @@ std::shared_ptr<TagProbeInfo> createTagProbeInfo(const ucp_tag_recv_info_t& info
 }
 
 }  // namespace detail
-
-std::shared_ptr<TagProbeInfo> createTagProbeInfo() { return detail::createTagProbeInfo(); }
-
-std::shared_ptr<TagProbeInfo> createTagProbeInfo(const ucp_tag_recv_info_t& info,
-                                                 ucp_tag_message_h handle)
-{
-  return detail::createTagProbeInfo(info, handle);
-}
 
 TagProbeInfo::~TagProbeInfo()
 {

--- a/cpp/src/tag_probe_builder.cpp
+++ b/cpp/src/tag_probe_builder.cpp
@@ -1,11 +1,11 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
 
-#include <ucxx/constructors.h>
 #include <ucxx/detail/builder_utils.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/tag_probe_builder.h>
 
 namespace ucxx {

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -140,9 +140,9 @@ std::shared_ptr<RequestAm> Worker::getAmRecv(
   }
 }
 
-std::shared_ptr<Worker> createWorker(std::shared_ptr<Context> context,
-                                     const bool enableDelayedSubmission,
-                                     const bool enableFuture)
+std::shared_ptr<Worker> detail::createWorker(std::shared_ptr<Context> context,
+                                             const bool enableDelayedSubmission,
+                                             const bool enableFuture)
 {
   auto worker = std::shared_ptr<Worker>(new Worker(context, enableDelayedSubmission, enableFuture));
   // We can only get a `shared_ptr<Worker>` for the Active Messages callback after it's
@@ -646,11 +646,12 @@ std::shared_ptr<Request> Worker::tagRecv(void* buffer,
                                          RequestCallbackUserData callbackData)
 {
   auto worker = std::static_pointer_cast<Worker>(shared_from_this());
-  return registerInflightRequest(createRequestTag(worker,
-                                                  data::TagReceive(buffer, length, tag, tagMask),
-                                                  enableFuture,
-                                                  std::move(callbackFunction),
-                                                  std::move(callbackData)));
+  return registerInflightRequest(
+    detail::createRequestTag(worker,
+                             data::TagReceive(buffer, length, tag, tagMask),
+                             enableFuture,
+                             std::move(callbackFunction),
+                             std::move(callbackData)));
 }
 
 RequestTagBuilder Worker::tagRecvBuilder(void* buffer, size_t length, Tag tag, TagMask tagMask)
@@ -675,12 +676,12 @@ std::shared_ptr<Request> Worker::tagRecvWithHandle(void* buffer,
   }
 
   auto worker = std::static_pointer_cast<Worker>(shared_from_this());
-  return registerInflightRequest(
-    createRequestTag(worker,
-                     data::TagReceiveWithHandle(buffer, probeInfo->getInfo().length, probeInfo),
-                     enableFuture,
-                     std::move(callbackFunction),
-                     std::move(callbackData)));
+  return registerInflightRequest(detail::createRequestTag(
+    worker,
+    data::TagReceiveWithHandle(buffer, probeInfo->getInfo().length, probeInfo),
+    enableFuture,
+    std::move(callbackFunction),
+    std::move(callbackData)));
 }
 
 RequestTagBuilder Worker::tagRecvWithHandleBuilder(void* buffer,
@@ -709,13 +710,6 @@ RequestTagBuilder Worker::tagRecvWithHandleBuilder(void* buffer,
                            data::TagReceiveWithHandle(buffer, length, probeInfo));
 }
 
-std::shared_ptr<Address> Worker::getAddress()
-{
-  auto worker  = std::static_pointer_cast<Worker>(shared_from_this());
-  auto address = detail::createAddressFromWorker(worker);
-  return address;
-}
-
 AddressBuilder Worker::addressBuilder()
 {
   return AddressBuilder(std::static_pointer_cast<Worker>(shared_from_this()));
@@ -727,26 +721,9 @@ EndpointBuilder Worker::endpointBuilder(std::string ipAddress, uint16_t port)
     std::static_pointer_cast<Worker>(shared_from_this()), std::move(ipAddress), port);
 }
 
-std::shared_ptr<Endpoint> Worker::createEndpointFromHostname(std::string ipAddress,
-                                                             uint16_t port,
-                                                             bool endpointErrorHandling)
-{
-  auto worker   = std::static_pointer_cast<Worker>(shared_from_this());
-  auto endpoint = ucxx::createEndpointFromHostname(worker, ipAddress, port, endpointErrorHandling);
-  return endpoint;
-}
-
 EndpointBuilder Worker::endpointBuilder(std::shared_ptr<Address> address)
 {
   return EndpointBuilder(std::static_pointer_cast<Worker>(shared_from_this()), std::move(address));
-}
-
-std::shared_ptr<Endpoint> Worker::createEndpointFromWorkerAddress(std::shared_ptr<Address> address,
-                                                                  bool endpointErrorHandling)
-{
-  auto worker   = std::static_pointer_cast<Worker>(shared_from_this());
-  auto endpoint = ucxx::createEndpointFromWorkerAddress(worker, address, endpointErrorHandling);
-  return endpoint;
 }
 
 ListenerBuilder Worker::listenerBuilder(uint16_t port,
@@ -755,15 +732,6 @@ ListenerBuilder Worker::listenerBuilder(uint16_t port,
 {
   return ListenerBuilder(
     std::static_pointer_cast<Worker>(shared_from_this()), port, callback, callbackArgs);
-}
-
-std::shared_ptr<Listener> Worker::createListener(uint16_t port,
-                                                 ucp_listener_conn_callback_t callback,
-                                                 void* callbackArgs)
-{
-  auto worker   = std::static_pointer_cast<Worker>(shared_from_this());
-  auto listener = detail::createListener(worker, port, callback, callbackArgs);
-  return listener;
 }
 
 void Worker::registerAmAllocator(ucs_memory_type_t memoryType, AmAllocatorType allocator)
@@ -796,7 +764,7 @@ std::shared_ptr<Request> Worker::flush(const bool enableFuture,
                                        RequestCallbackUserData callbackData)
 {
   auto worker = std::static_pointer_cast<Worker>(shared_from_this());
-  return registerInflightRequest(createRequestFlush(
+  return registerInflightRequest(detail::createRequestFlush(
     worker, data::Flush(), enableFuture, std::move(callbackFunction), std::move(callbackData)));
 }
 

--- a/cpp/src/worker.cpp
+++ b/cpp/src/worker.cpp
@@ -637,51 +637,10 @@ std::shared_ptr<TagProbeInfo> Worker::tagProbe(const Tag tag,
   }
 }
 
-std::shared_ptr<Request> Worker::tagRecv(void* buffer,
-                                         size_t length,
-                                         Tag tag,
-                                         TagMask tagMask,
-                                         const bool enableFuture,
-                                         RequestCallbackUserFunction callbackFunction,
-                                         RequestCallbackUserData callbackData)
-{
-  auto worker = std::static_pointer_cast<Worker>(shared_from_this());
-  return registerInflightRequest(
-    detail::createRequestTag(worker,
-                             data::TagReceive(buffer, length, tag, tagMask),
-                             enableFuture,
-                             std::move(callbackFunction),
-                             std::move(callbackData)));
-}
-
 RequestTagBuilder Worker::tagRecvBuilder(void* buffer, size_t length, Tag tag, TagMask tagMask)
 {
   auto worker = std::static_pointer_cast<Worker>(shared_from_this());
   return RequestTagBuilder(std::move(worker), data::TagReceive(buffer, length, tag, tagMask));
-}
-
-std::shared_ptr<Request> Worker::tagRecvWithHandle(void* buffer,
-                                                   std::shared_ptr<TagProbeInfo> probeInfo,
-                                                   const bool enableFuture,
-                                                   RequestCallbackUserFunction callbackFunction,
-                                                   RequestCallbackUserData callbackData)
-{
-  if (!probeInfo->isMatched()) { throw std::invalid_argument("TagProbeInfo must be matched"); }
-
-  // getHandle() will throw runtime_error if handle is nullptr or consumed
-  try {
-    probeInfo->getHandle();
-  } catch (const std::runtime_error& e) {
-    throw std::logic_error(std::string("TagProbeInfo handle validation failed: ") + e.what());
-  }
-
-  auto worker = std::static_pointer_cast<Worker>(shared_from_this());
-  return registerInflightRequest(detail::createRequestTag(
-    worker,
-    data::TagReceiveWithHandle(buffer, probeInfo->getInfo().length, probeInfo),
-    enableFuture,
-    std::move(callbackFunction),
-    std::move(callbackData)));
 }
 
 RequestTagBuilder Worker::tagRecvWithHandleBuilder(void* buffer,
@@ -757,15 +716,6 @@ void Worker::registerAmReceiverCallback(AmReceiverCallbackInfo info,
 bool Worker::amProbe(const ucp_ep_h endpointHandle) const
 {
   return _amData->_recvPool.find(endpointHandle) != _amData->_recvPool.end();
-}
-
-std::shared_ptr<Request> Worker::flush(const bool enableFuture,
-                                       RequestCallbackUserFunction callbackFunction,
-                                       RequestCallbackUserData callbackData)
-{
-  auto worker = std::static_pointer_cast<Worker>(shared_from_this());
-  return registerInflightRequest(detail::createRequestFlush(
-    worker, data::Flush(), enableFuture, std::move(callbackFunction), std::move(callbackData)));
 }
 
 RequestFlushBuilder Worker::flushBuilder()

--- a/cpp/src/worker_builder.cpp
+++ b/cpp/src/worker_builder.cpp
@@ -1,10 +1,11 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
 #include <utility>
 
+#include <ucxx/constructors.h>
 #include <ucxx/detail/builder_utils.h>
 #include <ucxx/worker.h>
 #include <ucxx/worker_builder.h>
@@ -55,7 +56,7 @@ WorkerBuilder& WorkerBuilder::cudaBufferType(BufferType bufferType)
 std::shared_ptr<Worker> WorkerBuilder::build()
 {
   auto worker =
-    ucxx::createWorker(_impl->context, _impl->enableDelayedSubmission, _impl->enableFuture);
+    detail::createWorker(_impl->context, _impl->enableDelayedSubmission, _impl->enableFuture);
   worker->_enableRequestAttributes = _impl->enableRequestAttributes;
   if (_impl->cudaBufferType != BufferType::Invalid)
     worker->setCudaBufferType(_impl->cudaBufferType);

--- a/cpp/src/worker_builder.cpp
+++ b/cpp/src/worker_builder.cpp
@@ -5,8 +5,8 @@
 #include <memory>
 #include <utility>
 
-#include <ucxx/constructors.h>
 #include <ucxx/detail/builder_utils.h>
+#include <ucxx/detail/constructors.h>
 #include <ucxx/worker.h>
 #include <ucxx/worker_builder.h>
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -29,9 +29,6 @@ function(ConfigureTest CMAKE_TEST_NAME)
     ${CMAKE_TEST_NAME} PRIVATE ucxx GTest::gmock_main GTest::gtest_main
                                $<TARGET_NAME_IF_EXISTS:conda_env>
   )
-  target_compile_definitions(
-    ${CMAKE_TEST_NAME} PRIVATE UCXX_DISABLE_DEPRECATED_NON_BUILDER_CONSTRUCTOR_WARNINGS
-  )
   if(UCXX_ENABLE_CCCL)
     find_package(CUDAToolkit REQUIRED)
     target_link_libraries(${CMAKE_TEST_NAME} PRIVATE CUDA::cudart_static)

--- a/cpp/tests/component_builders.cpp
+++ b/cpp/tests/component_builders.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -201,7 +201,7 @@ TEST(ContextBuilderTest, BuilderBackwardCompatibility)
   uint64_t featureFlags = UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP;
 
   // Old API should still work
-  auto context1 = ucxx::createContext({{"TLS", "tcp"}}, featureFlags);
+  auto context1 = ucxx::contextBuilder(featureFlags).configMap({{"TLS", "tcp"}}).build();
   ASSERT_TRUE(context1 != nullptr);
   ASSERT_TRUE(context1->getHandle() != nullptr);
   ASSERT_EQ(context1->getFeatureFlags(), featureFlags);
@@ -225,7 +225,7 @@ TEST(ContextBuilderTest, BuilderContextIsValid)
 {
   auto context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build();
 
-  auto worker = context->createWorker();
+  auto worker = context->workerBuilder().build();
   ASSERT_TRUE(worker != nullptr);
 }
 
@@ -373,7 +373,7 @@ TEST(WorkerBuilderTest, BuilderBackwardCompatibility)
   auto context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build();
 
   // Old API should still work
-  auto worker1 = context->createWorker(true, true);
+  auto worker1 = context->workerBuilder().delayedSubmission().pythonFuture().build();
   ASSERT_TRUE(worker1 != nullptr);
   ASSERT_TRUE(worker1->getHandle() != nullptr);
   ASSERT_TRUE(worker1->isDelayedRequestSubmissionEnabled());
@@ -501,7 +501,8 @@ TEST_F(ComponentBuilderTest, AddressBuilderFromWorkerAndString)
 
 TEST_F(ComponentBuilderTest, EndpointBuilderFromWorkerAddress)
 {
-  auto builder = ucxx::endpointBuilder(_worker, _worker->getAddress()).endpointErrorHandling(false);
+  auto builder =
+    ucxx::endpointBuilder(_worker, _worker->addressBuilder().build()).endpointErrorHandling(false);
   static_assert(std::is_same<decltype(builder), ucxx::EndpointBuilder>::value,
                 "endpointBuilder returns EndpointBuilder");
   assertBuildRequiresNonConstBuilder<ucxx::EndpointBuilder, ucxx::Endpoint>();
@@ -568,7 +569,7 @@ TEST_F(ComponentBuilderTest, RemoteKeyBuilderFromMemoryHandleAndSerialized)
   ASSERT_TRUE(localRemoteKey != nullptr);
   ASSERT_EQ(localRemoteKey->getSize(), memoryHandle->getSize());
 
-  auto endpoint = ucxx::endpointBuilder(_worker, _worker->getAddress()).build();
+  auto endpoint = ucxx::endpointBuilder(_worker, _worker->addressBuilder().build()).build();
   std::shared_ptr<ucxx::RemoteKey> unpackedRemoteKey =
     ucxx::RemoteKeyBuilder(endpoint, localRemoteKey->serialize());
   ASSERT_TRUE(unpackedRemoteKey != nullptr);
@@ -586,7 +587,7 @@ TEST_F(ComponentBuilderTest, RemoteKeyChildBuilders)
   auto localRemoteKey = builder.build();
   ASSERT_TRUE(localRemoteKey != nullptr);
 
-  auto endpoint      = _worker->endpointBuilder(_worker->getAddress()).build();
+  auto endpoint      = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
   auto unpackBuilder = endpoint->remoteKeyBuilder(localRemoteKey->serialize());
   static_assert(std::is_same<decltype(unpackBuilder), ucxx::RemoteKeyBuilder>::value,
                 "endpoint->remoteKeyBuilder() returns RemoteKeyBuilder");

--- a/cpp/tests/component_builders.cpp
+++ b/cpp/tests/component_builders.cpp
@@ -196,31 +196,6 @@ TEST(ContextBuilderTest, BuilderDifferentInstances)
   ASSERT_NE(context1->getHandle(), context2->getHandle());
 }
 
-TEST(ContextBuilderTest, BuilderBackwardCompatibility)
-{
-  uint64_t featureFlags = UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP;
-
-  // Old API should still work
-  auto context1 = ucxx::contextBuilder(featureFlags).configMap({{"TLS", "tcp"}}).build();
-  ASSERT_TRUE(context1 != nullptr);
-  ASSERT_TRUE(context1->getHandle() != nullptr);
-  ASSERT_EQ(context1->getFeatureFlags(), featureFlags);
-  auto config1 = context1->getConfig();
-  ASSERT_EQ(config1["TLS"], "tcp");
-
-  // New API should produce equivalent result
-  auto context2 = ucxx::contextBuilder(featureFlags).configMap({{"TLS", "tcp"}}).build();
-  ASSERT_TRUE(context2 != nullptr);
-  ASSERT_TRUE(context2->getHandle() != nullptr);
-  ASSERT_EQ(context2->getFeatureFlags(), featureFlags);
-  auto config2 = context2->getConfig();
-  ASSERT_EQ(config2["TLS"], "tcp");
-
-  // Both should have same configuration
-  ASSERT_EQ(context1->getFeatureFlags(), context2->getFeatureFlags());
-  ASSERT_EQ(config1["TLS"], config2["TLS"]);
-}
-
 TEST(ContextBuilderTest, BuilderContextIsValid)
 {
   auto context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build();
@@ -366,25 +341,6 @@ TEST(WorkerBuilderTest, BuilderDifferentInstances)
   ASSERT_TRUE(worker1 != nullptr);
   ASSERT_TRUE(worker2 != nullptr);
   ASSERT_NE(worker1->getHandle(), worker2->getHandle());
-}
-
-TEST(WorkerBuilderTest, BuilderBackwardCompatibility)
-{
-  auto context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build();
-
-  // Old API should still work
-  auto worker1 = context->workerBuilder().delayedSubmission().pythonFuture().build();
-  ASSERT_TRUE(worker1 != nullptr);
-  ASSERT_TRUE(worker1->getHandle() != nullptr);
-  ASSERT_TRUE(worker1->isDelayedRequestSubmissionEnabled());
-  ASSERT_TRUE(worker1->isFutureEnabled());
-
-  // New API should produce equivalent result
-  auto worker2 = ucxx::workerBuilder(context).delayedSubmission(true).pythonFuture(true).build();
-  ASSERT_TRUE(worker2 != nullptr);
-  ASSERT_TRUE(worker2->getHandle() != nullptr);
-  ASSERT_TRUE(worker2->isDelayedRequestSubmissionEnabled());
-  ASSERT_TRUE(worker2->isFutureEnabled());
 }
 
 TEST(WorkerBuilderTest, RequestAttributesDefaultDisabled)

--- a/cpp/tests/context.cpp
+++ b/cpp/tests/context.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdlib>
@@ -19,7 +19,7 @@ class ContextTestCustomConfig : public testing::TestWithParam<std::string> {};
 
 TEST(ContextTest, HandleIsValid)
 {
-  auto context = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
+  auto context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build();
 
   ASSERT_TRUE(context->getHandle() != nullptr);
 }
@@ -27,7 +27,7 @@ TEST(ContextTest, HandleIsValid)
 TEST(ContextTest, DefaultConfigsAndFlags)
 {
   static constexpr auto featureFlags = ucxx::Context::defaultFeatureFlags;
-  auto context                       = ucxx::createContext({}, featureFlags);
+  auto context                       = ucxx::contextBuilder(featureFlags).build();
   auto configMapOut                  = context->getConfig();
   ASSERT_GT(configMapOut.size(), 1u);
   ASSERT_NE(configMapOut.find("TLS"), configMapOut.end());
@@ -43,7 +43,7 @@ TEST_P(ContextTestCustomConfig, TLS)
 {
   auto tls                           = GetParam();
   static constexpr auto featureFlags = ucxx::Context::defaultFeatureFlags;
-  auto context                       = ucxx::createContext({{"TLS", tls}}, featureFlags);
+  auto context = ucxx::contextBuilder(featureFlags).configMap({{"TLS", tls}}).build();
 
   auto configMapOut = context->getConfig();
   ASSERT_GT(configMapOut.size(), 1u);
@@ -56,26 +56,27 @@ TEST_P(ContextTestCustomConfig, TLS)
 TEST(ContextTest, CustomFlags)
 {
   uint64_t featureFlags = UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP;
-  auto context          = ucxx::createContext({}, featureFlags);
+  auto context          = ucxx::contextBuilder(featureFlags).build();
 
   ASSERT_EQ(context->getFeatureFlags(), featureFlags);
 }
 
 TEST(ContextTest, Info)
 {
-  auto context = ucxx::createContext({{"TLS", "tcp"}}, ucxx::Context::defaultFeatureFlags);
+  auto context =
+    ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).configMap({{"TLS", "tcp"}}).build();
 
   ASSERT_GT(context->getInfo().size(), 0u);
 }
 
 TEST(ContextTest, CreateWorker)
 {
-  auto context = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
+  auto context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build();
 
-  auto worker1 = ucxx::createWorker(context, false, false);
+  auto worker1 = ucxx::workerBuilder(context).build();
   ASSERT_TRUE(worker1 != nullptr);
 
-  auto worker2 = context->createWorker();
+  auto worker2 = context->workerBuilder().build();
   ASSERT_TRUE(worker2 != nullptr);
 }
 

--- a/cpp/tests/endpoint.cpp
+++ b/cpp/tests/endpoint.cpp
@@ -49,7 +49,7 @@ TEST_F(EndpointTest, IsAlive)
 
   std::vector<int> buf{123};
   std::shared_ptr<ucxx::Request> send_req =
-    ep->tagSend(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0});
+    ep->tagSendBuilder(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0}).build();
   while (!send_req->isCompleted())
     _worker->progress();
 

--- a/cpp/tests/endpoint.cpp
+++ b/cpp/tests/endpoint.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -16,22 +16,22 @@ namespace {
 class EndpointTest : public ::testing::Test {
  protected:
   std::shared_ptr<ucxx::Context> _context{
-    ucxx::createContext({}, ucxx::Context::defaultFeatureFlags)};
+    ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build()};
   std::shared_ptr<ucxx::Context> _remoteContext{
-    ucxx::createContext({}, ucxx::Context::defaultFeatureFlags)};
+    ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build()};
   std::shared_ptr<ucxx::Worker> _worker{nullptr};
   std::shared_ptr<ucxx::Worker> _remoteWorker{nullptr};
 
   virtual void SetUp()
   {
-    _worker       = _context->createWorker();
-    _remoteWorker = _remoteContext->createWorker();
+    _worker       = _context->workerBuilder().build();
+    _remoteWorker = _remoteContext->workerBuilder().build();
   }
 };
 
 TEST_F(EndpointTest, HandleIsValid)
 {
-  auto ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
   _worker->progress();
 
   ASSERT_TRUE(ep->getHandle() != nullptr);
@@ -41,7 +41,7 @@ TEST_F(EndpointTest, IsAlive)
 {
   GTEST_SKIP()
     << "Connecting to worker via its UCX address doesn't seem to call endpoint error handler";
-  auto ep = _worker->createEndpointFromWorkerAddress(_remoteWorker->getAddress());
+  auto ep = _worker->endpointBuilder(_remoteWorker->addressBuilder().build()).build();
   _worker->progress();
   _remoteWorker->progress();
 
@@ -61,7 +61,7 @@ TEST_F(EndpointTest, IsAlive)
 
 TEST(AddressTest, EmptyAddressRejected)
 {
-  EXPECT_THROW(std::ignore = ucxx::createAddressFromString(""), std::invalid_argument);
+  EXPECT_THROW(std::ignore = ucxx::AddressBuilder("").build(), std::invalid_argument);
 }
 
 }  // namespace

--- a/cpp/tests/listener.cpp
+++ b/cpp/tests/listener.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -35,14 +35,15 @@ static void listenerCallback(ucp_conn_request_h connRequest, void* arg)
   listenerContainer->status = ucp_conn_request_query(connRequest, &attr);
   if (listenerContainer->status != UCS_OK) return;
 
-  listenerContainer->endpoint = listenerContainer->listener->createEndpointFromConnRequest(
-    connRequest, listenerContainer->endpointErrorHandling);
+  listenerContainer->endpoint = listenerContainer->listener->endpointBuilder(connRequest)
+                                  .endpointErrorHandling(listenerContainer->endpointErrorHandling)
+                                  .build();
 }
 
 class ListenerTestBase {
  protected:
   std::shared_ptr<ucxx::Context> _context{
-    ucxx::createContext({}, ucxx::Context::defaultFeatureFlags)};
+    ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build()};
   std::shared_ptr<ucxx::Worker> _worker{nullptr};
   bool _endpointErrorHandling{true};
 
@@ -62,12 +63,12 @@ class ListenerTest : public ListenerTestBase,
   virtual void SetUp()
   {
     _endpointErrorHandling = GetParam();
-    _worker                = _context->createWorker();
+    _worker                = _context->workerBuilder().build();
   }
 
-  virtual std::shared_ptr<ucxx::Listener> createListener(ListenerContainerPtr listenerContainer)
+  virtual std::shared_ptr<ucxx::Listener> buildListener(ListenerContainerPtr listenerContainer)
   {
-    auto listener = _worker->createListener(0, listenerCallback, listenerContainer.get());
+    auto listener = _worker->listenerBuilder(0, listenerCallback, listenerContainer.get()).build();
     listenerContainer->listener = listener;
     return listener;
   }
@@ -81,11 +82,12 @@ class ListenerPortTest : public ListenerTestBase,
   virtual void SetUp()
   {
     _port   = GetParam();
-    _worker = _context->createWorker();
+    _worker = _context->workerBuilder().build();
   }
-  virtual std::shared_ptr<ucxx::Listener> createListener(ListenerContainerPtr listenerContainer)
+  virtual std::shared_ptr<ucxx::Listener> buildListener(ListenerContainerPtr listenerContainer)
   {
-    auto listener = _worker->createListener(_port, listenerCallback, listenerContainer.get());
+    auto listener =
+      _worker->listenerBuilder(_port, listenerCallback, listenerContainer.get()).build();
     listenerContainer->listener = listener;
     return listener;
   }
@@ -94,7 +96,7 @@ class ListenerPortTest : public ListenerTestBase,
 TEST_P(ListenerTest, HandleIsValid)
 {
   auto listenerContainer = createListenerContainer();
-  auto listener          = createListener(listenerContainer);
+  auto listener          = buildListener(listenerContainer);
   _worker->progress();
 
   ASSERT_TRUE(listener->getHandle() != nullptr);
@@ -103,13 +105,14 @@ TEST_P(ListenerTest, HandleIsValid)
 TEST_P(ListenerTest, EndpointSendRecv)
 {
   auto listenerContainer = createListenerContainer();
-  auto listener          = createListener(listenerContainer);
+  auto listener          = buildListener(listenerContainer);
   auto progress          = getProgressFunction(_worker, ProgressMode::Polling);
 
   progress();
 
-  auto ep =
-    _worker->createEndpointFromHostname("127.0.0.1", listener->getPort(), _endpointErrorHandling);
+  auto ep = _worker->endpointBuilder("127.0.0.1", listener->getPort())
+              .endpointErrorHandling(_endpointErrorHandling)
+              .build();
   while (listenerContainer->endpoint == nullptr)
     progress();
 
@@ -137,11 +140,12 @@ TEST_P(ListenerTest, EndpointSendRecv)
 TEST_P(ListenerTest, IsAlive)
 {
   auto listenerContainer = createListenerContainer();
-  auto listener          = createListener(listenerContainer);
+  auto listener          = buildListener(listenerContainer);
   _worker->progress();
 
-  auto ep =
-    _worker->createEndpointFromHostname("127.0.0.1", listener->getPort(), _endpointErrorHandling);
+  auto ep = _worker->endpointBuilder("127.0.0.1", listener->getPort())
+              .endpointErrorHandling(_endpointErrorHandling)
+              .build();
   while (listenerContainer->endpoint == nullptr)
     _worker->progress();
 
@@ -169,11 +173,12 @@ TEST_P(ListenerTest, IsAlive)
 TEST_P(ListenerTest, RaiseOnError)
 {
   auto listenerContainer = createListenerContainer();
-  auto listener          = createListener(listenerContainer);
+  auto listener          = buildListener(listenerContainer);
   _worker->progress();
 
-  auto ep =
-    _worker->createEndpointFromHostname("127.0.0.1", listener->getPort(), _endpointErrorHandling);
+  auto ep = _worker->endpointBuilder("127.0.0.1", listener->getPort())
+              .endpointErrorHandling(_endpointErrorHandling)
+              .build();
   while (listenerContainer->endpoint == nullptr)
     _worker->progress();
 
@@ -195,11 +200,12 @@ TEST_P(ListenerTest, RaiseOnError)
 TEST_P(ListenerTest, EndpointCloseCallback)
 {
   auto listenerContainer = createListenerContainer();
-  auto listener          = createListener(listenerContainer);
+  auto listener          = buildListener(listenerContainer);
   _worker->progress();
 
-  auto ep =
-    _worker->createEndpointFromHostname("127.0.0.1", listener->getPort(), _endpointErrorHandling);
+  auto ep = _worker->endpointBuilder("127.0.0.1", listener->getPort())
+              .endpointErrorHandling(_endpointErrorHandling)
+              .build();
 
   struct CallbackData {
     ucs_status_t status{UCS_INPROGRESS};
@@ -235,11 +241,12 @@ TEST_P(ListenerTest, EndpointCloseCallback)
 TEST_P(ListenerTest, EndpointNonBlockingClose)
 {
   auto listenerContainer = createListenerContainer();
-  auto listener          = createListener(listenerContainer);
+  auto listener          = buildListener(listenerContainer);
   _worker->progress();
 
-  auto ep =
-    _worker->createEndpointFromHostname("127.0.0.1", listener->getPort(), _endpointErrorHandling);
+  auto ep = _worker->endpointBuilder("127.0.0.1", listener->getPort())
+              .endpointErrorHandling(_endpointErrorHandling)
+              .build();
 
   while (listenerContainer->endpoint == nullptr)
     _worker->progress();
@@ -262,7 +269,7 @@ TEST_P(ListenerTest, EndpointNonBlockingClose)
 TEST_P(ListenerTest, EndpointNonBlockingCloseWithCallbacks)
 {
   auto listenerContainer = createListenerContainer();
-  auto listener          = createListener(listenerContainer);
+  auto listener          = buildListener(listenerContainer);
   _worker->progress();
 
   auto closeCallback = [](ucs_status_t status, ucxx::EndpointCloseCallbackUserData data) {
@@ -272,8 +279,9 @@ TEST_P(ListenerTest, EndpointNonBlockingCloseWithCallbacks)
   auto closeCallbackEndpoint = std::make_shared<ucs_status_t>(UCS_INPROGRESS);
   auto closeCallbackRequest  = std::make_shared<ucs_status_t>(UCS_INPROGRESS);
 
-  auto ep =
-    _worker->createEndpointFromHostname("127.0.0.1", listener->getPort(), _endpointErrorHandling);
+  auto ep = _worker->endpointBuilder("127.0.0.1", listener->getPort())
+              .endpointErrorHandling(_endpointErrorHandling)
+              .build();
   ep->setCloseCallback(closeCallback, closeCallbackEndpoint);
 
   while (listenerContainer->endpoint == nullptr)
@@ -301,7 +309,7 @@ INSTANTIATE_TEST_SUITE_P(EndpointErrorHandling, ListenerTest, ::testing::Values(
 TEST_P(ListenerPortTest, Port)
 {
   auto listenerContainer = createListenerContainer();
-  auto listener          = createListener(listenerContainer);
+  auto listener          = buildListener(listenerContainer);
   _worker->progress();
 
   if (GetParam() == 0)

--- a/cpp/tests/listener.cpp
+++ b/cpp/tests/listener.cpp
@@ -120,17 +120,25 @@ TEST_P(ListenerTest, EndpointSendRecv)
 
   std::vector<int> client_buf{123};
   std::vector<int> server_buf{0};
-  requests.push_back(ep->tagSend(client_buf.data(), client_buf.size() * sizeof(int), ucxx::Tag{0}));
-  requests.push_back(listenerContainer->endpoint->tagRecv(
-    &server_buf.front(), server_buf.size() * sizeof(int), ucxx::Tag{0}, ucxx::TagMaskFull));
+  requests.push_back(
+    ep->tagSendBuilder(client_buf.data(), client_buf.size() * sizeof(int), ucxx::Tag{0}).build());
+  requests.push_back(
+    listenerContainer->endpoint
+      ->tagRecvBuilder(
+        &server_buf.front(), server_buf.size() * sizeof(int), ucxx::Tag{0}, ucxx::TagMaskFull)
+      .build());
   ::waitRequests(_worker, requests, progress);
 
   ASSERT_EQ(server_buf[0], client_buf[0]);
 
-  requests.push_back(listenerContainer->endpoint->tagSend(
-    &server_buf.front(), server_buf.size() * sizeof(int), ucxx::Tag{1}));
-  requests.push_back(ep->tagRecv(
-    client_buf.data(), client_buf.size() * sizeof(int), ucxx::Tag{1}, ucxx::TagMaskFull));
+  requests.push_back(
+    listenerContainer->endpoint
+      ->tagSendBuilder(&server_buf.front(), server_buf.size() * sizeof(int), ucxx::Tag{1})
+      .build());
+  requests.push_back(
+    ep->tagRecvBuilder(
+        client_buf.data(), client_buf.size() * sizeof(int), ucxx::Tag{1}, ucxx::TagMaskFull)
+      .build());
   ::waitRequests(_worker, requests, progress);
   ASSERT_EQ(client_buf[0], server_buf[0]);
 
@@ -153,7 +161,7 @@ TEST_P(ListenerTest, IsAlive)
 
   std::vector<int> buf{123};
   std::shared_ptr<ucxx::Request> send_req =
-    ep->tagSend(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0});
+    ep->tagSendBuilder(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0}).build();
   while (!send_req->isCompleted())
     _worker->progress();
 
@@ -251,7 +259,7 @@ TEST_P(ListenerTest, EndpointNonBlockingClose)
   while (listenerContainer->endpoint == nullptr)
     _worker->progress();
 
-  auto closeRequest = ep->close();
+  auto closeRequest = ep->closeBuilder().build();
 
   auto f = [this, &closeRequest]() {
     _worker->progress();
@@ -287,7 +295,11 @@ TEST_P(ListenerTest, EndpointNonBlockingCloseWithCallbacks)
   while (listenerContainer->endpoint == nullptr)
     _worker->progress();
 
-  auto closeRequest = ep->close(false, closeCallback, closeCallbackRequest);
+  auto closeRequest = ep->closeBuilder()
+                        .pythonFuture(false)
+                        .callbackFunction(closeCallback)
+                        .callbackData(closeCallbackRequest)
+                        .build();
 
   auto f = [this, &closeRequest]() {
     _worker->progress();

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>
@@ -19,7 +19,6 @@
 
 #include "include/utils.h"
 #include "ucxx/buffer.h"
-#include "ucxx/constructors.h"
 #include "ucxx/utils/ucx.h"
 
 #ifndef UCXX_TESTS_ENABLE_RMM
@@ -119,7 +118,7 @@ class RequestTest
 
     _progressWorker = getProgressFunction(_worker, _progressMode);
 
-    _ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+    _ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
   }
 
   void rebuildWorker(bool enableRequestAttributes)
@@ -153,8 +152,9 @@ class RequestTest
     _memoryType  = isCudaBufferType(_bufferType) ? UCS_MEMORY_TYPE_CUDA : UCS_MEMORY_TYPE_HOST;
     _messageSize = _messageLength * sizeof(int);
 
-    _context = ucxx::createContext({{"RNDV_THRESH", std::to_string(_rndvThresh)}},
-                                   ucxx::Context::defaultFeatureFlags);
+    _context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags)
+                 .configMap({{"RNDV_THRESH", std::to_string(_rndvThresh)}})
+                 .build();
     buildWorker(false);
   }
 
@@ -608,11 +608,11 @@ class RequestAttributesDisabledTest : public ::testing::Test {
 
   void SetUp() override
   {
-    _context = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
+    _context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build();
     _worker  = ucxx::workerBuilder(_context).build();
     ASSERT_FALSE(_worker->isRequestAttributesEnabled());
 
-    _ep             = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+    _ep             = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
     _progressWorker = getProgressFunction(_worker, ProgressMode::Polling);
 
     _sendBuf.resize(kMessageLength);
@@ -668,12 +668,15 @@ TEST_F(RequestAttributesDisabledTest, Am)
 
 TEST_F(RequestAttributesDisabledTest, MemoryGet)
 {
-  auto memoryHandle = _context->createMemoryHandle(kMessageSize, nullptr, UCS_MEMORY_TYPE_HOST);
+  auto memoryHandle = _context->memoryHandleBuilder(kMessageSize)
+                        .buffer(nullptr)
+                        .memoryType(UCS_MEMORY_TYPE_HOST)
+                        .build();
   std::memcpy(
     reinterpret_cast<void*>(memoryHandle->getBaseAddress()), _sendBuf.data(), kMessageSize);
 
-  auto serializedRemoteKey = memoryHandle->createRemoteKey()->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto serializedRemoteKey = memoryHandle->remoteKeyBuilder().build()->serialize();
+  auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::shared_ptr<ucxx::Request> request = _ep->memGet(_recvBuf.data(), kMessageSize, remoteKey);
   std::vector<std::shared_ptr<ucxx::Request>> requests{request, _ep->flush()};
@@ -685,10 +688,13 @@ TEST_F(RequestAttributesDisabledTest, MemoryGet)
 
 TEST_F(RequestAttributesDisabledTest, MemoryPut)
 {
-  auto memoryHandle = _context->createMemoryHandle(kMessageSize, nullptr, UCS_MEMORY_TYPE_HOST);
+  auto memoryHandle = _context->memoryHandleBuilder(kMessageSize)
+                        .buffer(nullptr)
+                        .memoryType(UCS_MEMORY_TYPE_HOST)
+                        .build();
 
-  auto serializedRemoteKey = memoryHandle->createRemoteKey()->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto serializedRemoteKey = memoryHandle->remoteKeyBuilder().build()->serialize();
+  auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::shared_ptr<ucxx::Request> request = _ep->memPut(_sendBuf.data(), kMessageSize, remoteKey);
   std::vector<std::shared_ptr<ucxx::Request>> requests{request, _ep->flush()};
@@ -768,13 +774,14 @@ TEST_P(RequestTest, MemoryGetRequestAttributes)
 
   allocate();
 
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, nullptr, _memoryType);
+  auto memoryHandle =
+    _context->memoryHandleBuilder(_messageSize).buffer(nullptr).memoryType(_memoryType).build();
   copyMemoryTypeAware(
     reinterpret_cast<void*>(memoryHandle->getBaseAddress()), _sendPtr[0], _messageSize);
 
-  auto localRemoteKey      = memoryHandle->createRemoteKey();
+  auto localRemoteKey      = memoryHandle->remoteKeyBuilder().build();
   auto serializedRemoteKey = localRemoteKey->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::shared_ptr<ucxx::Request> request = _ep->memGet(_recvPtr[0], _messageSize, remoteKey);
   std::vector<std::shared_ptr<ucxx::Request>> requests;
@@ -797,11 +804,12 @@ TEST_P(RequestTest, MemoryPutRequestAttributes)
 
   allocate();
 
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, nullptr, _memoryType);
+  auto memoryHandle =
+    _context->memoryHandleBuilder(_messageSize).buffer(nullptr).memoryType(_memoryType).build();
 
-  auto localRemoteKey      = memoryHandle->createRemoteKey();
+  auto localRemoteKey      = memoryHandle->remoteKeyBuilder().build();
   auto serializedRemoteKey = localRemoteKey->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::shared_ptr<ucxx::Request> request = _ep->memPut(_sendPtr[0], _messageSize, remoteKey);
   std::vector<std::shared_ptr<ucxx::Request>> requests;
@@ -957,7 +965,8 @@ TEST_P(RequestTest, MemoryGet)
 {
   allocate();
 
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, nullptr, _memoryType);
+  auto memoryHandle =
+    _context->memoryHandleBuilder(_messageSize).buffer(nullptr).memoryType(_memoryType).build();
   // If message size is 0, there's no allocation and memory type is then "host" by default.
   if (_messageSize > 0) ASSERT_EQ(memoryHandle->getMemoryType(), _memoryType);
 
@@ -965,9 +974,9 @@ TEST_P(RequestTest, MemoryGet)
   copyMemoryTypeAware(
     reinterpret_cast<void*>(memoryHandle->getBaseAddress()), _sendPtr[0], _messageSize);
 
-  auto localRemoteKey      = memoryHandle->createRemoteKey();
+  auto localRemoteKey      = memoryHandle->remoteKeyBuilder().build();
   auto serializedRemoteKey = localRemoteKey->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(_ep->memGet(_recvPtr[0], _messageSize, remoteKey));
@@ -985,14 +994,16 @@ TEST_P(RequestTest, MemoryGetPreallocated)
   allocate();
 
   // Memory handles are always non-const
-  auto memoryHandle =
-    _context->createMemoryHandle(_messageSize, const_cast<void*>(_sendPtr[0]), _memoryType);
+  auto memoryHandle = _context->memoryHandleBuilder(_messageSize)
+                        .buffer(const_cast<void*>(_sendPtr[0]))
+                        .memoryType(_memoryType)
+                        .build();
   // If message size is 0, there's no allocation and memory type is then "host" by default.
   if (_messageSize > 0) ASSERT_EQ(memoryHandle->getMemoryType(), _memoryType);
 
-  auto localRemoteKey      = memoryHandle->createRemoteKey();
+  auto localRemoteKey      = memoryHandle->remoteKeyBuilder().build();
   auto serializedRemoteKey = localRemoteKey->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(_ep->memGet(_recvPtr[0], _messageSize, remoteKey));
@@ -1013,7 +1024,8 @@ TEST_P(RequestTest, MemoryGetWithOffset)
   size_t offset      = 1;
   size_t offsetBytes = offset * sizeof(_send[0][0]);
 
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, nullptr, _memoryType);
+  auto memoryHandle =
+    _context->memoryHandleBuilder(_messageSize).buffer(nullptr).memoryType(_memoryType).build();
   // If message size is 0, there's no allocation and memory type is then "host" by default.
   if (_messageSize > 0) ASSERT_EQ(memoryHandle->getMemoryType(), _memoryType);
 
@@ -1021,9 +1033,9 @@ TEST_P(RequestTest, MemoryGetWithOffset)
   copyMemoryTypeAware(
     reinterpret_cast<void*>(memoryHandle->getBaseAddress()), _sendPtr[0], _messageSize);
 
-  auto localRemoteKey      = memoryHandle->createRemoteKey();
+  auto localRemoteKey      = memoryHandle->remoteKeyBuilder().build();
   auto serializedRemoteKey = localRemoteKey->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(_ep->memGet(reinterpret_cast<char*>(_recvPtr[0]) + offsetBytes,
@@ -1045,13 +1057,14 @@ TEST_P(RequestTest, MemoryPut)
 {
   allocate();
 
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, nullptr, _memoryType);
+  auto memoryHandle =
+    _context->memoryHandleBuilder(_messageSize).buffer(nullptr).memoryType(_memoryType).build();
   // If message size is 0, there's no allocation and memory type is then "host" by default.
   if (_messageSize > 0) ASSERT_EQ(memoryHandle->getMemoryType(), _memoryType);
 
-  auto localRemoteKey      = memoryHandle->createRemoteKey();
+  auto localRemoteKey      = memoryHandle->remoteKeyBuilder().build();
   auto serializedRemoteKey = localRemoteKey->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(_ep->memPut(_sendPtr[0], _messageSize, remoteKey));
@@ -1072,13 +1085,14 @@ TEST_P(RequestTest, MemoryPutPreallocated)
 {
   allocate();
 
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, _recvPtr[0], _memoryType);
+  auto memoryHandle =
+    _context->memoryHandleBuilder(_messageSize).buffer(_recvPtr[0]).memoryType(_memoryType).build();
   // If message size is 0, there's no allocation and memory type is then "host" by default.
   if (_messageSize > 0) ASSERT_EQ(memoryHandle->getMemoryType(), _memoryType);
 
-  auto localRemoteKey      = memoryHandle->createRemoteKey();
+  auto localRemoteKey      = memoryHandle->remoteKeyBuilder().build();
   auto serializedRemoteKey = localRemoteKey->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(_ep->memPut(_sendPtr[0], _messageSize, remoteKey));
@@ -1099,13 +1113,14 @@ TEST_P(RequestTest, MemoryPutWithOffset)
   size_t offset      = 1;
   size_t offsetBytes = offset * sizeof(_send[0][0]);
 
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, nullptr, _memoryType);
+  auto memoryHandle =
+    _context->memoryHandleBuilder(_messageSize).buffer(nullptr).memoryType(_memoryType).build();
   // If message size is 0, there's no allocation and memory type is then "host" by default.
   if (_messageSize > 0) ASSERT_EQ(memoryHandle->getMemoryType(), _memoryType);
 
-  auto localRemoteKey      = memoryHandle->createRemoteKey();
+  auto localRemoteKey      = memoryHandle->remoteKeyBuilder().build();
   auto serializedRemoteKey = localRemoteKey->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(_ep->memPut(reinterpret_cast<const char*>(_sendPtr[0]) + offsetBytes,

--- a/cpp/tests/request.cpp
+++ b/cpp/tests/request.cpp
@@ -257,8 +257,8 @@ TEST_P(RequestTest, ProgressAm)
 
   // Submit and wait for transfers to complete
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendPtr[0], _messageSize, _memoryType));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amSendBuilder(_sendPtr[0], _messageSize, _memoryType).build());
+  requests.push_back(_ep->amRecvBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq = requests[1];
@@ -304,8 +304,8 @@ TEST_P(RequestTest, ProgressAmIovHost)
   amSendParams.memoryType = UCS_MEMORY_TYPE_HOST;
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(iov, amSendParams));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amSendBuilder(iov, amSendParams).build());
+  requests.push_back(_ep->amRecvBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq    = requests[1];
@@ -324,13 +324,14 @@ TEST_P(RequestTest, ProgressAmIovValidation)
   amSendParams.datatype   = UCP_DATATYPE_IOV;
   amSendParams.memoryType = UCS_MEMORY_TYPE_HOST;
 
-  EXPECT_THROW(std::ignore = _ep->amSend(std::vector<ucp_dt_iov_t>{}, amSendParams),
+  EXPECT_THROW(std::ignore = _ep->amSendBuilder(std::vector<ucp_dt_iov_t>{}, amSendParams).build(),
                std::runtime_error);
 
   std::vector<ucp_dt_iov_t> iovWithNullBuffer(1);
   iovWithNullBuffer[0].buffer = nullptr;
   iovWithNullBuffer[0].length = 16;
-  EXPECT_THROW(std::ignore = _ep->amSend(iovWithNullBuffer, amSendParams), std::runtime_error);
+  EXPECT_THROW(std::ignore = _ep->amSendBuilder(iovWithNullBuffer, amSendParams).build(),
+               std::runtime_error);
 
   std::vector<int> send{1, 2, 3, 4};
   std::vector<ucp_dt_iov_t> validIov(1);
@@ -339,7 +340,8 @@ TEST_P(RequestTest, ProgressAmIovValidation)
 
   auto wrongDatatypeParams     = amSendParams;
   wrongDatatypeParams.datatype = ucp_dt_make_contig(1);
-  EXPECT_THROW(std::ignore = _ep->amSend(validIov, wrongDatatypeParams), std::runtime_error);
+  EXPECT_THROW(std::ignore = _ep->amSendBuilder(validIov, wrongDatatypeParams).build(),
+               std::runtime_error);
 }
 
 TEST_P(RequestTest, ProgressAmMemoryTypePolicyStrict)
@@ -356,8 +358,8 @@ TEST_P(RequestTest, ProgressAmMemoryTypePolicyStrict)
   amSendParams.memoryTypePolicy = ucxx::AmSendMemoryTypePolicy::ErrorOnUnsupported;
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(send.data(), send.size(), amSendParams));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amSendBuilder(send.data(), send.size(), amSendParams).build());
+  requests.push_back(_ep->amRecvBuilder().build());
 
   // Wait for completion without calling checkError(), since the receive request
   // is expected to complete with UCS_ERR_UNSUPPORTED.
@@ -407,7 +409,9 @@ TEST_P(RequestTest, ProgressAmReceiverCallback)
 
   // Submit and wait for transfers to complete
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendPtr[0], _messageSize, _memoryType, receiverCallbackInfo));
+  requests.push_back(_ep->amSendBuilder(_sendPtr[0], _messageSize, _memoryType)
+                       .receiverCallbackInfo(receiverCallbackInfo)
+                       .build());
   waitRequests(_worker, requests, _progressWorker);
 
   while (receivedRequests.size() < 1)
@@ -449,8 +453,8 @@ TEST_P(RequestTest, ProgressAmUserHeader)
   amSendParams.setUserHeader(sentHeader);
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendPtr[0], _messageSize, amSendParams));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amSendBuilder(_sendPtr[0], _messageSize, amSendParams).build());
+  requests.push_back(_ep->amRecvBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq = requests[1];
@@ -491,8 +495,8 @@ TEST_P(RequestTest, ProgressAmIovUserHeader)
   amSendParams.setUserHeader(sentHeader);
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(iov, amSendParams));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amSendBuilder(iov, amSendParams).build());
+  requests.push_back(_ep->amRecvBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq    = requests[1];
@@ -520,8 +524,8 @@ TEST_P(RequestTest, ProgressAmEmptyUserHeader)
 
   // Send without user header (default empty)
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendPtr[0], _messageSize, _memoryType));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amSendBuilder(_sendPtr[0], _messageSize, _memoryType).build());
+  requests.push_back(_ep->amRecvBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq = requests[1];
@@ -538,12 +542,16 @@ TEST_P(RequestTest, ProgressStream)
 
   // Submit and wait for transfers to complete
   if (_messageSize == 0) {
-    EXPECT_THROW(std::ignore = _ep->streamSend(_sendPtr[0], _messageSize, 0), std::runtime_error);
-    EXPECT_THROW(std::ignore = _ep->streamRecv(_recvPtr[0], _messageSize, 0), std::runtime_error);
+    EXPECT_THROW(
+      std::ignore = _ep->streamSendBuilder(_sendPtr[0], _messageSize).pythonFuture(0).build(),
+      std::runtime_error);
+    EXPECT_THROW(
+      std::ignore = _ep->streamRecvBuilder(_recvPtr[0], _messageSize).pythonFuture(0).build(),
+      std::runtime_error);
   } else {
     std::vector<std::shared_ptr<ucxx::Request>> requests;
-    requests.push_back(_ep->streamSend(_sendPtr[0], _messageSize, 0));
-    requests.push_back(_ep->streamRecv(_recvPtr[0], _messageSize, 0));
+    requests.push_back(_ep->streamSendBuilder(_sendPtr[0], _messageSize).pythonFuture(0).build());
+    requests.push_back(_ep->streamRecvBuilder(_recvPtr[0], _messageSize).pythonFuture(0).build());
     waitRequests(_worker, requests, _progressWorker);
 
     copyResults();
@@ -559,8 +567,9 @@ TEST_P(RequestTest, ProgressTag)
 
   // Submit and wait for transfers to complete
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->tagSend(_sendPtr[0], _messageSize, ucxx::Tag{0}));
-  requests.push_back(_ep->tagRecv(_recvPtr[0], _messageSize, ucxx::Tag{0}, ucxx::TagMaskFull));
+  requests.push_back(_ep->tagSendBuilder(_sendPtr[0], _messageSize, ucxx::Tag{0}).build());
+  requests.push_back(
+    _ep->tagRecvBuilder(_recvPtr[0], _messageSize, ucxx::Tag{0}, ucxx::TagMaskFull).build());
   waitRequests(_worker, requests, _progressWorker);
 
   copyResults();
@@ -579,8 +588,9 @@ TEST_P(RequestTest, ProgressTagRequestAttributes)
   allocate();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->tagSend(_sendPtr[0], _messageSize, ucxx::Tag{0}));
-  requests.push_back(_ep->tagRecv(_recvPtr[0], _messageSize, ucxx::Tag{0}, ucxx::TagMaskFull));
+  requests.push_back(_ep->tagSendBuilder(_sendPtr[0], _messageSize, ucxx::Tag{0}).build());
+  requests.push_back(
+    _ep->tagRecvBuilder(_recvPtr[0], _messageSize, ucxx::Tag{0}, ucxx::TagMaskFull).build());
   waitRequests(_worker, requests, _progressWorker);
 
   for (const auto& request : requests) {
@@ -631,8 +641,9 @@ class RequestAttributesDisabledTest : public ::testing::Test {
 TEST_F(RequestAttributesDisabledTest, Tag)
 {
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->tagSend(_sendBuf.data(), kMessageSize, ucxx::Tag{0}));
-  requests.push_back(_ep->tagRecv(_recvBuf.data(), kMessageSize, ucxx::Tag{0}, ucxx::TagMaskFull));
+  requests.push_back(_ep->tagSendBuilder(_sendBuf.data(), kMessageSize, ucxx::Tag{0}).build());
+  requests.push_back(
+    _ep->tagRecvBuilder(_recvBuf.data(), kMessageSize, ucxx::Tag{0}, ucxx::TagMaskFull).build());
   waitRequests(_worker, requests, _progressWorker);
 
   expectAllThrow(requests);
@@ -642,8 +653,8 @@ TEST_F(RequestAttributesDisabledTest, Tag)
 TEST_F(RequestAttributesDisabledTest, Stream)
 {
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->streamSend(_sendBuf.data(), kMessageSize, 0));
-  requests.push_back(_ep->streamRecv(_recvBuf.data(), kMessageSize, 0));
+  requests.push_back(_ep->streamSendBuilder(_sendBuf.data(), kMessageSize).pythonFuture(0).build());
+  requests.push_back(_ep->streamRecvBuilder(_recvBuf.data(), kMessageSize).pythonFuture(0).build());
   waitRequests(_worker, requests, _progressWorker);
 
   expectAllThrow(requests);
@@ -653,8 +664,9 @@ TEST_F(RequestAttributesDisabledTest, Stream)
 TEST_F(RequestAttributesDisabledTest, Am)
 {
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendBuf.data(), kMessageSize, UCS_MEMORY_TYPE_HOST));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(
+    _ep->amSendBuilder(_sendBuf.data(), kMessageSize, UCS_MEMORY_TYPE_HOST).build());
+  requests.push_back(_ep->amRecvBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   expectAllThrow(requests);
@@ -678,8 +690,9 @@ TEST_F(RequestAttributesDisabledTest, MemoryGet)
   auto serializedRemoteKey = memoryHandle->remoteKeyBuilder().build()->serialize();
   auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
-  std::shared_ptr<ucxx::Request> request = _ep->memGet(_recvBuf.data(), kMessageSize, remoteKey);
-  std::vector<std::shared_ptr<ucxx::Request>> requests{request, _ep->flush()};
+  std::shared_ptr<ucxx::Request> request =
+    _ep->memGetBuilder(_recvBuf.data(), kMessageSize, remoteKey).build();
+  std::vector<std::shared_ptr<ucxx::Request>> requests{request, _ep->flushBuilder().build()};
   waitRequests(_worker, requests, _progressWorker);
 
   expectAllThrow({request});
@@ -696,8 +709,9 @@ TEST_F(RequestAttributesDisabledTest, MemoryPut)
   auto serializedRemoteKey = memoryHandle->remoteKeyBuilder().build()->serialize();
   auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
-  std::shared_ptr<ucxx::Request> request = _ep->memPut(_sendBuf.data(), kMessageSize, remoteKey);
-  std::vector<std::shared_ptr<ucxx::Request>> requests{request, _ep->flush()};
+  std::shared_ptr<ucxx::Request> request =
+    _ep->memPutBuilder(_sendBuf.data(), kMessageSize, remoteKey).build();
+  std::vector<std::shared_ptr<ucxx::Request>> requests{request, _ep->flushBuilder().build()};
   waitRequests(_worker, requests, _progressWorker);
 
   expectAllThrow({request});
@@ -715,8 +729,10 @@ TEST_P(RequestTest, ProgressStreamRequestAttributes)
 
   allocate();
 
-  std::shared_ptr<ucxx::Request> sendRequest = _ep->streamSend(_sendPtr[0], _messageSize, 0);
-  std::shared_ptr<ucxx::Request> recvRequest = _ep->streamRecv(_recvPtr[0], _messageSize, 0);
+  std::shared_ptr<ucxx::Request> sendRequest =
+    _ep->streamSendBuilder(_sendPtr[0], _messageSize).pythonFuture(0).build();
+  std::shared_ptr<ucxx::Request> recvRequest =
+    _ep->streamRecvBuilder(_recvPtr[0], _messageSize).pythonFuture(0).build();
   std::vector<std::shared_ptr<ucxx::Request>> requests{sendRequest, recvRequest};
   waitRequests(_worker, requests, _progressWorker);
 
@@ -751,8 +767,8 @@ TEST_P(RequestTest, ProgressAmRequestAttributes)
   allocate(1, false);
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->amSend(_sendPtr[0], _messageSize, _memoryType));
-  requests.push_back(_ep->amRecv());
+  requests.push_back(_ep->amSendBuilder(_sendPtr[0], _messageSize, _memoryType).build());
+  requests.push_back(_ep->amRecvBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   for (const auto& request : requests) {
@@ -783,10 +799,11 @@ TEST_P(RequestTest, MemoryGetRequestAttributes)
   auto serializedRemoteKey = localRemoteKey->serialize();
   auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
-  std::shared_ptr<ucxx::Request> request = _ep->memGet(_recvPtr[0], _messageSize, remoteKey);
+  std::shared_ptr<ucxx::Request> request =
+    _ep->memGetBuilder(_recvPtr[0], _messageSize, remoteKey).build();
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(request);
-  requests.push_back(_ep->flush());
+  requests.push_back(_ep->flushBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   auto debugString = request->queryAttributes().debugString;
@@ -811,10 +828,11 @@ TEST_P(RequestTest, MemoryPutRequestAttributes)
   auto serializedRemoteKey = localRemoteKey->serialize();
   auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
-  std::shared_ptr<ucxx::Request> request = _ep->memPut(_sendPtr[0], _messageSize, remoteKey);
+  std::shared_ptr<ucxx::Request> request =
+    _ep->memPutBuilder(_sendPtr[0], _messageSize, remoteKey).build();
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(request);
-  requests.push_back(_ep->flush());
+  requests.push_back(_ep->flushBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   try {
@@ -853,8 +871,11 @@ TEST_P(RequestTest, ProgressTagMulti)
 
   // Submit and wait for transfers to complete
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->tagMultiSend(_sendPtr, multiSize, multiIsCUDA, ucxx::Tag{0}, false));
-  requests.push_back(_ep->tagMultiRecv(ucxx::Tag{0}, ucxx::TagMaskFull, false));
+  requests.push_back(_ep->tagMultiSendBuilder(_sendPtr, multiSize, multiIsCUDA, ucxx::Tag{0})
+                       .pythonFuture(false)
+                       .build());
+  requests.push_back(
+    _ep->tagMultiRecvBuilder(ucxx::Tag{0}, ucxx::TagMaskFull).pythonFuture(false).build());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvRequest = requests[1];
@@ -902,10 +923,16 @@ TEST_P(RequestTest, TagUserCallback)
   auto recvIndex = std::make_shared<size_t>(1u);
 
   // Submit and wait for transfers to complete
-  requests[0] =
-    _ep->tagSend(_sendPtr[0], _messageSize, ucxx::Tag{0}, false, checkStatus, sendIndex);
-  requests[1] = _ep->tagRecv(
-    _recvPtr[0], _messageSize, ucxx::Tag{0}, ucxx::TagMaskFull, false, checkStatus, recvIndex);
+  requests[0] = _ep->tagSendBuilder(_sendPtr[0], _messageSize, ucxx::Tag{0})
+                  .pythonFuture(false)
+                  .callbackFunction(checkStatus)
+                  .callbackData(sendIndex)
+                  .build();
+  requests[1] = _ep->tagRecvBuilder(_recvPtr[0], _messageSize, ucxx::Tag{0}, ucxx::TagMaskFull)
+                  .pythonFuture(false)
+                  .callbackFunction(checkStatus)
+                  .callbackData(recvIndex)
+                  .build();
   waitRequests(_worker, requests, _progressWorker);
 
   copyResults();
@@ -947,9 +974,17 @@ TEST_P(RequestTest, TagUserCallbackDiscardReturn)
   // Submit and wait for transfers to complete via callbacks; the shared_ptr is discarded
   // but the request is kept alive by the endpoint's inflight-request registry.
   std::shared_ptr<ucxx::Request> sendReq =
-    _ep->tagSend(_sendPtr[0], _messageSize, ucxx::Tag{0}, false, checkStatus, sendIndex);
-  std::shared_ptr<ucxx::Request> recvReq = _ep->tagRecv(
-    _recvPtr[0], _messageSize, ucxx::Tag{0}, ucxx::TagMaskFull, false, checkStatus, recvIndex);
+    _ep->tagSendBuilder(_sendPtr[0], _messageSize, ucxx::Tag{0})
+      .pythonFuture(false)
+      .callbackFunction(checkStatus)
+      .callbackData(sendIndex)
+      .build();
+  std::shared_ptr<ucxx::Request> recvReq =
+    _ep->tagRecvBuilder(_recvPtr[0], _messageSize, ucxx::Tag{0}, ucxx::TagMaskFull)
+      .pythonFuture(false)
+      .callbackFunction(checkStatus)
+      .callbackData(recvIndex)
+      .build();
   checkCompletion();
 
   copyResults();
@@ -979,8 +1014,8 @@ TEST_P(RequestTest, MemoryGet)
   auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->memGet(_recvPtr[0], _messageSize, remoteKey));
-  requests.push_back(_ep->flush());
+  requests.push_back(_ep->memGetBuilder(_recvPtr[0], _messageSize, remoteKey).build());
+  requests.push_back(_ep->flushBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   copyResults();
@@ -1006,8 +1041,8 @@ TEST_P(RequestTest, MemoryGetPreallocated)
   auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->memGet(_recvPtr[0], _messageSize, remoteKey));
-  requests.push_back(_ep->flush());
+  requests.push_back(_ep->memGetBuilder(_recvPtr[0], _messageSize, remoteKey).build());
+  requests.push_back(_ep->flushBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   copyResults();
@@ -1038,11 +1073,13 @@ TEST_P(RequestTest, MemoryGetWithOffset)
   auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->memGet(reinterpret_cast<char*>(_recvPtr[0]) + offsetBytes,
-                                 _messageSize - offsetBytes,
-                                 remoteKey,
-                                 offsetBytes));
-  requests.push_back(_ep->flush());
+  requests.push_back(_ep
+                       ->memGetBuilder(reinterpret_cast<char*>(_recvPtr[0]) + offsetBytes,
+                                       _messageSize - offsetBytes,
+                                       remoteKey->getBaseAddress() + offsetBytes,
+                                       remoteKey->getHandle())
+                       .build());
+  requests.push_back(_ep->flushBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   copyResults();
@@ -1067,8 +1104,8 @@ TEST_P(RequestTest, MemoryPut)
   auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->memPut(_sendPtr[0], _messageSize, remoteKey));
-  requests.push_back(_ep->flush());
+  requests.push_back(_ep->memPutBuilder(_sendPtr[0], _messageSize, remoteKey).build());
+  requests.push_back(_ep->flushBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   // Copy memory handle data to receive buffer
@@ -1095,8 +1132,8 @@ TEST_P(RequestTest, MemoryPutPreallocated)
   auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->memPut(_sendPtr[0], _messageSize, remoteKey));
-  requests.push_back(_ep->flush());
+  requests.push_back(_ep->memPutBuilder(_sendPtr[0], _messageSize, remoteKey).build());
+  requests.push_back(_ep->flushBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   copyResults();
@@ -1123,11 +1160,13 @@ TEST_P(RequestTest, MemoryPutWithOffset)
   auto remoteKey           = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(_ep->memPut(reinterpret_cast<const char*>(_sendPtr[0]) + offsetBytes,
-                                 _messageSize - offsetBytes,
-                                 remoteKey,
-                                 offsetBytes));
-  requests.push_back(_ep->flush());
+  requests.push_back(_ep
+                       ->memPutBuilder(reinterpret_cast<const char*>(_sendPtr[0]) + offsetBytes,
+                                       _messageSize - offsetBytes,
+                                       remoteKey->getBaseAddress() + offsetBytes,
+                                       remoteKey->getHandle())
+                       .build());
+  requests.push_back(_ep->flushBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   // Copy memory handle data to receive buffer

--- a/cpp/tests/request_builders.cpp
+++ b/cpp/tests/request_builders.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <memory>
@@ -27,14 +27,14 @@ namespace {
 class RequestBuilderTest : public ::testing::Test {
  protected:
   std::shared_ptr<ucxx::Context> _context{
-    ucxx::createContext({}, ucxx::Context::defaultFeatureFlags)};
+    ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build()};
   std::shared_ptr<ucxx::Worker> _worker{nullptr};
   std::shared_ptr<ucxx::Endpoint> _ep{nullptr};
 
   void SetUp() override
   {
-    _worker = _context->createWorker();
-    _ep     = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+    _worker = _context->workerBuilder().build();
+    _ep     = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
   }
 
   void progressUntilCompleted(std::shared_ptr<ucxx::Request> req)
@@ -381,7 +381,7 @@ TEST_F(RequestBuilderTest, StreamBuilderImplicitConversion)
 
 TEST_F(RequestBuilderTest, EndpointCloseBuilderAutoType)
 {
-  auto ep      = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep      = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
   auto builder = ucxx::requestEndpointCloseBuilder(ep, ucxx::data::EndpointClose{false});
   static_assert(std::is_same<decltype(builder), ucxx::RequestEndpointCloseBuilder>::value,
                 "auto without .build() is RequestEndpointCloseBuilder");
@@ -389,7 +389,7 @@ TEST_F(RequestBuilderTest, EndpointCloseBuilderAutoType)
 
 TEST_F(RequestBuilderTest, EndpointCloseBuilderMethodChaining)
 {
-  auto ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   ucxx::RequestCallbackUserFunction callbackFn{nullptr};
   ucxx::RequestCallbackUserData callbackData{nullptr};
@@ -404,7 +404,7 @@ TEST_F(RequestBuilderTest, EndpointCloseBuilderMethodChaining)
 
 TEST_F(RequestBuilderTest, EndpointCloseBuilderBuild)
 {
-  auto ep  = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep  = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
   auto req = ucxx::requestEndpointCloseBuilder(ep, ucxx::data::EndpointClose{true}).build();
 
   ASSERT_TRUE(req != nullptr);
@@ -444,7 +444,7 @@ TEST_F(RequestBuilderTest, AllBuilderAutoTypes)
                 "auto without .build() is RequestFlushBuilder");
 
   {
-    auto closeEp = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+    auto closeEp = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
     auto closeBuilder =
       ucxx::requestEndpointCloseBuilder(closeEp, ucxx::data::EndpointClose{false});
     static_assert(std::is_same<decltype(closeBuilder), ucxx::RequestEndpointCloseBuilder>::value,

--- a/cpp/tests/request_builders.cpp
+++ b/cpp/tests/request_builders.cpp
@@ -409,7 +409,6 @@ TEST_F(RequestBuilderTest, EndpointCloseBuilderBuild)
 
   ASSERT_TRUE(req != nullptr);
   progressUntilCompleted(req);
-  EXPECT_EQ(nullptr, ep->close());
 }
 
 TEST_F(RequestBuilderTest, AllBuilderAutoTypes)
@@ -670,95 +669,6 @@ TEST(RequestBuilderSingleUseTest, ImplicitConversionAttemptMarksBuilderBuilt)
   EXPECT_THROW(std::ignore = static_cast<std::shared_ptr<ucxx::Request>>(builder), ucxx::Error);
   EXPECT_THROW(std::ignore = static_cast<std::shared_ptr<ucxx::Request>>(builder),
                std::logic_error);
-}
-
-TEST_F(RequestBuilderTest, EndpointFlushReturnsRequest)
-{
-  auto req = _ep->flush();
-  static_assert(std::is_same<decltype(req), std::shared_ptr<ucxx::Request>>::value,
-                "ep->flush() returns shared_ptr<Request>");
-  ASSERT_TRUE(req != nullptr);
-  progressUntilCompleted(req);
-}
-
-TEST_F(RequestBuilderTest, WorkerFlushReturnsRequest)
-{
-  auto req = _worker->flush();
-  static_assert(std::is_same<decltype(req), std::shared_ptr<ucxx::Request>>::value,
-                "worker->flush() returns shared_ptr<Request>");
-  ASSERT_TRUE(req != nullptr);
-  progressUntilCompleted(req);
-}
-
-TEST_F(RequestBuilderTest, EndpointWorkerTagSendRecvReturnRequests)
-{
-  std::vector<int> sendBuf{10, 20, 30};
-  std::vector<int> recvBuf(3);
-  auto tag     = ucxx::Tag{42};
-  auto tagMask = ucxx::TagMaskFull;
-
-  auto sendReq = _ep->tagSend(sendBuf.data(), sendBuf.size() * sizeof(int), tag);
-  auto recvReq = _worker->tagRecv(recvBuf.data(), recvBuf.size() * sizeof(int), tag, tagMask);
-  static_assert(std::is_same<decltype(sendReq), std::shared_ptr<ucxx::Request>>::value,
-                "ep->tagSend() returns shared_ptr<Request>");
-  static_assert(std::is_same<decltype(recvReq), std::shared_ptr<ucxx::Request>>::value,
-                "worker->tagRecv() returns shared_ptr<Request>");
-
-  ASSERT_TRUE(sendReq != nullptr);
-  ASSERT_TRUE(recvReq != nullptr);
-
-  while (!sendReq->isCompleted() || !recvReq->isCompleted())
-    _worker->progress();
-  sendReq->checkError();
-  recvReq->checkError();
-
-  EXPECT_EQ(sendBuf, recvBuf);
-}
-
-TEST_F(RequestBuilderTest, EndpointTagSendCallback)
-{
-  std::vector<int> sendBuf{1, 2};
-  std::vector<int> recvBuf(2);
-  auto tag     = ucxx::Tag{99};
-  auto tagMask = ucxx::TagMaskFull;
-
-  bool callbackCalled                  = false;
-  ucxx::RequestCallbackUserFunction cb = [&callbackCalled](ucs_status_t, std::shared_ptr<void>) {
-    callbackCalled = true;
-  };
-
-  auto sendReq = _ep->tagSend(sendBuf.data(), sendBuf.size() * sizeof(int), tag, false, cb);
-  auto recvReq = _worker->tagRecv(recvBuf.data(), recvBuf.size() * sizeof(int), tag, tagMask);
-
-  while (!sendReq->isCompleted() || !recvReq->isCompleted())
-    _worker->progress();
-  sendReq->checkError();
-  recvReq->checkError();
-
-  EXPECT_EQ(sendBuf, recvBuf);
-  EXPECT_TRUE(callbackCalled);
-}
-
-TEST_F(RequestBuilderTest, EndpointTagSendAutoDeducesRequest)
-{
-  // Verify that `auto req = ep->tagSend(...)` preserves the legacy request type.
-  std::vector<int> sendBuf{9, 8, 7};
-  std::vector<int> recvBuf(3);
-  auto tag     = ucxx::Tag{55};
-  auto tagMask = ucxx::TagMaskFull;
-
-  auto sendReq = _ep->tagSend(sendBuf.data(), sendBuf.size() * sizeof(int), tag);
-  auto recvReq = _worker->tagRecv(recvBuf.data(), recvBuf.size() * sizeof(int), tag, tagMask);
-
-  static_assert(std::is_same<decltype(sendReq), std::shared_ptr<ucxx::Request>>::value,
-                "auto ep->tagSend() deduces shared_ptr<Request>");
-
-  while (!sendReq->isCompleted() || !recvReq->isCompleted())
-    _worker->progress();
-  sendReq->checkError();
-  recvReq->checkError();
-
-  EXPECT_EQ(sendBuf, recvBuf);
 }
 
 TEST_F(RequestBuilderTest, EndpointFlushBuilderMethod)

--- a/cpp/tests/rma.cpp
+++ b/cpp/tests/rma.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <algorithm>
@@ -19,7 +19,6 @@
 
 #include "include/utils.h"
 #include "ucxx/buffer.h"
-#include "ucxx/constructors.h"
 #include "ucxx/utils/ucx.h"
 
 namespace {
@@ -43,11 +42,12 @@ class RmaTest : public ::testing::TestWithParam<std::tuple<ucs_memory_type_t, si
   {
     std::tie(_memoryType, _messageSize, _preallocateBuffer) = GetParam();
 
-    _context = ucxx::createContext({{"RNDV_THRESH", std::to_string(_rndvThresh)}},
-                                   ucxx::Context::defaultFeatureFlags);
-    _worker  = _context->createWorker();
+    _context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags)
+                 .configMap({{"RNDV_THRESH", std::to_string(_rndvThresh)}})
+                 .build();
+    _worker = _context->workerBuilder().build();
 
-    _ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+    _ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
     _buffer = preallocate();
   }
@@ -85,27 +85,15 @@ class BasicUcxxRmaTest : public ::testing::TestWithParam<std::tuple<size_t>> {
   {
     std::tie(_messageSize) = GetParam();
 
-    _context = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
-    _worker  = _context->createWorker();
-    _ep      = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+    _context = ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build();
+    _worker  = _context->workerBuilder().build();
+    _ep      = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
   }
 };
 
 TEST_P(RmaTest, MemoryHandle)
 {
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, _buffer);
-  ASSERT_GE(memoryHandle->getSize(), _messageSize);
-  if (_messageSize == 0)
-    ASSERT_EQ(memoryHandle->getBaseAddress(), 0);
-  else
-    ASSERT_NE(memoryHandle->getBaseAddress(), 0);
-
-  ASSERT_NE(memoryHandle->getHandle(), nullptr);
-}
-
-TEST_P(RmaTest, MemoryHandleUcxxNamespaceConstructor)
-{
-  auto memoryHandle = ucxx::createMemoryHandle(_context, _messageSize, _buffer);
+  auto memoryHandle = _context->memoryHandleBuilder(_messageSize).buffer(_buffer).build();
   ASSERT_GE(memoryHandle->getSize(), _messageSize);
   if (_messageSize == 0)
     ASSERT_EQ(memoryHandle->getBaseAddress(), 0);
@@ -117,20 +105,9 @@ TEST_P(RmaTest, MemoryHandleUcxxNamespaceConstructor)
 
 TEST_P(RmaTest, RemoteKey)
 {
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, _buffer);
+  auto memoryHandle = _context->memoryHandleBuilder(_messageSize).buffer(_buffer).build();
 
-  auto remoteKey = memoryHandle->createRemoteKey();
-
-  ASSERT_EQ(remoteKey->getSize(), memoryHandle->getSize());
-  ASSERT_EQ(remoteKey->getBaseAddress(), memoryHandle->getBaseAddress());
-  ASSERT_EQ(remoteKey->getHandle(), nullptr);
-}
-
-TEST_P(RmaTest, RemoteKeyUcxxNamespaceConstructor)
-{
-  auto memoryHandle = ucxx::createMemoryHandle(_context, _messageSize, _buffer);
-
-  auto remoteKey = ucxx::createRemoteKeyFromMemoryHandle(memoryHandle);
+  auto remoteKey = memoryHandle->remoteKeyBuilder().build();
 
   ASSERT_EQ(remoteKey->getSize(), memoryHandle->getSize());
   ASSERT_EQ(remoteKey->getBaseAddress(), memoryHandle->getBaseAddress());
@@ -139,13 +116,13 @@ TEST_P(RmaTest, RemoteKeyUcxxNamespaceConstructor)
 
 TEST_P(RmaTest, RemoteKeySerialization)
 {
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, _buffer);
+  auto memoryHandle = _context->memoryHandleBuilder(_messageSize).buffer(_buffer).build();
 
-  auto remoteKey = memoryHandle->createRemoteKey();
+  auto remoteKey = memoryHandle->remoteKeyBuilder().build();
 
   auto serializedRemoteKey = remoteKey->serialize();
 
-  auto deserializedRemoteKey = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey);
+  auto deserializedRemoteKey = _ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   ASSERT_EQ(remoteKey->getSize(), deserializedRemoteKey->getSize());
   ASSERT_EQ(remoteKey->getBaseAddress(), deserializedRemoteKey->getBaseAddress());
@@ -154,14 +131,14 @@ TEST_P(RmaTest, RemoteKeySerialization)
 
 TEST_P(BasicUcxxRmaTest, RemoteKeyCorruptedSerializedData)
 {
-  auto memoryHandle = _context->createMemoryHandle(_messageSize, nullptr);
+  auto memoryHandle = _context->memoryHandleBuilder(_messageSize).buffer(nullptr).build();
 
-  auto remoteKey = memoryHandle->createRemoteKey();
+  auto remoteKey = memoryHandle->remoteKeyBuilder().build();
 
   auto serializedRemoteKey = remoteKey->serialize();
   serializedRemoteKey[1]   = ~serializedRemoteKey[1];
 
-  EXPECT_THROW(std::ignore = ucxx::createRemoteKeyFromSerialized(_ep, serializedRemoteKey),
+  EXPECT_THROW(std::ignore = _ep->remoteKeyBuilder(serializedRemoteKey).build(),
                std::runtime_error);
 }
 
@@ -188,8 +165,7 @@ TEST_P(BasicUcxxRmaTest, RemoteKeyTruncatedSerializedData)
   ssFull.write(reinterpret_cast<const char*>(&hash), sizeof(hash));
   ssFull << dataStr;
 
-  EXPECT_THROW(std::ignore = ucxx::createRemoteKeyFromSerialized(_ep, ssFull.str()),
-               std::overflow_error);
+  EXPECT_THROW(std::ignore = _ep->remoteKeyBuilder(ssFull.str()).build(), std::overflow_error);
 }
 
 INSTANTIATE_TEST_SUITE_P(FailureTests, BasicUcxxRmaTest, Combine(Values(0, 4194304)));

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -96,10 +96,10 @@ struct ProbedTagTransfer {
 class WorkerTest : public ::testing::Test {
  protected:
   std::shared_ptr<ucxx::Context> _context{
-    ucxx::createContext({}, ucxx::Context::defaultFeatureFlags)};
+    ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build()};
   std::shared_ptr<ucxx::Worker> _worker{nullptr};
 
-  virtual void SetUp() { _worker = _context->createWorker(); }
+  virtual void SetUp() { _worker = _context->workerBuilder().build(); }
 
   void consumeTagMessageHandle(std::vector<int>* recv_buf, ucp_tag_message_h handle, size_t length)
   {
@@ -116,10 +116,11 @@ class WorkerTest : public ::testing::Test {
                                           bool delayedSubmission,
                                           bool waitForSendCompletion = false)
   {
-    ProbedTagTransfer transfer{_context->createWorker(delayedSubmission),
-                               _context->createWorker(false)};
+    ProbedTagTransfer transfer{
+      _context->workerBuilder().delayedSubmission(delayedSubmission).build(),
+      _context->workerBuilder().build()};
     transfer.endpoint =
-      transfer.sendWorker->createEndpointFromWorkerAddress(transfer.recvWorker->getAddress());
+      transfer.sendWorker->endpointBuilder(transfer.recvWorker->addressBuilder().build()).build();
     transfer.sendRequest = transfer.endpoint->tagSend(buffer, length, ucxx::Tag{0});
 
     loopWithTimeout(std::chrono::milliseconds(5000), [&]() {
@@ -149,7 +150,7 @@ class WorkerCapabilityTest : public ::testing::Test,
                              public ::testing::WithParamInterface<std::tuple<bool, bool>> {
  protected:
   std::shared_ptr<ucxx::Context> _context{
-    ucxx::createContext({}, ucxx::Context::defaultFeatureFlags)};
+    ucxx::contextBuilder(ucxx::Context::defaultFeatureFlags).build()};
   std::shared_ptr<ucxx::Worker> _worker{nullptr};
   bool _enableDelayedSubmission;
   bool _enableFuture;
@@ -158,7 +159,10 @@ class WorkerCapabilityTest : public ::testing::Test,
   {
     std::tie(_enableDelayedSubmission, _enableFuture) = GetParam();
 
-    _worker = _context->createWorker(_enableDelayedSubmission, _enableFuture);
+    _worker = _context->workerBuilder()
+                .delayedSubmission(_enableDelayedSubmission)
+                .pythonFuture(_enableFuture)
+                .build();
   }
 };
 
@@ -175,7 +179,7 @@ class WorkerProgressTest
   {
     std::tie(_enableDelayedSubmission, _progressMode, _extraParams) = GetParam();
 
-    _worker = _context->createWorker(_enableDelayedSubmission);
+    _worker = _context->workerBuilder().delayedSubmission(_enableDelayedSubmission).build();
 
     if (_progressMode == ProgressMode::Blocking)
       _worker->initBlockingProgressMode();
@@ -279,7 +283,7 @@ INSTANTIATE_TEST_SUITE_P(Capabilities,
 TEST_F(WorkerTest, TagProbe)
 {
   auto progressWorker = getProgressFunction(_worker, ProgressMode::Polling);
-  auto ep             = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep             = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   auto probed = _worker->tagProbe(ucxx::Tag{0});
   ASSERT_FALSE(probed->isMatched());
@@ -321,7 +325,7 @@ TEST_F(WorkerTest, TagProbeRemoveBasicFunctionality)
 TEST_F(WorkerTest, TagProbeRemoveWithMessage)
 {
   auto progressWorker = getProgressFunction(_worker, ProgressMode::Polling);
-  auto ep             = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep             = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   // Send a message
   std::vector<int> buf{123};
@@ -475,7 +479,7 @@ TEST_F(WorkerTest, TagRecvWithHandleConsumesMessageWithZeroLengthBuffer)
 TEST_F(WorkerTest, TagProbeUnconsumedWarning)
 {
   auto progressWorker = getProgressFunction(_worker, ProgressMode::Polling);
-  auto ep             = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep             = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   // Send a message
   std::vector<int> buf{123};
@@ -526,7 +530,7 @@ TEST_F(WorkerTest, TagProbeUnconsumedWarning)
 TEST_F(WorkerTest, TagProbeReleaseHandle)
 {
   auto progressWorker = getProgressFunction(_worker, ProgressMode::Polling);
-  auto ep             = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep             = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   // Send a message
   std::vector<int> buf{123};
@@ -566,7 +570,7 @@ TEST_F(WorkerTest, TagProbeReleaseHandle)
 TEST_F(WorkerTest, TagProbeConsumeHandle)
 {
   auto progressWorker = getProgressFunction(_worker, ProgressMode::Polling);
-  auto ep             = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep             = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   // Send a message
   std::vector<int> buf{123};
@@ -607,7 +611,7 @@ TEST_F(WorkerTest, TagProbeConsumeHandle)
 TEST_F(WorkerTest, AmProbe)
 {
   auto progressWorker = getProgressFunction(_worker, ProgressMode::Polling);
-  auto ep             = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep             = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   ASSERT_FALSE(_worker->amProbe(ep->getHandle()));
 
@@ -631,7 +635,7 @@ TEST_P(WorkerProgressTest, ProgressAm)
     GTEST_SKIP() << "Wait mode not supported";
   }
 
-  auto ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   std::vector<int> send{123};
 
@@ -676,7 +680,7 @@ TEST_P(WorkerProgressTest, ProgressAmReceiverCallback)
     });
   _worker->registerAmReceiverCallback(receiverCallbackInfo, callback);
 
-  auto ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   std::vector<int> send{123};
 
@@ -705,18 +709,18 @@ TEST_P(WorkerProgressTest, ProgressAmReceiverCallback)
 
 TEST_P(WorkerProgressTest, ProgressMemoryGet)
 {
-  auto ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   std::vector<int> send{123};
   std::vector<int> recv(1);
 
   size_t messageSize = send.size() * sizeof(int);
 
-  auto memoryHandle = _context->createMemoryHandle(messageSize, send.data());
+  auto memoryHandle = _context->memoryHandleBuilder(messageSize).buffer(send.data()).build();
 
-  auto localRemoteKey      = memoryHandle->createRemoteKey();
+  auto localRemoteKey      = memoryHandle->remoteKeyBuilder().build();
   auto serializedRemoteKey = localRemoteKey->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(ep, serializedRemoteKey);
+  auto remoteKey           = ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(
@@ -729,18 +733,18 @@ TEST_P(WorkerProgressTest, ProgressMemoryGet)
 
 TEST_P(WorkerProgressTest, ProgressMemoryPut)
 {
-  auto ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   std::vector<int> send{123};
   std::vector<int> recv(1);
 
   size_t messageSize = send.size() * sizeof(int);
 
-  auto memoryHandle = _context->createMemoryHandle(messageSize, recv.data());
+  auto memoryHandle = _context->memoryHandleBuilder(messageSize).buffer(recv.data()).build();
 
-  auto localRemoteKey      = memoryHandle->createRemoteKey();
+  auto localRemoteKey      = memoryHandle->remoteKeyBuilder().build();
   auto serializedRemoteKey = localRemoteKey->serialize();
-  auto remoteKey           = ucxx::createRemoteKeyFromSerialized(ep, serializedRemoteKey);
+  auto remoteKey           = ep->remoteKeyBuilder(serializedRemoteKey).build();
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(
@@ -753,7 +757,7 @@ TEST_P(WorkerProgressTest, ProgressMemoryPut)
 
 TEST_P(WorkerProgressTest, ProgressStream)
 {
-  auto ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   std::vector<int> send{123};
   std::vector<int> recv(1);
@@ -768,7 +772,7 @@ TEST_P(WorkerProgressTest, ProgressStream)
 
 TEST_P(WorkerProgressTest, ProgressTag)
 {
-  auto ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   std::vector<int> send{123};
   std::vector<int> recv(1);
@@ -788,7 +792,7 @@ TEST_P(WorkerProgressTest, ProgressTagMulti)
     GTEST_SKIP() << "Interrupting UCP worker progress operation in wait mode is not possible";
   }
 
-  auto ep = _worker->createEndpointFromWorkerAddress(_worker->getAddress());
+  auto ep = _worker->endpointBuilder(_worker->addressBuilder().build()).build();
 
   std::vector<int> send{123};
 

--- a/cpp/tests/worker.cpp
+++ b/cpp/tests/worker.cpp
@@ -121,7 +121,7 @@ class WorkerTest : public ::testing::Test {
       _context->workerBuilder().build()};
     transfer.endpoint =
       transfer.sendWorker->endpointBuilder(transfer.recvWorker->addressBuilder().build()).build();
-    transfer.sendRequest = transfer.endpoint->tagSend(buffer, length, ucxx::Tag{0});
+    transfer.sendRequest = transfer.endpoint->tagSendBuilder(buffer, length, ucxx::Tag{0}).build();
 
     loopWithTimeout(std::chrono::milliseconds(5000), [&]() {
       transfer.sendWorker->progress();
@@ -292,7 +292,8 @@ TEST_F(WorkerTest, TagProbe)
 
   std::vector<int> buf{123};
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(ep->tagSend(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0}));
+  requests.push_back(
+    ep->tagSendBuilder(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0}).build());
   waitRequests(_worker, requests, progressWorker);
 
   loopWithTimeout(std::chrono::milliseconds(5000), [this, progressWorker]() {
@@ -330,7 +331,7 @@ TEST_F(WorkerTest, TagProbeRemoveWithMessage)
   // Send a message
   std::vector<int> buf{123};
   std::shared_ptr<ucxx::Request> send_req =
-    ep->tagSend(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0});
+    ep->tagSendBuilder(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0}).build();
 
   // Progress until message is sent
   while (!send_req->isCompleted()) {
@@ -359,7 +360,8 @@ TEST_F(WorkerTest, TagProbeRemoveWithMessage)
 
   // Test receiving with the message handle
   std::vector<int> recv_buf(1);
-  std::shared_ptr<ucxx::Request> recv_req = _worker->tagRecvWithHandle(recv_buf.data(), probe2);
+  std::shared_ptr<ucxx::Request> recv_req =
+    _worker->tagRecvWithHandleBuilder(recv_buf.data(), probe2).build();
 
   // Progress until message is received
   while (!recv_req->isCompleted()) {
@@ -484,7 +486,7 @@ TEST_F(WorkerTest, TagProbeUnconsumedWarning)
   // Send a message
   std::vector<int> buf{123};
   std::shared_ptr<ucxx::Request> send_req =
-    ep->tagSend(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0});
+    ep->tagSendBuilder(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0}).build();
 
   // Progress until message is sent
   while (!send_req->isCompleted()) {
@@ -535,7 +537,7 @@ TEST_F(WorkerTest, TagProbeReleaseHandle)
   // Send a message
   std::vector<int> buf{123};
   std::shared_ptr<ucxx::Request> send_req =
-    ep->tagSend(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0});
+    ep->tagSendBuilder(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0}).build();
 
   // Progress until message is sent
   while (!send_req->isCompleted()) {
@@ -575,7 +577,7 @@ TEST_F(WorkerTest, TagProbeConsumeHandle)
   // Send a message
   std::vector<int> buf{123};
   std::shared_ptr<ucxx::Request> send_req =
-    ep->tagSend(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0});
+    ep->tagSendBuilder(buf.data(), buf.size() * sizeof(int), ucxx::Tag{0}).build();
 
   // Progress until message is sent
   while (!send_req->isCompleted()) {
@@ -598,7 +600,8 @@ TEST_F(WorkerTest, TagProbeConsumeHandle)
 
     // Actually use the handle via tagRecvWithHandle to consume it properly
     std::vector<int> recv_buf(1);
-    std::shared_ptr<ucxx::Request> recv_req = _worker->tagRecvWithHandle(recv_buf.data(), probe);
+    std::shared_ptr<ucxx::Request> recv_req =
+      _worker->tagRecvWithHandleBuilder(recv_buf.data(), probe).build();
 
     // Progress until message is received
     while (!recv_req->isCompleted()) {
@@ -617,7 +620,8 @@ TEST_F(WorkerTest, AmProbe)
 
   std::vector<int> buf{123};
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(ep->amSend(buf.data(), buf.size() * sizeof(int), UCS_MEMORY_TYPE_HOST));
+  requests.push_back(
+    ep->amSendBuilder(buf.data(), buf.size() * sizeof(int), UCS_MEMORY_TYPE_HOST).build());
   waitRequests(_worker, requests, progressWorker);
 
   loopWithTimeout(std::chrono::milliseconds(5000), [this, progressWorker, ep]() {
@@ -640,8 +644,9 @@ TEST_P(WorkerProgressTest, ProgressAm)
   std::vector<int> send{123};
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(ep->amSend(send.data(), send.size() * sizeof(int), UCS_MEMORY_TYPE_HOST));
-  requests.push_back(ep->amRecv());
+  requests.push_back(
+    ep->amSendBuilder(send.data(), send.size() * sizeof(int), UCS_MEMORY_TYPE_HOST).build());
+  requests.push_back(ep->amRecvBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   auto recvReq    = requests[1];
@@ -685,8 +690,9 @@ TEST_P(WorkerProgressTest, ProgressAmReceiverCallback)
   std::vector<int> send{123};
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(
-    ep->amSend(send.data(), send.size() * sizeof(int), UCS_MEMORY_TYPE_HOST, receiverCallbackInfo));
+  requests.push_back(ep->amSendBuilder(send.data(), send.size() * sizeof(int), UCS_MEMORY_TYPE_HOST)
+                       .receiverCallbackInfo(receiverCallbackInfo)
+                       .build());
   waitRequests(_worker, requests, _progressWorker);
 
   while (receivedRequests.size() < 1)
@@ -724,8 +730,9 @@ TEST_P(WorkerProgressTest, ProgressMemoryGet)
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(
-    ep->memGet(recv.data(), messageSize, remoteKey->getBaseAddress(), remoteKey->getHandle()));
-  requests.push_back(_worker->flush());
+    ep->memGetBuilder(recv.data(), messageSize, remoteKey->getBaseAddress(), remoteKey->getHandle())
+      .build());
+  requests.push_back(_worker->flushBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   ASSERT_EQ(recv[0], send[0]);
@@ -748,8 +755,9 @@ TEST_P(WorkerProgressTest, ProgressMemoryPut)
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
   requests.push_back(
-    ep->memPut(send.data(), messageSize, remoteKey->getBaseAddress(), remoteKey->getHandle()));
-  requests.push_back(_worker->flush());
+    ep->memPutBuilder(send.data(), messageSize, remoteKey->getBaseAddress(), remoteKey->getHandle())
+      .build());
+  requests.push_back(_worker->flushBuilder().build());
   waitRequests(_worker, requests, _progressWorker);
 
   ASSERT_EQ(recv[0], send[0]);
@@ -763,8 +771,10 @@ TEST_P(WorkerProgressTest, ProgressStream)
   std::vector<int> recv(1);
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(ep->streamSend(send.data(), send.size() * sizeof(int), 0));
-  requests.push_back(ep->streamRecv(recv.data(), recv.size() * sizeof(int), 0));
+  requests.push_back(
+    ep->streamSendBuilder(send.data(), send.size() * sizeof(int)).pythonFuture(0).build());
+  requests.push_back(
+    ep->streamRecvBuilder(recv.data(), recv.size() * sizeof(int)).pythonFuture(0).build());
   waitRequests(_worker, requests, _progressWorker);
 
   ASSERT_EQ(recv[0], send[0]);
@@ -778,9 +788,11 @@ TEST_P(WorkerProgressTest, ProgressTag)
   std::vector<int> recv(1);
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(ep->tagSend(send.data(), send.size() * sizeof(int), ucxx::Tag{0}));
   requests.push_back(
-    ep->tagRecv(recv.data(), recv.size() * sizeof(int), ucxx::Tag{0}, ucxx::TagMaskFull));
+    ep->tagSendBuilder(send.data(), send.size() * sizeof(int), ucxx::Tag{0}).build());
+  requests.push_back(
+    ep->tagRecvBuilder(recv.data(), recv.size() * sizeof(int), ucxx::Tag{0}, ucxx::TagMaskFull)
+      .build());
   waitRequests(_worker, requests, _progressWorker);
 
   ASSERT_EQ(recv[0], send[0]);
@@ -803,8 +815,11 @@ TEST_P(WorkerProgressTest, ProgressTagMulti)
   std::vector<int> multiIsCUDA(numMulti, false);
 
   std::vector<std::shared_ptr<ucxx::Request>> requests;
-  requests.push_back(ep->tagMultiSend(multiBuffer, multiSize, multiIsCUDA, ucxx::Tag{0}, false));
-  requests.push_back(ep->tagMultiRecv(ucxx::Tag{0}, ucxx::TagMaskFull, false));
+  requests.push_back(ep->tagMultiSendBuilder(multiBuffer, multiSize, multiIsCUDA, ucxx::Tag{0})
+                       .pythonFuture(false)
+                       .build());
+  requests.push_back(
+    ep->tagMultiRecvBuilder(ucxx::Tag{0}, ucxx::TagMaskFull).pythonFuture(false).build());
   waitRequests(_worker, requests, _progressWorker);
 
   for (const auto& br :


### PR DESCRIPTION
Removes the deprecated C++ construction APIs as planned for UCXX 0.52.

Users should construct UCXX objects through the supported builder APIs. Internal construction support remains isolated from the public API, and examples and benchmarks now use the supported interfaces.

This is a breaking API change for code that still uses the removed `create*` constructors.