### PR TITLE
[0.52] Backport remove deleted C++ methods from Cython declarations

### DIFF
--- a/python/ucxx/ucxx/_lib/ucxx_api.pxd
+++ b/python/ucxx/ucxx/_lib/ucxx_api.pxd
@@ -271,10 +271,6 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
         shared_ptr[Component] getParent()
 
     cdef cppclass Context(Component):
-        shared_ptr[Worker] createWorker(
-            bint enableDelayedSubmission,
-            bint enableFuture,
-        ) except +raise_py_error
         ConfigMap getConfig() except +raise_py_error
         ucp_context_h getHandle()
         string getInfo() except +raise_py_error
@@ -287,7 +283,6 @@ cdef extern from "<ucxx/api.h>" namespace "ucxx" nogil:
     cdef cppclass Worker(Component):
         ucp_worker_h getHandle()
         string getInfo() except +raise_py_error
-        shared_ptr[Address] getAddress() except +raise_py_error
         EndpointBuilder endpointBuilder(
             string ip_address, uint16_t port
         )


### PR DESCRIPTION
Backport https://github.com/rapidsai/ucxx/pull/746 to `release/0.52`.

Depends on #743 and is based on its head commit. The novel changes are in 6ed1ba7.

Removes the stale Cython declarations for `Context::createWorker()` and `Worker::getAddress()`, which #743 removes from the C++ API. This prevents future Cython users from generating calls to members that no longer exist.

There is no runtime API impact.