### PR TITLE
Update pip devcontainers to UCX 1.21

### DIFF
--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:26.12-cpp-cuda12.9-ucx1.19.0-openmpi5.0.10"
+      "BASE": "rapidsai/devcontainers:26.12-cpp-cuda12.9-ucx1.21.0-openmpi5.0.10"
     },
     "cacheFrom": [
       "ghcr.io/rapidsai/ucxx/devcontainer:0.51-cuda12.9-pip"

--- a/.devcontainer/cuda13.3-pip/devcontainer.json
+++ b/.devcontainer/cuda13.3-pip/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "13.3",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:26.12-cpp-cuda13.3-ucx1.19.0-openmpi5.0.10"
+      "BASE": "rapidsai/devcontainers:26.12-cpp-cuda13.3-ucx1.21.0-openmpi5.0.10"
     },
     "cacheFrom": [
       "ghcr.io/rapidsai/ucxx/devcontainer:0.51-cuda13.3-pip"


### PR DESCRIPTION
This updates pip devcontainers from UCX 1.19 to UCX 1.21.

Part of https://github.com/rapidsai/build-planning/issues/314.
