### PR TITLE
Skip package tests during Python Conda build

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -31,8 +31,11 @@ source rapids-telemetry-setup
 # --no-build-id allows for caching with `sccache`
 # more info is available at
 # https://rattler.build/latest/tips_and_tricks/#using-sccache-or-ccache-with-rattler-build
+# Package tests install the newly built outputs and therefore require runtime
+# packages from the complete RAPIDS build. Run those in the separate test jobs.
 rapids-telemetry-record build.log rattler-build build \
     --recipe conda/recipes/ucxx \
+    --test skip \
     --experimental \
     --no-build-id \
     --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \


### PR DESCRIPTION
**Posted by Codex (GPT-5) on Michael Sarahan’s behalf. Treat this message as LLM-generated.**

## Why

The Python Conda recipe builds `distributed-ucxx`, whose runtime requirements include the train-versioned `rapids-dask-dependency`. Rattler currently tests each newly built output as part of the build invocation. Setting up the `distributed-ucxx` package-test environment therefore requires a matching `rapids-dask-dependency` package before the rest of that RAPIDS train is available. This makes artifact production fail even though `rapids-dask-dependency` is not required to compile or package UCXX.

The package-install and import checks belong in UCXX’s separate test jobs, where runtime packages are available. Keeping them out of the artifact-build invocation also avoids adding a false build-time dependency from UCXX to the repository that produces `rapids-dask-dependency`.

## Change

Pass `--test skip` to the rattler invocation for the Python Conda recipe. The C++ Conda recipe is unchanged.

This is deliberately scoped to UCXX. A candidate-build-wide policy may replace this repository-specific setting once the candidate build system is used for these builds.

## Validation

- `bash -n ci/build_python.sh`
- `pre-commit run --all-files`
- The metadata-backed `verify-alpha-spec` hook was rerun with network access after its sandboxed attempt could not resolve GitHub; it passed.